### PR TITLE
Create array on non-array input in quoteAll

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,9 +123,9 @@ console.log(safeArgs);
 | --------- | ---------- | --------------------------------- |
 | `safeArg` | `string[]` | The quoted and escaped arguments. |
 
-> `quoteAll` automatically converts individual non-string values to strings if
-> needed and will error if this is not possible. You are responsible for
-> verifying the input makes sense.
+> `quoteAll` automatically converts non-array inputs to single-value arrays and
+> individual non-string values to strings if needed and will error if this is
+> not possible. You are responsible for verifying the input makes sense.
 
 ### `escape(arg)`
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports.quote = function (arg) {
 };
 
 module.exports.quoteAll = function (args) {
-  if (!Array.isArray(args)) return args;
+  if (!Array.isArray(args)) args = [args];
 
   const platform = os.platform();
   const result = [];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,8 +92,17 @@ describe("index.js", function () {
   });
 
   it("quoteAll gracefully handles inputs that are not an array", function () {
-    const input = 42;
-    const output = shescape.quoteAll(input);
-    assert.deepStrictEqual(output, input);
+    const osStubOutput = "MundOS";
+    sinon.stub(os, "platform").returns(osStubOutput);
+    const mainStubOutput = "foobar";
+    sinon.stub(main, "quoteByPlatform").returns(mainStubOutput);
+
+    const output = shescape.quoteAll("Hello world!");
+    assert(os.platform.called);
+    assert(main.quoteByPlatform.called);
+    assert.deepStrictEqual(output, [mainStubOutput]);
+
+    os.platform.restore();
+    main.quoteByPlatform.restore();
   });
 });


### PR DESCRIPTION
Update `quoteAll` to return an array-ified value if the input is not an array.

This change is not backwards compatible and will be included in the same release as #6