### PR TITLE
Fixes for issues detected by Codacy

### DIFF
--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -26,7 +26,7 @@ jobs:
           - powershell.exe
         target:
           - exec
-          - execFile
+          - exec-file
           - fork
           - spawn
         exclude:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions][ci-image]][ci-url]
 [![Coverage Report][coverage-image]][coverage-url]
 [![Mutation Report][mutation-image]][mutation-url]
-[![quality Report][quality-image]][quality-url]
+[![Quality Report][quality-image]][quality-url]
 [![NPM Package][npm-image]][npm-url]
 
 A simple shell escape package for JavaScript. Use it to escape user-controlled

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 get_stash_count () {
-  local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
+  readonly count="$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)"
   if [ "$count" = "" ]; then
     echo "0"
   else
-    echo $count
+    echo "$count"
   fi
 }
 
-STASH_COUNT_BEFORE=$(get_stash_count)
+readonly STASH_COUNT_BEFORE="$(get_stash_count)"
 DID_STASH () {
-  local STASH_COUNT_AFTER=$(get_stash_count)
+  readonly STASH_COUNT_AFTER="$(get_stash_count)"
   if [ "$STASH_COUNT_BEFORE" != "$STASH_COUNT_AFTER" ]; then
     echo "x"  # true
   else

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -9,7 +9,7 @@ get_stash_count () {
   fi
 }
 
-readonly STASH_COUNT_BEFORE="$(get_stash_count)"
+STASH_COUNT_BEFORE="$(get_stash_count)"
 DID_STASH () {
   readonly STASH_COUNT_AFTER="$(get_stash_count)"
   if [ "$STASH_COUNT_BEFORE" != "$STASH_COUNT_AFTER" ]; then

--- a/src/executables.js
+++ b/src/executables.js
@@ -27,13 +27,13 @@ export function resolveExecutable({ executable }, { exists, readlink, which }) {
   try {
     executable = which(executable);
   } catch (_) {
-    // for backwards compatibility return the executable even if its location
+    // For backwards compatibility return the executable even if its location
     // cannot be obtained
     return executable;
   }
 
   if (!exists(executable)) {
-    // for backwards compatibility return the executable even if there exists no
+    // For backwards compatibility return the executable even if there exists no
     // file at the specified path
     return executable;
   }

--- a/test/e2e/_macros.js
+++ b/test/e2e/_macros.js
@@ -282,7 +282,7 @@ export const spawnSync = test.macro({
 
     const echo = cp.spawnSync("node", safeArgs, spawnOptions);
     if (echo.error) {
-      t.fail(`an unexpected error occurred: ${error}`);
+      t.fail(`an unexpected error occurred: ${echo.error}`);
     } else {
       const actual = `${echo.stdout}`;
       const expected = `${benignInput} ${maliciousInput}\n`;

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -1,3 +1,5 @@
+// prevent issues on case sensitive file systems
+
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `execFile` / `execFileSync`.

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -1,5 +1,3 @@
-// prevent issues on case sensitive file systems
-
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `execFile` / `execFileSync`.


### PR DESCRIPTION
> **Note**: The fuzz job for `execFile`/`exec-file` ([example](https://github.com/ericcornelissen/shescape/runs/7599576533)) will keep failing until this is merged because it references a re-usable workflow on the `main` branch which specifies the fuzz target "execFile", but this Pull Request changes the name of that fuzz target to "exec-file" (and updates the re-usable workflow accordingly).