### PR TITLE
Ensure argument's `toString` method returns a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Improve error messaging for certain non-string arguments.
 
 ## [1.5.0] - 2022-02-14
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,12 @@ function isStringable(value) {
     return false;
   }
 
-  return typeof value.toString === "function";
+  if (typeof value.toString !== "function") {
+    return false;
+  }
+
+  const str = value.toString();
+  return typeof str === "string";
 }
 
 /**

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -27,6 +27,7 @@ import * as win from "../src/win.js";
 describe("main.js", function () {
   const booleanInputs = [true, false];
   const noToStringObject = { toString: null };
+  const toStringNotStringObject = { toString: () => null };
   const numericInputs = [42, 3.14];
   const stringInputs = [
     "Hello world!",
@@ -130,6 +131,17 @@ describe("main.js", function () {
       it(`fails when toString is missing`, function () {
         assert.throws(
           () => escapeShellArgByPlatform(noToStringObject, platform, env),
+          {
+            name: "TypeError",
+            message: typeError,
+          }
+        );
+      });
+
+      it(`fails when toString does not return a string`, function () {
+        assert.throws(
+          () =>
+            escapeShellArgByPlatform(toStringNotStringObject, platform, env),
           {
             name: "TypeError",
             message: typeError,
@@ -245,6 +257,17 @@ describe("main.js", function () {
           }
         );
       });
+
+      it(`fails when toString does not return a string`, function () {
+        assert.throws(
+          () =>
+            escapeShellArgByPlatform(toStringNotStringObject, platform, env),
+          {
+            name: "TypeError",
+            message: typeError,
+          }
+        );
+      });
     });
   });
 
@@ -303,6 +326,16 @@ describe("main.js", function () {
       it(`fails when toString is missing`, function () {
         assert.throws(
           () => quoteShellArgByPlatform(noToStringObject, platform, env),
+          {
+            name: "TypeError",
+            message: typeError,
+          }
+        );
+      });
+
+      it(`fails when toString does not return a string`, function () {
+        assert.throws(
+          () => quoteShellArgByPlatform(toStringNotStringObject, platform, env),
           {
             name: "TypeError",
             message: typeError,
@@ -373,6 +406,16 @@ describe("main.js", function () {
       it(`fails when toString is missing`, function () {
         assert.throws(
           () => quoteShellArgByPlatform(noToStringObject, platform, env),
+          {
+            name: "TypeError",
+            message: typeError,
+          }
+        );
+      });
+
+      it(`fails when toString does not return a string`, function () {
+        assert.throws(
+          () => quoteShellArgByPlatform(toStringNotStringObject, platform, env),
           {
             name: "TypeError",
             message: typeError,


### PR DESCRIPTION
- [x] Unit tests
- [x] Implementation
- [x] Changelog
