### PR TITLE
Update fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,8 +10,15 @@ jobs:
     name: Fuzz
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            shell: /bin/sh
+          - os: windows-latest
+            shell: cmd.exe
+          - os: windows-latest
+            shell: powershell.exe
     steps:
       - name: Check out code
         uses: actions/checkout@v2.4.0
@@ -32,6 +39,8 @@ jobs:
       - name: Fuzz
         id: fuzz
         shell: bash {0}
+        env:
+          FUZZ_SHELL: ${{ matrix.shell }}
         run: |
           timeout 30m npm run fuzz
           export EXIT_CODE=$?

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ vendor/
 .stryker-tmp/
 reports/
 crash-*
+.env
 
 # generated files
 index.cjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,18 @@ You can start fuzzing using the command `npm run fuzz`, which runs
 `index.fuzz.cjs` by default. If you improve or add to the fuzz code, please
 share your improvements.
 
+By default, the [`execSync`] default shell is used when fuzzing. You can change
+this with the `FUZZ_SHELL` environment variable. The easiest way to change this
+is with a `.env` file containing, for example:
+
+```ini
+# Unix example
+FUZZ_SHELL=/bin/sh
+
+# Windows example
+FUZZ_SHELL=powershell.exe
+```
+
 When you discover a bug by fuzzing please keep the crash file. If you do not
 plan to fix the bug, either follow the [security policy] or file a [bug report],
 depending on the type of bug, and include the crash file. If you do plan to fix
@@ -134,6 +146,7 @@ folder the bug will automatically be retested when fuzzing again.
 [assert package]: https://nodejs.org/api/assert.html
 [bug report]: https://github.com/ericcornelissen/shescape/issues/new?labels=bug&template=bug_report.md
 [editorconfig]: https://editorconfig.org/
+[`execsync`]: https://nodejs.org/api/child_process.html#child_processexecsynccommand-options
 [fast-check]: https://www.npmjs.com/package/fast-check
 [fuzz testing]: https://en.wikipedia.org/wiki/Fuzzing
 [husky]: https://github.com/typicode/husky

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@stryker-mutator/core": "^5.0.0",
         "c8": "^7.7.1",
+        "dotenv": "^10.0.0",
         "fast-check": "^2.17.0",
         "husky": "^7.0.0",
         "is-ci": "^3.0.0",
@@ -1445,6 +1446,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5613,6 +5623,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "dev": true
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "typings": "index.d.ts",
   "scripts": {
-    "clean": "rm -rf .corpus/ .nyc_output/ .stryker-tmp/ reports/ crash-* index.cjs",
+    "clean": "node script/clean.js",
     "coverage": "c8 --reports-dir=reports/coverage --reporter=lcov --reporter=text npm test",
     "format": "prettier --write ./**/*.{cjs,js,md,yml} --ignore-path .gitignore",
     "prefuzz": "npm run transpile && node script/prefuzz.js",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@stryker-mutator/core": "^5.0.0",
     "c8": "^7.7.1",
+    "dotenv": "^10.0.0",
     "fast-check": "^2.17.0",
     "husky": "^7.0.0",
     "is-ci": "^3.0.0",

--- a/script/clean.js
+++ b/script/clean.js
@@ -1,0 +1,39 @@
+/**
+ * @overview Reset the repository to a clean state, removing any generated
+ * files.
+ * @license Unlicense
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const files = ["index.cjs"];
+const folders = ["./.corpus", "./.nyc_output", "./.stryker-tmp", "./reports"];
+
+for (const file of files) {
+  const filePath = path.resolve(file);
+  deleteFile(filePath);
+}
+
+for (const folder of folders) {
+  const folderPath = path.resolve(folder);
+  deleteFolder(folderPath);
+}
+
+for (const file of fs.readdirSync(".")) {
+  if (/^crash-[a-z0-9]+/.test(file)) {
+    const filePath = path.resolve(file);
+    deleteFile(filePath);
+  }
+}
+
+function deleteFile(filePath) {
+  fs.rmSync(filePath, { force: true });
+}
+
+function deleteFolder(folderPath) {
+  if (fs.existsSync(folderPath)) {
+    fs.rmSync(folderPath, { recursive: true });
+  }
+}

--- a/test/fuzz/echo.js
+++ b/test/fuzz/echo.js
@@ -6,4 +6,10 @@
  */
 
 const argToEcho = process.argv[2];
-process.stdout.write(argToEcho);
+
+// Protect against `argToEcho` being undefined, which causes an error when
+// writing to `process.stdout`. `argToEcho` will be undefined when using certain
+// shells if you provide an empty string as argument.
+const safeArgToEcho = argToEcho || "";
+
+process.stdout.write(safeArgToEcho);


### PR DESCRIPTION
Following up on #87 with:

- Support for configuring the shell to fuzz (without having to change VCS controlled files)
- Support for fuzzing PowerShell
- Continuous fuzzing on Windows with both `cmd.exe` and `powershell.exe`
- A platform agnostic clean script