### PR TITLE
Add fuzzing of `child_process.fork` to fuzz job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,44 @@ jobs:
         if: ${{ steps.fuzz-exec-file.outputs.fuzz-error == 'true' }}
         run: exit 1
 
+      - name: Fuzz fork
+        id: fuzz-fork
+        shell: bash {0}
+        env:
+          FUZZ_SHELL: ${{ matrix.shell }}
+        run: |
+          timeout 5m npm run fuzz fork
+          export EXIT_CODE=$?
+          if [[ ($EXIT_CODE == 124) ]]
+          then
+            echo "::set-output name=fuzz-error::false"
+            echo "::set-output name=script-error::false"
+          elif [[ ($EXIT_CODE == 1) ]]
+          then
+            echo "::set-output name=fuzz-error::true"
+            echo "::set-output name=script-error::false"
+          else
+            echo "::set-output name=fuzz-error::false"
+            echo "::set-output name=script-error::true"
+            echo "::set-output name=exit-code::"$EXIT_CODE
+          fi
+      - name: Check for unexpected error
+        if: ${{ steps.fuzz-fork.outputs.script-error == 'true' }}
+        run: |
+          echo "Unexpected error: ${{ steps.fuzz-fork.outputs.exit-code }}"
+          exit 1
+      - name: Upload crash (if any)
+        if: ${{ steps.fuzz-fork.outputs.fuzz-error == 'true' }}
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: fuzz-crash-${{ matrix.os }}-${{ matrix.name }}-fork
+          path: |
+            .corpus/
+            crash-*
+      - name: Error for fuzz crash
+        if: ${{ steps.fuzz-fork.outputs.fuzz-error == 'true' }}
+        run: exit 1
+
       - name: Fuzz spawn/spawnSync
         id: fuzz-spawn
         shell: bash {0}

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -14,21 +14,32 @@ const shescape = require("../../index.cjs");
 function check(arg) {
   const preparedArg = common.prepareArg(arg, false, true);
 
-  const echo = fork(common.ECHO_SCRIPT, shescape.escapeAll([preparedArg]), {
-    silent: true,
-  });
+  return new Promise((resolve, reject) => {
+    const echo = fork(common.ECHO_SCRIPT, shescape.escapeAll([preparedArg]), {
+      silent: true,
+    });
 
-  echo.stdout.on("data", (data) => {
-    const result = data.toString();
-    const expected = common.getExpectedOutput(arg);
-    assert.strictEqual(result, expected);
+    echo.stdout.on("data", (data) => {
+      const result = data.toString();
+      const expected = common.getExpectedOutput(arg);
+      try {
+        assert.strictEqual(result, expected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
   });
 }
 
-function fuzz(buf) {
+async function fuzz(buf) {
   const arg = buf.toString();
 
-  check(arg);
+  try {
+    await check(arg);
+  } catch (e) {
+    throw e;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Follow up on #310 to enable fuzzing of `child_process.fork` in the CI. In #310 it was originally enabled (as it fixed a bug that caused the `fork` fuzz target to always crash prior to 5 minutes of running), but then disabled again because of seeming flakiness on Windows. When fuzzing on Windows, with either `cmd.exe` or `powershell.exe`, something like the following error (example) was observed:

```
...
#3266 PULSE     cov: 332 corp: 47 exec/s: 0 rss: 64.16 MB
    ^
=================================================================

Error: spawn UNKNOWN
Error: spawn UNKNOWN
    at ChildProcess.spawn (node:internal/child_process:413:11)
    at ChildProcess.spawn (node:internal/child_process:413:11)
    at spawn (node:child_process:689:9)
    at spawn (node:child_process:689:9)
    at fork (node:child_process:163:10)
    at run (D:\a\shescape\shescape\node_modules\pidusage\lib\bin.js:18:12)
    at check (D:\a\shescape\shescape\test\fuzz\fork.test.cjs:5:410)
    at wmic (D:\a\shescape\shescape\node_modules\pidusage\lib\wmic.js:48:3)
    at Worker.fuzz [as fn] (D:\a\shescape\shescape\test\fuzz\fork.test.cjs:5:855)
    at get (D:\a\shescape\shescape\node_modules\pidusage\lib\stats.js:74:3)
    at process.<anonymous> (D:\a\shescape\shescape\node_modules\jsfuzz\build\src\worker.js:55:30)
    at D:\a\shescape\shescape\node_modules\pidusage\index.js:30:5
    at process.emit (node:events:527:28)
    at new Promise (<anonymous>)
    at emit (node:internal/child_process:936:14)
    at pidusage (D:\a\shescape\shescape\node_modules\pidusage\index.js:29:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
    at Timeout._onTimeout (D:\a\shescape\shescape\node_modules\jsfuzz\build\src\fuzzer.js:131:33)
  errno: -4094,
  code: 'UNKNOWN',
    at listOnTimeout (node:internal/timers:564:17) {
  syscall: 'spawn'
  errno: -4094,
}
  code: 'UNKNOWN',
  syscall: 'spawn'
}
```