### PR TITLE
Update harden-runner configuration

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -50,6 +50,7 @@ jobs:
             artifactcache.actions.githubusercontent.com:443
             github.com:443
             objects.githubusercontent.com:443
+            y2oiacprodeus2file6.blob.core.windows.net:443
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:


### PR DESCRIPTION
- [x] Allow GitLeaks job to access cache endpoint ([reference job (see annotations)](https://github.com/ericcornelissen/shescape/actions/runs/3145116553))