### PR TITLE
Replace Node 17 by Node 18 for compatibility tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.13.0, 12, 14, 16, 17]
+        node-version: [10.13.0, 12, 14, 16, 18]
     steps:
       - name: Check out code
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
Following [this tweet](https://twitter.com/trott/status/1529593378190393344) (also [the EOL (end-of-life) matrix by Node.js](https://nodejs.org/en/about/releases/)), update the compatibility testing matrix in the CI to test Node.js v18 over v17, as v17 is almost EOL.

Since 2022-06-01 is the EOL date for Node.js v17 the intend is to merge this Pull Request on 2022-05-31 or 2022-06-01.