### PR TITLE
Replace ava-fast-check by @fast-check/ava

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "which": "^2.0.0"
       },
       "devDependencies": {
+        "@fast-check/ava": "0.0.1",
         "@stryker-mutator/core": "6.1.2",
         "ava": "4.3.0",
-        "ava-fast-check": "6.0.0",
         "benchmark": "2.1.4",
         "c8": "7.11.3",
         "depcheck": "1.4.3",
@@ -713,6 +713,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fast-check/ava": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@fast-check/ava/-/ava-0.0.1.tgz",
+      "integrity": "sha512-scgivoKEv+TuoYI67NHj9wubkZ8KORReoaAhjDEphFyMdqbeu5aSdWOuVC/vzv9qxj+Jl0FuL8jDtdbFwJlw3g==",
+      "dev": true,
+      "dependencies": {
+        "fast-check": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
+      },
+      "peerDependencies": {
+        "ava": ">=4.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1558,20 +1574,6 @@
         "@ava/typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ava-fast-check": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ava-fast-check/-/ava-fast-check-6.0.0.tgz",
-      "integrity": "sha512-d4UpID9dsrCSg4zRR7xl63oQSUQYN4R6qeF1+wn8Gi9qQjtK12OblrUyxoA6M7RUgX5BUI3rsTBi/e5cxYu2Vg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
-      },
-      "peerDependencies": {
-        "ava": ">=4.0.0",
-        "fast-check": "^3.0.0"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "which": "^2.0.0"
   },
   "devDependencies": {
+    "@fast-check/ava": "0.0.1",
     "@stryker-mutator/core": "6.1.2",
     "ava": "4.3.0",
-    "ava-fast-check": "6.0.0",
     "benchmark": "2.1.4",
     "c8": "7.11.3",
     "depcheck": "1.4.3",

--- a/test/prop/index/escape-all.test.js
+++ b/test/prop/index/escape-all.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/index/escape.test.js
+++ b/test/prop/index/escape.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/index/quote-all.test.js
+++ b/test/prop/index/quote-all.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/index/quote.test.js
+++ b/test/prop/index/quote.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/platforms/get-helpers.test.js
+++ b/test/prop/platforms/get-helpers.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 
 import { arbitrary } from "./_.js";
 

--- a/test/prop/unix/default-shell.test.js
+++ b/test/prop/unix/default-shell.test.js
@@ -3,7 +3,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 
 import { arbitrary } from "./_.js";
 

--- a/test/prop/unix/escape.test.js
+++ b/test/prop/unix/escape.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/unix/quote.test.js
+++ b/test/prop/unix/quote.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 
 import { arbitrary } from "./_.js";
 

--- a/test/prop/unix/shell-name.test.js
+++ b/test/prop/unix/shell-name.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import sinon from "sinon";
 

--- a/test/prop/win/default-shell.test.js
+++ b/test/prop/win/default-shell.test.js
@@ -3,7 +3,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 
 import { arbitrary, constants } from "./_.js";
 

--- a/test/prop/win/escape.test.js
+++ b/test/prop/win/escape.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";

--- a/test/prop/win/quote.test.js
+++ b/test/prop/win/quote.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 
 import { arbitrary } from "./_.js";
 

--- a/test/prop/win/shell-name.test.js
+++ b/test/prop/win/shell-name.test.js
@@ -4,7 +4,7 @@
  * @license Unlicense
  */
 
-import { testProp } from "ava-fast-check";
+import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import sinon from "sinon";
 


### PR DESCRIPTION
Per the deprecation warning for [ava-fast-check](https://www.npmjs.com/package/ava-fast-check):

    Replaced by @fast-check/ava
