### PR TITLE
Improve git hooks

### DIFF
--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+get_stash_count () {
+  local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
+  if [ "$count" = "" ]
+  then
+    echo "0"
+  else
+    echo $count
+  fi
+}

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
 
 IS_MERGING=""  # false
-if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]
-then
+if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
   IS_MERGING="x"  # true
 fi
 
 get_stash_count () {
   local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
-  if [ "$count" = "" ]
-  then
+  if [ "$count" = "" ]; then
     echo "0"
   else
     echo $count

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -12,10 +12,10 @@ get_stash_count () {
 STASH_COUNT_BEFORE=$(get_stash_count)
 DID_STASH () {
   local STASH_COUNT_AFTER=$(get_stash_count)
-  if [ "$STASH_COUNT_BEFORE" = "$STASH_COUNT_AFTER" ]; then
-    echo ""  # false
-  else
+  if [ "$STASH_COUNT_BEFORE" != "$STASH_COUNT_AFTER" ]; then
     echo "x"  # true
+  else
+    echo ""  # false
   fi
 }
 

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+IS_MERGING=""  # false
+if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]
+then
+  IS_MERGING="x"  # true
+fi
+
 get_stash_count () {
   local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
   if [ "$count" = "" ]

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -13,3 +13,13 @@ get_stash_count () {
     echo $count
   fi
 }
+
+STASH_COUNT_BEFORE=$(get_stash_count)
+DID_STASH () {
+  local STASH_COUNT_AFTER=$(get_stash_count)
+  if [ "$STASH_COUNT_BEFORE" = "$STASH_COUNT_AFTER" ]; then
+    echo ""  # false
+  else
+    echo "x"  # true
+  fi
+}

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-IS_MERGING=""  # false
-if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
-  IS_MERGING="x"  # true
-fi
-
 get_stash_count () {
   local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
   if [ "$count" = "" ]; then
@@ -21,5 +16,13 @@ DID_STASH () {
     echo ""  # false
   else
     echo "x"  # true
+  fi
+}
+
+IS_MERGING () {
+  if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+    echo "x"  # true
+  else
+    echo ""  # false
   fi
 }

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,7 +4,10 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-git stash push --include-untracked --keep-index --quiet
+if [ ! $IS_MERGING ]
+then
+  git stash push --include-untracked --keep-index --quiet
+fi
 
 # Checks
 npm run format

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,8 +4,7 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-if [ ! $IS_MERGING ]
-then
+if [ ! $IS_MERGING ]; then
   git stash push --include-untracked --keep-index --quiet
 fi
 
@@ -15,7 +14,6 @@ git update-index --again
 
 # Post
 STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
-then
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,7 +3,7 @@
 . "$(dirname $0)/common.sh"
 
 # Pre
-if [ ! $IS_MERGING ]; then
+if [ ! $(IS_MERGING) ]; then
   git stash push --include-untracked --keep-index --quiet
 fi
 

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,7 +4,7 @@
 
 # Pre
 if [ ! $(IS_MERGING) ]; then
-  git stash push --include-untracked --keep-index --quiet
+  git stash push --quiet --include-untracked --keep-index
 fi
 
 # Checks

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,7 +3,6 @@
 . "$(dirname $0)/common.sh"
 
 # Pre
-STASH_COUNT_BEFORE=$(get_stash_count)
 if [ ! $IS_MERGING ]; then
   git stash push --include-untracked --keep-index --quiet
 fi
@@ -13,7 +12,6 @@ npm run format
 git update-index --again
 
 # Post
-STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
+if [ $(DID_STASH) ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -1,7 +1,18 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
+. "$(dirname $0)/common.sh"
 
-git stash -q -u --keep-index
+# Pre
+STASH_COUNT_BEFORE=$(get_stash_count)
+git stash push --include-untracked --keep-index --quiet
+
+# Checks
 npm run format
 git update-index --again
-git stash pop -q
+
+# Post
+STASH_COUNT_AFTER=$(get_stash_count)
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
+then
+  git stash pop --quiet
+fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -3,7 +3,7 @@
 . "$(dirname $0)/common.sh"
 
 # Pre
-if [ ! $IS_MERGING ]; then
+if [ ! $(IS_MERGING) ]; then
   git stash push --include-untracked --quiet
 fi
 

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -14,5 +14,5 @@ npm run transpile
 
 # Post
 if [ $(DID_STASH) ]; then
-  git stash pop --quiet
+  git stash pop --quiet --index
 fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,7 +4,10 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-git stash push --include-untracked --quiet
+if [ ! $IS_MERGING ]
+then
+  git stash push --include-untracked --quiet
+fi
 
 # Checks
 npm run lint

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,7 +4,7 @@
 
 # Pre
 if [ ! $(IS_MERGING) ]; then
-  git stash push --include-untracked --quiet
+  git stash push --quiet --include-untracked
 fi
 
 # Checks

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -3,7 +3,6 @@
 . "$(dirname $0)/common.sh"
 
 # Pre
-STASH_COUNT_BEFORE=$(get_stash_count)
 if [ ! $IS_MERGING ]; then
   git stash push --include-untracked --quiet
 fi
@@ -14,7 +13,6 @@ npm run test
 npm run transpile
 
 # Post
-STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
+if [ $(DID_STASH) ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,8 +4,7 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-if [ ! $IS_MERGING ]
-then
+if [ ! $IS_MERGING ]; then
   git stash push --include-untracked --quiet
 fi
 
@@ -16,7 +15,6 @@ npm run transpile
 
 # Post
 STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
-then
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -1,8 +1,19 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
+. "$(dirname $0)/common.sh"
 
-git stash -q -u --keep-index
+# Pre
+STASH_COUNT_BEFORE=$(get_stash_count)
+git stash push --include-untracked --keep-index --quiet
+
+# Checks
 npm run lint
 npm run test
 npm run transpile
-git stash pop -q || true
+
+# Post
+STASH_COUNT_AFTER=$(get_stash_count)
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
+then
+  git stash pop --quiet
+fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,7 +4,7 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-git stash push --include-untracked --keep-index --quiet
+git stash push --include-untracked --quiet
 
 # Checks
 npm run lint


### PR DESCRIPTION
:heavy_check_mark: Prevent restoring stashes if non were created.
:heavy_check_mark: Don't stash if there's a merge in progress.
:heavy_check_mark: Maintain index (staged/unstaged) of files when popping stashes.
:heavy_check_mark: Use full names for flags/options to improve readability.