### PR TITLE
Use `.failing` tests

### DIFF
--- a/test/e2e/child_process.test.js
+++ b/test/e2e/child_process.test.js
@@ -32,9 +32,9 @@ test(macros.execFile, { arg: '" ls', options: { shell: true } });
 test(macros.execFileSync, { arg: "&& ls" });
 test(macros.execFileSync, { arg: "' ls" });
 test(macros.execFileSync, { arg: '" ls' });
-test.skip(macros.execFileSync, { arg: "&& ls", options: { shell: true } }); // Skipped due to https://github.com/nodejs/node/issues/43333
-test.skip(macros.execFileSync, { arg: "' ls", options: { shell: true } }); // Skipped due to https://github.com/nodejs/node/issues/43333
-test.skip(macros.execFileSync, { arg: '" ls', options: { shell: true } }); // Skipped due to https://github.com/nodejs/node/issues/43333
+test.failing(macros.execFileSync, { arg: "&& ls", options: { shell: true } }); // due to https://github.com/nodejs/node/issues/43333
+test.failing(macros.execFileSync, { arg: "' ls", options: { shell: true } }); // due to https://github.com/nodejs/node/issues/43333
+test.failing(macros.execFileSync, { arg: '" ls', options: { shell: true } }); // due to https://github.com/nodejs/node/issues/43333
 
 test(macros.fork, { arg: "&& ls" });
 test(macros.fork, { arg: "' ls" });


### PR DESCRIPTION
Update the child_process e2e test suite to use [`.failing`](https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#failing-tests) over `.skip` for known failing tests.