### PR TITLE
Start using the online Stryker dashboard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run mutation test
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: npm run test:mutation
   property:
     name: Property

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Actions][ci-image]][ci-url]
 [![Coverage Report][coverage-image]][coverage-url]
+[![Mutation Report][mutation-image]][mutation-url]
 [![quality Report][quality-image]][quality-url]
 [![NPM Package][npm-image]][npm-url]
 [![Documentation][docs-image]][docs-url]
@@ -32,6 +33,8 @@ console.log(stdout.toString());
 [ci-image]: https://img.shields.io/github/workflow/status/ericcornelissen/shescape/Push%20checks/main?logo=github
 [coverage-url]: https://codecov.io/gh/ericcornelissen/shescape
 [coverage-image]: https://codecov.io/gh/ericcornelissen/shescape/branch/main/graph/badge.svg
+[mutation-url]: https://dashboard.stryker-mutator.io/reports/github.com/ericcornelissen/shescape/main
+[mutation-image]: https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fericcornelissen%2Fshescape%2Fmain
 [quality-url]: https://codeclimate.com/github/ericcornelissen/shescape/maintainability
 [quality-image]: https://api.codeclimate.com/v1/badges/6eb1a10f41cf6950b6ce/maintainability
 [npm-url]: https://www.npmjs.com/package/shescape

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -6,6 +6,7 @@
   ],
 
   "reporters": [
+    "dashboard",
     "clear-text",
     "html",
     "progress"


### PR DESCRIPTION
Add "dashboard" reporter to Stryker configuration to use the [online Stryker dashboard](https://dashboard.stryker-mutator.io).

For documentation, see: https://stryker-mutator.io/docs/General/dashboard
For a preview of the dashboard, see: https://dashboard.stryker-mutator.io/reports/github.com/ericcornelissen/shescape/online-mutation-report (the dashboard for this branch of this repo)

## Notes

- The dashboard reporter won't try to do anything on your local system (unless configured to simulate a CI system), it will only output:
  ```
  INFO DashboardReporter The report was not send to the dashboard. The dashboard.project and/or dashboard.version values were missing and not detected to be running on a build server.
  ```
- If the `env.STRYKER_DASHBOARD_API_KEY` value is not explicitly set in the step running the mutation tests this won't work as Stryker won't detect the API key that way.
- The mutation badge will start working once this is merged. It is configured to display the mutation score for the `main` branch, but there's currently no uploaded report for that branch.