### PR TITLE
Create fuzz target for `child_process.fork`

### DIFF
--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -1,6 +1,6 @@
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
- * function `spawn` / `spawnSync`.
+ * function `fork`.
  * @license Unlicense
  */
 

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -1,0 +1,38 @@
+/**
+ * @overview Contains fuzz tests for using Shescape with the child_process
+ * function `spawn` / `spawnSync`.
+ * @license Unlicense
+ */
+
+const assert = require("node:assert");
+const { fork } = require("node:child_process");
+
+const common = require("./_common.cjs");
+
+const shescape = require("../../index.cjs");
+
+function check(arg) {
+  const preparedArg = common.prepareArg(arg, false);
+
+  const echo = fork("test/fuzz/echo.js", shescape.escapeAll([preparedArg]), {
+    silent: true,
+  });
+
+  echo.stdout.on("data", (data) => {
+    const result = data.toString();
+    const expected = common.getExpectedOutput(arg);
+    assert.strictEqual(result, expected);
+  });
+}
+
+function fuzz(buf) {
+  const arg = buf.toString();
+
+  // Skipped because of a bug with fork in shescape, see:
+  // - https://github.com/ericcornelissen/shescape/issues/286
+  //check(arg);
+}
+
+module.exports = {
+  fuzz,
+};


### PR DESCRIPTION
Unfortunately, due to a known bug, the fuzz target is currently disabled as it will just find the known bug. See #275 and #286