### PR TITLE
Set up a website for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - Add `quoteAll` function to quote and escape an array of arguments.
+- Create website with full documentation ([link](https://ericcornelissen.github.io/shescape/)).
 
 ## [0.3.1] - 2020-12-07
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![NPM Package][npm-image]][npm-url]
 [![Documentation][docs-image]][docs-url]
 
-A simple shell escape library for NodeJS. Use it to escape user-specified inputs
-to shell commands to prevent [shell injection].
+A simple shell escape package for JavaScript. Use it to escape user-specified
+inputs to shell commands to prevent [shell injection].
 
 ## Example
 
@@ -13,7 +13,8 @@ to shell commands to prevent [shell injection].
 
 Below is a basic example of how to use _Shescape_. In this example `spawn` is
 used to invoke a shell command and `shescape.quoteAll` is used to quote and
-escape any character in any of the arguments specified by `userInput`.
+escape any _dangerous_ character in any of the arguments specified by
+`userInput`.
 
 ```js
 const cp = require("child_process");

--- a/README.md
+++ b/README.md
@@ -2,21 +2,24 @@
 
 [![GitHub Actions][ci-image]][ci-url]
 [![NPM Package][npm-image]][npm-url]
+[![Documentation][docs-image]][docs-url]
 
-A simple shell escape library. Use it to escape user-specified inputs to shell
-commands to prevent [shell injection].
+A simple shell escape library for NodeJS. Use it to escape user-specified inputs
+to shell commands to prevent [shell injection].
 
 ## Example
 
-Below is a basic example of how to use _Shescape_. It is recommended to use the
-`quote` function. This will put (OS appropriate) quotes around the user input
-and escape any characters in the input if necessary.
+> Please read [the documentation][docs-url] for more information.
+
+Below is a basic example of how to use _Shescape_. In this example `spawn` is
+used to invoke a shell command and `shescape.quoteAll` is used to quote and
+escape any character in any of the arguments specified by `userInput`.
 
 ```js
 const cp = require("child_process");
 const shescape = require("shescape");
 
-cp.exec(`command ${shescape.quote(userInput)}`, callback);
+cp.spawn("command", shescape.quoteAll(userInput), options);
 ```
 
 [shell injection]: https://portswigger.net/web-security/os-command-injection
@@ -24,3 +27,5 @@ cp.exec(`command ${shescape.quote(userInput)}`, callback);
 [ci-image]: https://github.com/ericcornelissen/shescape/workflows/Test%20and%20Lint/badge.svg
 [npm-url]: https://www.npmjs.com/package/shescape
 [npm-image]: https://img.shields.io/npm/v/shescape.svg
+[docs-url]: https://ericcornelissen.github.io/shescape/
+[docs-image]: https://img.shields.io/badge/read-the%20docs-informational

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![NPM Package][npm-image]][npm-url]
 [![Documentation][docs-image]][docs-url]
 
-A simple shell escape package for JavaScript. Use it to escape user-specified
+A simple shell escape package for JavaScript. Use it to escape user-controlled
 inputs to shell commands to prevent [shell injection].
 
 ## Example
 
-> Please read [the documentation][docs-url] for more information.
+> Please read [the full documentation][docs-url] for more information.
 
 Below is a basic example of how to use _Shescape_. In this example `spawn` is
 used to invoke a shell command and `shescape.quoteAll` is used to quote and

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: Shescape
-description: Documentation for Shescape, the shell escape package for Node.
+description: Documentation for Shescape, a shell escape package for JavaScript.
 remote_theme: pages-themes/minimal
 
 plugins:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+title: Shescape
+description: Documentation for Shescape, the shell escape package for Node.
+remote_theme: pages-themes/minimal
+
+plugins:
+  - jekyll-remote-theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,8 @@ title: Documentation
 
 # Documentation
 
-placeholder
+Shescape is a simple shell escape package for JavaScript. Use it to escape
+user-controlled inputs to shell commands to prevent [shell injection].
 
 **Quick links**:
 [NPM] |
@@ -145,6 +146,7 @@ console.log(safeArg);
 | --------- | -------- | --------------------- |
 | `safeArg` | `string` | The escaped argument. |
 
+[shell injection]: https://portswigger.net/web-security/os-command-injection
 [npm]: https://www.npmjs.com/package/shescape
 [changelog]: https://github.com/ericcornelissen/shescape/blob/main/CHANGELOG.md
 [license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ yarn add shescape
 import * as shescape from "shescape";
 ```
 
+3. Use `shescape`
+
 ### Recipes
 
 When using `fork`, `spawn`, `execFile`, or similar, it is recommended to use the
@@ -77,7 +79,7 @@ import { quote } from "shescape";
 const arg = " && ls -al";
 const safeArg = quote(arg);
 console.log(safeArg);
-// Outputs:  "' && ls -al'"
+// Output:  "' && ls -al'"
 ```
 
 #### Input-output
@@ -104,7 +106,7 @@ import { quoteAll } from "shescape";
 const args = ["Guppy", " && ls -al"];
 const safeArgs = quoteAll(args);
 console.log(safeArgs);
-// Outputs:  ["'Guppy'", "' && ls -al"]
+// Output:  ["'Guppy'", "' && ls -al"]
 ```
 
 #### Input-output
@@ -133,7 +135,7 @@ import { escape } from "shescape";
 const arg = "' && ls -al";
 const safeArg = `'${escape(arg)}'`;
 console.log(safeArg);
-// Outputs:  "''\'' && ls -al'"
+// Output:  "''\'' && ls -al'"
 ```
 
 #### Input-output

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,151 @@
+---
+layout: default
+title: Documentation
+---
+
+# Documentation
+
+placeholder
+
+**Quick links**:
+[NPM] |
+[License] |
+[Changelog] |
+[Security]
+
+## Features
+
+- Zero dependencies
+- Lightweight
+- Supports MacOS, Linux, and Windows
+
+## Usage
+
+### Install
+
+1. Install `shescape`
+
+```shell
+# npm
+npm install shescape
+
+# yarn
+yarn add shescape
+```
+
+2. Import `shescape`
+
+```js
+import * as shescape from "shescape";
+```
+
+### Recipes
+
+When using `fork`, `spawn`, `execFile`, or similar, it is recommended to use the
+[quoteAll()](#quoteallargs) function to escape the array of arguments.
+
+```js
+import { spawn } from "child_process";
+import * as shescape from "shescape";
+
+spawn("command", shescape.quoteAll(args), options);
+```
+
+When using the `exec` function, or similar, it is recommended to use the
+[quote()](#quotearg) function to escape individual arguments.
+
+```js
+import { exec } from "child_process";
+import * as shescape from "shescape";
+
+exec(`command ${shescape.quote(arg)}`, callback);
+```
+
+## API
+
+### `quote(arg)`
+
+The `quote` function takes as input a single value, the argument, puts
+OS-specific quotes around it, and escapes any _dangerous_ characters.
+
+#### Example
+
+```js
+import { quote } from "shescape";
+
+const arg = " && ls -al";
+const safeArg = quote(arg);
+console.log(safeArg);
+// Outputs:  "' && ls -al'"
+```
+
+#### Input-output
+
+| Input | Type     | Description                       |
+| ----- | -------- | --------------------------------- |
+| `arg` | `string` | The argument to quote and escape. |
+
+| Output    | Type     | Description                      |
+| --------- | -------- | -------------------------------- |
+| `safeArg` | `string` | The quoted and escaped argument. |
+
+### `quoteAll(args)`
+
+The `quoteAll` function takes as input an array of values, the arguments, puts
+OS-specific quotes around every argument, and escapes any _dangerous_ characters
+in every argument.
+
+#### Example
+
+```js
+import { quoteAll } from "shescape";
+
+const args = ["Guppy", " && ls -al"];
+const safeArgs = quoteAll(args);
+console.log(safeArgs);
+// Outputs:  ["'Guppy'", "' && ls -al"]
+```
+
+#### Input-output
+
+| Input  | Type       | Description                        |
+| ------ | ---------- | ---------------------------------- |
+| `args` | `string[]` | The arguments to quote and escape. |
+
+| Output    | Type       | Description                       |
+| --------- | ---------- | --------------------------------- |
+| `safeArg` | `string[]` | The quoted and escaped arguments. |
+
+### `escape(arg)`
+
+The `escape` function takes as input a value, the argument, and escapes any
+_dangerous_ characters.
+
+Calling `escape()` directly is not recommended unless you know what you're
+doing.
+
+#### Example
+
+```js
+import { escape } from "shescape";
+
+const arg = "' && ls -al";
+const safeArg = `'${escape(arg)}'`;
+console.log(safeArg);
+// Outputs:  "''\'' && ls -al'"
+```
+
+#### Input-output
+
+| Input | Type     | Description             |
+| ----- | -------- | ----------------------- |
+| `arg` | `string` | The argument to escape. |
+
+| Output    | Type     | Description           |
+| --------- | -------- | --------------------- |
+| `safeArg` | `string` | The escaped argument. |
+
+[npm]: https://www.npmjs.com/package/shescape
+[changelog]: https://github.com/ericcornelissen/shescape/blob/main/CHANGELOG.md
+[license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE
+[security]: https://github.com/ericcornelissen/shescape/blob/main/SECURITY.md

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shescape",
   "version": "0.3.1",
   "description": "simple shell escape library",
-  "homepage": "https://github.com/ericcornelissen/shescape#readme",
+  "homepage": "https://ericcornelissen.github.io/shescape/",
   "license": "MPL-2.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hosted from the `docs/` directory, keeping it separate from the `README.md` in the root. The rationale behind this is that the website is for users of the packages and the README for potential contributors and, of course, users as well since NPM displays the README on [the package page](https://www.npmjs.com/package/shescape).