### PR TITLE
Escaping for Unix shells after whitespace with `{interpolation:true}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix escaping of characters after whitespace with `{interpolation:true}` for
+  Bash, Dash, and Zsh on Unix systems. ([#324])
 
 ## [1.5.6] - 2022-07-02
 
@@ -142,5 +143,6 @@ Versioning].
 [#272]: https://github.com/ericcornelissen/shescape/pull/272
 [#277]: https://github.com/ericcornelissen/shescape/pull/277
 [#310]: https://github.com/ericcornelissen/shescape/pull/310
+[#324]: https://github.com/ericcornelissen/shescape/pull/324
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/unix.js
+++ b/src/unix.js
@@ -46,7 +46,7 @@ function escapeArgBash(arg, interpolation, quoted) {
   if (interpolation) {
     result = result
       .replace(/\\/g, "\\\\")
-      .replace(/^(~|#)/g, "\\$1")
+      .replace(/(^|\s)(~|#)/g, "$1\\$2")
       .replace(/(\*|\?)/g, "\\$1")
       .replace(/(\$|\;|\&|\|)/g, "\\$1")
       .replace(/(\(|\)|\<|\>)/g, "\\$1")
@@ -74,7 +74,7 @@ function escapeArgDash(arg, interpolation, quoted) {
   if (interpolation) {
     result = result
       .replace(/\\/g, "\\\\")
-      .replace(/^(~|#)/g, "\\$1")
+      .replace(/(^|\s)(~|#)/g, "$1\\$2")
       .replace(/(\*|\?)/g, "\\$1")
       .replace(/(\$|\;|\&|\|)/g, "\\$1")
       .replace(/(\(|\)|\<|\>)/g, "\\$1")
@@ -101,12 +101,12 @@ function escapeArgZsh(arg, interpolation, quoted) {
   if (interpolation) {
     result = result
       .replace(/\\/g, "\\\\")
-      .replace(/^(~|#)/g, "\\$1")
+      .replace(/(^|\s)(~|#)/g, "$1\\$2")
       .replace(/(\*|\?)/g, "\\$1")
       .replace(/(\$|\;|\&|\|)/g, "\\$1")
       .replace(/(\(|\)|\<|\>)/g, "\\$1")
       .replace(/("|'|`)/g, "\\$1")
-      .replace(/^=/g, "\\=")
+      .replace(/(^|\s)=/g, "$1\\=")
       .replace(/(\[|\]|\{|\})/g, "\\$1");
   } else if (quoted) {
     result = result.replace(/'/g, `'\\''`);

--- a/test/fixtures/unix.cjs
+++ b/test/fixtures/unix.cjs
@@ -169,6 +169,10 @@ module.exports.escape = {
         input: "a ~b",
         expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
       },
+      {
+        input: "a	~b",
+        expected: { interpolation: "a	\\~b", noInterpolation: "a	~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -190,6 +194,10 @@ module.exports.escape = {
       {
         input: "a #b",
         expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
+      },
+      {
+        input: "a	#b",
+        expected: { interpolation: "a	\\#b", noInterpolation: "a	#b" },
       },
     ],
     "dollar signs ('$')": [
@@ -570,6 +578,10 @@ module.exports.escape = {
         input: "a ~b",
         expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
       },
+      {
+        input: "a	~b",
+        expected: { interpolation: "a	\\~b", noInterpolation: "a	~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -591,6 +603,10 @@ module.exports.escape = {
       {
         input: "a #b",
         expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
+      },
+      {
+        input: "a	#b",
+        expected: { interpolation: "a	\\#b", noInterpolation: "a	#b" },
       },
     ],
     "dollar signs ('$')": [
@@ -891,6 +907,10 @@ module.exports.escape = {
         input: "a ~b",
         expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
       },
+      {
+        input: "a	~b",
+        expected: { interpolation: "a	\\~b", noInterpolation: "a	~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -912,6 +932,10 @@ module.exports.escape = {
       {
         input: "a #b",
         expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
+      },
+      {
+        input: "a	#b",
+        expected: { interpolation: "a	\\#b", noInterpolation: "a	#b" },
       },
     ],
     "dollar signs ('$')": [
@@ -964,6 +988,10 @@ module.exports.escape = {
       {
         input: "a =b",
         expected: { interpolation: "a \\=b", noInterpolation: "a =b" },
+      },
+      {
+        input: "a	=b",
+        expected: { interpolation: "a	\\=b", noInterpolation: "a	=b" },
       },
     ],
     "backslashes ('\\')": [

--- a/test/fixtures/unix.cjs
+++ b/test/fixtures/unix.cjs
@@ -165,6 +165,10 @@ module.exports.escape = {
         input: "a=~ ",
         expected: { interpolation: "a=\\~ ", noInterpolation: "a=~ " },
       },
+      {
+        input: "a ~b",
+        expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -182,6 +186,10 @@ module.exports.escape = {
       {
         input: "a#b#c",
         expected: { interpolation: "a#b#c", noInterpolation: "a#b#c" },
+      },
+      {
+        input: "a #b",
+        expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
       },
     ],
     "dollar signs ('$')": [
@@ -558,6 +566,10 @@ module.exports.escape = {
         input: "a=~ ",
         expected: { interpolation: "a=~ ", noInterpolation: "a=~ " },
       },
+      {
+        input: "a ~b",
+        expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -575,6 +587,10 @@ module.exports.escape = {
       {
         input: "a#b#c",
         expected: { interpolation: "a#b#c", noInterpolation: "a#b#c" },
+      },
+      {
+        input: "a #b",
+        expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
       },
     ],
     "dollar signs ('$')": [
@@ -871,6 +887,10 @@ module.exports.escape = {
         input: "a~b~c",
         expected: { interpolation: "a~b~c", noInterpolation: "a~b~c" },
       },
+      {
+        input: "a ~b",
+        expected: { interpolation: "a \\~b", noInterpolation: "a ~b" },
+      },
     ],
     "hashtags ('#')": [
       {
@@ -888,6 +908,10 @@ module.exports.escape = {
       {
         input: "a#b#c",
         expected: { interpolation: "a#b#c", noInterpolation: "a#b#c" },
+      },
+      {
+        input: "a #b",
+        expected: { interpolation: "a \\#b", noInterpolation: "a #b" },
       },
     ],
     "dollar signs ('$')": [
@@ -936,6 +960,10 @@ module.exports.escape = {
       {
         input: "a=b=c",
         expected: { interpolation: "a=b=c", noInterpolation: "a=b=c" },
+      },
+      {
+        input: "a =b",
+        expected: { interpolation: "a \\=b", noInterpolation: "a =b" },
       },
     ],
     "backslashes ('\\')": [

--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -28,7 +28,7 @@ export const escape = test.macro({
     t.is(actual, expected);
   },
   title(_, { input, interpolation, quoted, shellName }) {
-    input = input.replace(/\u{0}/gu, "\\x00");
+    input = input.replace(/\u{0}/gu, "\\x00").replace(/\t/g, "\\t");
     interpolation = interpolation ? "interpolation" : "no interpolation";
     quoted = quoted ? "quoted" : "not quoted";
 


### PR DESCRIPTION
Closes #323 

Fuzzing for this requires #318, hence fuzzing will be taken care of after this is merged into `main`