### PR TITLE
Fix usage of `fetch-depth` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,14 +79,14 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3.0.0
+        with:
+          fetch-depth: 0
       - name: Get release version
         id: tag_version
         uses: dawidd6/action-get-tag@v1.1.0
       - name: Get release text
         id: tag_text
         uses: ericcornelissen/git-tag-annotation-action@v1.1.5
-        with:
-          fetch-depth: 0
       - name: Create release
         id: create_release
         uses: actions/create-release@v1.1.4


### PR DESCRIPTION
Fixing a mistake made in #185, the `fetch-depth` option should be set on `actions/checkout` not `ericcornelissen/git-tag-annotation-action` (as per [the latter's documentation](https://github.com/ericcornelissen/git-tag-annotation-action#full-example)).