### PR TITLE
Enable dependabot updates for GitHub Actions actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       time: "08:00"
     labels:
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Searches for `.github/workflows` in this directory
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
For more information, see [the documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).