### PR TITLE
Expand use of coverage in CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,7 @@ coverage:
           - src/
 
 comment:
-  layout: diff, files
+  layout: diff, flags, files
   behavior: default # update, if exists. Otherwise post new.
   require_changes: true # only post the comment if coverage changes
   require_base: no

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -35,6 +35,11 @@ flags:
       - src/**/*.js
       - index.js
       - index.cjs
+  property:
+    carryforward: true
+    paths:
+      - src/**/*.js
+      - index.js
   unit:
     carryforward: true
     paths:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,6 +16,30 @@ comment:
   require_base: no
   require_head: yes
 
+flags:
+  e2e-macos-latest:
+    carryforward: true
+    paths:
+      - src/**/*.js
+      - index.js
+      - index.cjs
+  e2e-ubuntu-latest:
+    carryforward: true
+    paths:
+      - src/**/*.js
+      - index.js
+      - index.cjs
+  e2e-windows-latest:
+    carryforward: true
+    paths:
+      - src/**/*.js
+      - index.js
+      - index.cjs
+  unit:
+    carryforward: true
+    paths:
+      - src/**/*.js
+
 ignore:
   - "script/**/*"
   - "test/**/*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Transpile to CommonJS
         run: npm run transpile
       - name: Run compatibility tests
-        run: npm run test:compatibility
+        run: npm run coverage:compatibility
   e2e:
     name: End-to-end
     needs: [transpile, unit]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,11 @@ jobs:
         run: npm run transpile
       - name: Run end-to-end tests
         run: npm run coverage:e2e
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          file: ./_reports/coverage/e2e/lcov.info
+          flags: e2e-${{ matrix.os }}
   fuzz:
     name: Fuzz
     needs: [e2e]
@@ -285,3 +290,4 @@ jobs:
         uses: codecov/codecov-action@v3.1.0
         with:
           file: ./_reports/coverage/unit/lcov.info
+          flags: unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run property tests
-        run: npm run test:property
+        run: npm run coverage:property
   transpile:
     name: Transpile
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,11 @@ jobs:
         run: npm ci
       - name: Run property tests
         run: npm run coverage:property
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          file: ./_reports/coverage/property/lcov.info
+          flags: property
   transpile:
     name: Transpile
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Transpile to CommonJS
         run: npm run transpile
       - name: Run end-to-end tests
-        run: npm run test:e2e
+        run: npm run coverage:e2e
   fuzz:
     name: Fuzz
     needs: [e2e]


### PR DESCRIPTION
Expand to use of coverage reports in the CI to include e2e tests, property tests, and compatibility tests. Given that commands for this are already available, it's simple and convenient to provide the coverage results in the CI as well.

Also add the coverage reports of e2e tests and property tests to Codecov. For e2e tests the coverage report is uploaded per-os. The coverage reports for unit tests, e2e tests, and property tests are separated in Codecov using ["flags"](https://docs.codecov.com/docs/flags).

Compatibility tests are **not** being uploaded to Codecov yet. At the time of creating this Pull Request this seems unnecessary.