### PR TITLE
Removely curly brace escaping for Dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Improve performance of escaping for Dash. ([#336])
 
 ## [1.5.8] - 2022-07-15
 
@@ -161,5 +161,6 @@ Versioning].
 [#322]: https://github.com/ericcornelissen/shescape/pull/322
 [#324]: https://github.com/ericcornelissen/shescape/pull/324
 [#332]: https://github.com/ericcornelissen/shescape/pull/332
+[#336]: https://github.com/ericcornelissen/shescape/pull/336
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/unix.js
+++ b/src/unix.js
@@ -80,8 +80,7 @@ function escapeArgDash(arg, interpolation, quoted) {
       .replace(/(\*|\?)/g, "\\$1")
       .replace(/(\$|\;|\&|\|)/g, "\\$1")
       .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/\{(?=([^]*?(?:\,|\.)[^]*?)\})/g, "\\{");
+      .replace(/("|'|`)/g, "\\$1");
   } else if (quoted) {
     result = result.replace(/'/g, `'\\''`);
   }

--- a/test/fixtures/unix.cjs
+++ b/test/fixtures/unix.cjs
@@ -1206,115 +1206,115 @@ module.exports.escape = {
       },
       {
         input: "a{b,c}d",
-        expected: { interpolation: "a\\{b,c}d", noInterpolation: "a{b,c}d" },
+        expected: { interpolation: "a{b,c}d", noInterpolation: "a{b,c}d" },
       },
       {
         input: "a{,b}c",
-        expected: { interpolation: "a\\{,b}c", noInterpolation: "a{,b}c" },
+        expected: { interpolation: "a{,b}c", noInterpolation: "a{,b}c" },
       },
       {
         input: "a{b,}c",
-        expected: { interpolation: "a\\{b,}c", noInterpolation: "a{b,}c" },
+        expected: { interpolation: "a{b,}c", noInterpolation: "a{b,}c" },
       },
       {
         input: "a{bc,de}f",
         expected: {
-          interpolation: "a\\{bc,de}f",
+          interpolation: "a{bc,de}f",
           noInterpolation: "a{bc,de}f",
         },
       },
       {
         input: "a{b,{c,d},e}f",
         expected: {
-          interpolation: "a\\{b,\\{c,d},e}f",
+          interpolation: "a{b,{c,d},e}f",
           noInterpolation: "a{b,{c,d},e}f",
         },
       },
       {
         input: "a{0..2}b",
-        expected: { interpolation: "a\\{0..2}b", noInterpolation: "a{0..2}b" },
+        expected: { interpolation: "a{0..2}b", noInterpolation: "a{0..2}b" },
       },
       {
         input: "a{\u000Db,c}d",
         expected: {
-          interpolation: "a\\{\u000Db,c}d",
+          interpolation: "a{\u000Db,c}d",
           noInterpolation: "a{\u000Db,c}d",
         },
       },
       {
         input: "a{\u2028b,c}d",
         expected: {
-          interpolation: "a\\{\u2028b,c}d",
+          interpolation: "a{\u2028b,c}d",
           noInterpolation: "a{\u2028b,c}d",
         },
       },
       {
         input: "a{\u2029b,c}d",
         expected: {
-          interpolation: "a\\{\u2029b,c}d",
+          interpolation: "a{\u2029b,c}d",
           noInterpolation: "a{\u2029b,c}d",
         },
       },
       {
         input: "a{b,c\u000D}d",
         expected: {
-          interpolation: "a\\{b,c\u000D}d",
+          interpolation: "a{b,c\u000D}d",
           noInterpolation: "a{b,c\u000D}d",
         },
       },
       {
         input: "a{b,c\u2028}d",
         expected: {
-          interpolation: "a\\{b,c\u2028}d",
+          interpolation: "a{b,c\u2028}d",
           noInterpolation: "a{b,c\u2028}d",
         },
       },
       {
         input: "a{b,c\u2029}d",
         expected: {
-          interpolation: "a\\{b,c\u2029}d",
+          interpolation: "a{b,c\u2029}d",
           noInterpolation: "a{b,c\u2029}d",
         },
       },
       {
         input: "a{\u000D0..2}b",
         expected: {
-          interpolation: "a\\{\u000D0..2}b",
+          interpolation: "a{\u000D0..2}b",
           noInterpolation: "a{\u000D0..2}b",
         },
       },
       {
         input: "a{\u20280..2}b",
         expected: {
-          interpolation: "a\\{\u20280..2}b",
+          interpolation: "a{\u20280..2}b",
           noInterpolation: "a{\u20280..2}b",
         },
       },
       {
         input: "a{\u20290..2}b",
         expected: {
-          interpolation: "a\\{\u20290..2}b",
+          interpolation: "a{\u20290..2}b",
           noInterpolation: "a{\u20290..2}b",
         },
       },
       {
         input: "a{0..2\u000D}b",
         expected: {
-          interpolation: "a\\{0..2\u000D}b",
+          interpolation: "a{0..2\u000D}b",
           noInterpolation: "a{0..2\u000D}b",
         },
       },
       {
         input: "a{0..2\u2028}b",
         expected: {
-          interpolation: "a\\{0..2\u2028}b",
+          interpolation: "a{0..2\u2028}b",
           noInterpolation: "a{0..2\u2028}b",
         },
       },
       {
         input: "a{0..2\u2029}b",
         expected: {
-          interpolation: "a\\{0..2\u2029}b",
+          interpolation: "a{0..2\u2029}b",
           noInterpolation: "a{0..2\u2029}b",
         },
       },


### PR DESCRIPTION
Following up on #272, remove another unnecessary escaping for Dash that was inherited from Bash since Dash doesn't do curly brace expansion.