### PR TITLE
Update manual release guidelines

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,17 +36,20 @@ release a version to [npm] (using `v3.1.4` as an example):
    git clone git@github.com:ericcornelissen/shescape.git
    ```
 
-2. Verify that the repository is in a state that can be released:
+1. Verify that the repository is in a state that can be released:
 
    ```sh
-   npm install
+   npm clean-install
    npm run lint
    npm run lint:js
    npm run lint:md
    npm run test
+   npm run test:integration
+   npm run test:e2e
+   npm run test:compat
    ```
 
-3. Update the version number in the package manifest and lockfile:
+1. Update the version number in the package manifest and lockfile:
 
    ```sh
    npm version v3.1.4 --no-git-tag-version
@@ -64,7 +67,7 @@ release a version to [npm] (using `v3.1.4` as an example):
    `npm install` (after updating `package.json`) which will sync the version
    number.
 
-4. Update the version number in `index.js`:
+1. Update the version number in `index.js`:
 
    ```sh
    node script/bump-jsdoc.js
@@ -80,7 +83,7 @@ release a version to [npm] (using `v3.1.4` as an example):
      * @license MPL-2.0
    ```
 
-5. Update the changelog:
+1. Update the changelog:
 
    ```sh
    node script/bump-changelog.js
@@ -98,32 +101,51 @@ release a version to [npm] (using `v3.1.4` as an example):
    The date should follow the year-month-day format where single-digit months
    and days should be prefixed with a `0` (e.g. `2022-01-01`).
 
-6. Commit the changes to `main` using:
+1. Commit the changes to a new release branch and push using:
 
    ```sh
+   git checkout -b release-$(sha1sum package-lock.json | awk '{print $1}')
    git add CHANGELOG.md index.js package.json package-lock.json
    git commit -m "Version bump"
+   git push origin release-$(sha1sum package-lock.json | awk '{print $1}')
    ```
 
-7. Create an annotated tag for the new version:
+1. Create a Pull Request to merge the release branch into `main`. Merge the Pull
+   Request if the changes look OK and all continuous integration checks are
+   passing.
+
+1. After the Pull Request is merged, sync the `main` branch:
+
+   ```sh
+   git checkout main
+   git pull origin main
+   ```
+
+1. Create an annotated [git tag] for the new version:
 
    ```sh
    git tag -a v3.1.4
    ```
 
-   Set the annotation to the list of changes for that version.
+   Set the annotation to the list of changes for that version from the
+   changelog (excluding references).
 
-8. Push the commit and tag:
+1. Push the tag:
 
    ```sh
-   git push origin main v3.1.4
+   git push origin v3.1.4
    ```
 
-9. Publish to [npm] using:
+1. _If_ the continuous delivery setup doesn't automatically publish to [npm], do
+   this locally using:
 
    ```sh
    npm publish
    ```
+
+1. _If_ the continuous delivery setup doesn't automatically create a [GitHub
+   Release], do this manually. The release title should be "Release v3.1.4" and
+   the release text should be the items in the changelog (including reference).
 
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [github actions]: https://github.com/features/actions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,31 +22,21 @@ The release process is as follows:
 
 ## Manual Releases (Discouraged)
 
-If it's not possible to use automated releases you can follow these steps to
-release a version to [npm] (using `v3.1.4` as an example):
+If it's not possible to use automated releases, or if something goes wrong with
+the automatic release process, you can follow these steps to release a new
+version (using `v3.1.4` as an example):
 
-1. Make sure that your local copy of the repository is up-to-date:
+1. Make sure that your local copy of the repository is up-to-date, sync:
 
    ```sh
-   # Sync
-   git switch main
+   git checkout main
    git pull origin main
-
-   # Or clone
-   git clone git@github.com:ericcornelissen/shescape.git
    ```
 
-1. Verify that the repository is in a state that can be released:
+   Or clone:
 
    ```sh
-   npm clean-install
-   npm run lint
-   npm run lint:js
-   npm run lint:md
-   npm run test
-   npm run test:integration
-   npm run test:e2e
-   npm run test:compat
+   git clone git@github.com:ericcornelissen/shescape.git
    ```
 
 1. Update the version number in the package manifest and lockfile:
@@ -63,9 +53,8 @@ release a version to [npm] (using `v3.1.4` as an example):
    +  "version": "3.1.4",
    ```
 
-   To update the version number in `package-lock.json` it is recommended to run
-   `npm install` (after updating `package.json`) which will sync the version
-   number.
+   And update the version number in `package-lock.json` using `npm install`
+   (after updating `package.json`), which will sync the version number.
 
 1. Update the version number in `index.js`:
 
@@ -110,11 +99,12 @@ release a version to [npm] (using `v3.1.4` as an example):
    git push origin release-$(sha1sum package-lock.json | awk '{print $1}')
    ```
 
-1. Create a Pull Request to merge the release branch into `main`. Merge the Pull
-   Request if the changes look OK and all continuous integration checks are
-   passing.
+1. Create a Pull Request to merge the release branch into `main`.
 
-1. After the Pull Request is merged, sync the `main` branch:
+1. Merge the Pull Request if the changes look OK and all continuous integration
+   checks are passing.
+
+1. Immediately after the Pull Request is merged, sync the `main` branch:
 
    ```sh
    git checkout main
@@ -127,8 +117,8 @@ release a version to [npm] (using `v3.1.4` as an example):
    git tag -a v3.1.4
    ```
 
-   Set the annotation to the list of changes for that version from the
-   changelog (excluding references).
+   Set the annotation to the list of changes for the version from the changelog
+   (excluding references).
 
 1. Push the tag:
 
@@ -136,16 +126,19 @@ release a version to [npm] (using `v3.1.4` as an example):
    git push origin v3.1.4
    ```
 
-1. _If_ the continuous delivery setup doesn't automatically publish to [npm], do
-   this locally using:
+   > **Note**: At this point, the continuous delivery automation may pick up and
+   > complete the release process. If not, or only partially, continue following
+   > the remaining steps.
+
+1. Publish to [npm]:
 
    ```sh
    npm publish
    ```
 
-1. _If_ the continuous delivery setup doesn't automatically create a [GitHub
-   Release], do this manually. The release title should be "Release v3.1.4" and
-   the release text should be the items in the changelog (including reference).
+1. Create a [GitHub Release]. The release title should be "Release v3.1.4" and
+   the release text should be the list of changes for the version from the
+   changelog (including reference).
 
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [github actions]: https://github.com/features/actions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ The release process is as follows:
 
 If it's not possible to use automated releases, or if something goes wrong with
 the automatic release process, you can follow these steps to release a new
-version (using `v3.1.4` as an example):
+version (using `v1.6.2` as an example):
 
 1. Make sure that your local copy of the repository is up-to-date, sync:
 
@@ -42,15 +42,15 @@ version (using `v3.1.4` as an example):
 1. Update the version number in the package manifest and lockfile:
 
    ```sh
-   npm version v3.1.4 --no-git-tag-version
+   npm version --no-git-tag-version v1.6.2
    ```
 
    If that fails change the value of the version field in `package.json` to the
    new version:
 
    ```diff
-   -  "version": "3.1.3",
-   +  "version": "3.1.4",
+   -  "version": "1.6.1",
+   +  "version": "1.6.2",
    ```
 
    And update the version number in `package-lock.json` using `npm install`
@@ -67,8 +67,8 @@ version (using `v3.1.4` as an example):
 
    ```diff
      * @module shescape
-   - * @version 3.1.3
-   + * @version 3.1.4
+   - * @version 1.6.1
+   + * @version 1.6.2
      * @license MPL-2.0
    ```
 
@@ -84,7 +84,7 @@ version (using `v3.1.4` as an example):
    ```md
    - _No changes yet_
 
-   ## [3.1.4] - YYYY-MM-DD
+   ## [1.6.2] - YYYY-MM-DD
    ```
 
    The date should follow the year-month-day format where single-digit months
@@ -114,16 +114,16 @@ version (using `v3.1.4` as an example):
 1. Create an annotated [git tag] for the new version:
 
    ```sh
-   git tag -a v3.1.4
+   git tag -a v1.6.2
    ```
 
    Set the annotation to the list of changes for the version from the changelog
-   (excluding references).
+   (excluding links).
 
 1. Push the tag:
 
    ```sh
-   git push origin v3.1.4
+   git push origin v1.6.2
    ```
 
    > **Note**: At this point, the continuous delivery automation may pick up and
@@ -136,9 +136,9 @@ version (using `v3.1.4` as an example):
    npm publish
    ```
 
-1. Create a [GitHub Release]. The release title should be "Release v3.1.4" and
+1. Create a [GitHub Release]. The release title should be "Release v1.6.2" and
    the release text should be the list of changes for the version from the
-   changelog (including reference).
+   changelog (including links).
 
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [github actions]: https://github.com/features/actions


### PR DESCRIPTION
Primarily adjust it so that it asks the releaser to create a release branch and release Pull Request, avoiding pushes to the `main` branch. Also some additional minor but related changes.