### PR TITLE
Improve win::getDefaultShell property tests

### DIFF
--- a/test/win.prop.js
+++ b/test/win.prop.js
@@ -25,6 +25,25 @@ describe("win.js", function () {
   });
 
   describe("::getDefaultShell", function () {
+    it("always returns a string", function () {
+      fc.assert(
+        fc.property(
+          fc.object({
+            // These constraints models the behaviour of a `process.env` object.
+            // Additionally, it is ensured that the %COMSPEC% is likely present.
+            // See https://nodejs.org/api/process.html#processenv
+            key: fc.oneof(fc.constant("ComSpec"), fc.string()),
+            values: [fc.string()],
+            maxDepth: 0,
+          }),
+          function (env) {
+            const result = win.getDefaultShell({ env });
+            assert.ok(typeof result === "string");
+          }
+        )
+      );
+    });
+
     it("returns %COMSPEC% if present", function () {
       fc.assert(
         fc.property(fc.object(), fc.string(), function (env, ComSpec) {


### PR DESCRIPTION
Add a new property test for [the `getDefaultShell` of the win module](https://github.com/ericcornelissen/shescape/blob/0324efd8838c132f1a929376e4832853b3534008/src/win.js#L119-L125) that aims to test that it always returns a string given the `process.env` object. The `process.env` object is modeled as a specialized instance of [the `fc.object` arbitrary](https://github.com/dubzzz/fast-check/blob/40fdb4bc5c2edcb7773aafbf3afc90882c2db8f3/documentation/Arbitraries.md#object) based on [the official Node.js `process.env` documentation](https://nodejs.org/api/process.html#processenv).
