### PR TITLE
Refactor `platforms.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ import { getHelpersByPlatform } from "./src/platforms.js";
  */
 function getPlatformHelpers() {
   const platform = os.platform();
-  const helpers = getHelpersByPlatform({ platform, process });
+  const helpers = getHelpersByPlatform({ env: process.env, platform });
   return helpers;
 }
 

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -26,26 +26,20 @@ const win32 = "win32";
  * Check if the current platform is Windows.
  *
  * @param {Object} args The arguments for this function.
+ * @param {Record<string, string>} args.env The environment variables.
  * @param {string} args.platform The `os.platform()` value.
- * @param {Object} args.process The `process` values.
- * @param {Object} args.process.env The environment variables.
  * @returns {boolean} `true` iff the current platform is Windows.
  */
-function isWindow({ platform, process }) {
-  return (
-    platform === win32 ||
-    process.env.OSTYPE === cygwin ||
-    process.env.OSTYPE === msys
-  );
+function isWindow({ env, platform }) {
+  return platform === win32 || env.OSTYPE === cygwin || env.OSTYPE === msys;
 }
 
 /**
  * Get all helper functions for a specific platform.
  *
  * @param {Object} args The arguments for this function.
+ * @param {Record<string, string>} args.env The environment variables.
  * @param {string} args.platform The `os.platform()` value.
- * @param {Object} args.process The `process` values.
- * @param {Object} args.process.env The environment variables.
  * @returns {Object} The helper functions for the current platform.
  */
 export function getHelpersByPlatform(args) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,12 +19,12 @@ describe("index.js", function () {
   const getExpectedEscaped = (arg) =>
     main.escapeShellArg(
       { arg, options, process },
-      getHelpersByPlatform({ platform, process })
+      getHelpersByPlatform({ env: process.env, platform })
     );
   const getExpectedQuoted = (arg) =>
     main.quoteShellArg(
       { arg, options, process },
-      getHelpersByPlatform({ platform, process })
+      getHelpersByPlatform({ env: process.env, platform })
     );
 
   before(function () {
@@ -58,10 +58,7 @@ describe("index.js", function () {
 
     it("gracefully handles inputs that are not an array", function () {
       const input = "Hello world!";
-      const expected = main.escapeShellArg(
-        { arg: input, options, platform, process },
-        getHelpersByPlatform({ platform, process })
-      );
+      const expected = getExpectedEscaped(input);
 
       const output = shescape.escapeAll(input);
       assert.deepStrictEqual(output, [expected]);

--- a/test/platform.prop.js
+++ b/test/platform.prop.js
@@ -46,16 +46,14 @@ describe("platforms.js", function () {
       fc.assert(
         fc.property(
           fc.object(),
-          fc.object(),
           fc.constantFrom(...allPlatforms),
           fc.constantFrom(...osTypes),
-          function (process, env, platform, osType) {
+          function (env, platform, osType) {
             env.osType = osType;
-            process.env = env;
 
             const result = platforms.getHelpersByPlatform({
+              env,
               platform,
-              process,
             });
 
             assert.ok(typeof result.getDefaultShell === "function");

--- a/test/platforms.test.js
+++ b/test/platforms.test.js
@@ -24,84 +24,81 @@ import * as win from "../src/win.js";
 
 describe("platforms.js", function () {
   describe("::getHelpersByPlatform", function () {
-    let process;
+    let env;
 
     beforeEach(function () {
-      process = { env: {} };
+      env = {};
     });
 
     it("returns the unix module for platform 'aix'", function () {
       const platform = osAix;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the unix module for platform 'darwin'", function () {
       const platform = osDarwin;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the unix module for platform 'freebsd'", function () {
       const platform = osFreebsd;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the unix module for platform 'linux'", function () {
       const platform = osLinux;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the unix module for platform 'openbsd'", function () {
       const platform = osOpenbsd;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the unix module for platform 'sunos'", function () {
       const platform = osSunos;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, unix);
     });
 
     it("returns the windows module for platform 'win32'", function () {
       const platform = osWin32;
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, win);
     });
 
     it("returns the windows module for OS type 'cygwin'", function () {
       const platform = "foobar";
-      process.env = { OSTYPE: ostypeCygwin };
+      env = { OSTYPE: ostypeCygwin };
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, win);
     });
 
     it("returns the windows module for OS type 'msys'", function () {
       const platform = "foobar";
-      process.env = { OSTYPE: ostypeMsys };
+      env = { OSTYPE: ostypeMsys };
 
-      const result = platforms.getHelpersByPlatform({ platform, process });
+      const result = platforms.getHelpersByPlatform({ env, platform });
       assert.deepStrictEqual(result, win);
     });
 
     it("does throw if the environment variables are missing", function () {
       const platform = "foobar";
-      delete process.env;
 
-      assert.throws(() =>
-        platforms.getHelpersByPlatform({ platform, process })
-      );
+      assert.throws(() => platforms.getHelpersByPlatform({ platform }));
     });
   });
 });


### PR DESCRIPTION
... such that it no longer expects as input the `process` object, but rather the environment variables directly. This takes away the assumption/requirement that the environment variables must come from the `process` object. This makes it easier to change where the environment variables come from later, as well as simplifies the function signature for testing.