### PR TITLE
Use incremental mode for mutation testing in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -304,7 +304,8 @@ jobs:
           key: mutation-${{ github.run_number }}
           restore-keys: |
             mutation-
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+      - name: Determine if unit tests changed
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
         id: changes
         with:
           filters: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -297,12 +297,32 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
+      - name: Cache Stryker incremental report
+        uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        with:
+          path: _reports/mutation/stryker-incremental.json
+          key: mutation-${{ github.run_number }}
+          restore-keys: |
+            mutation-
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: changes
+        with:
+          filters: |
+            unit-tests:
+              - test/unit/**
+              - test/_*.{cjs,js}
       - name: Install dependencies
         run: npm ci
-      - name: Run mutation tests
+      - name: Run mutation tests (incremental)
+        if: ${{ steps.changes.outputs.unit-tests == 'false' }}
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        run: npm run test:mutation
+        run: npm run test:mutation -- --incremental
+      - name: Run mutation tests (non-incremental)
+        if: ${{ steps.changes.outputs.unit-tests == 'true' }}
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        run: npm run test:mutation -- --incremental --force
   test-property:
     name: Property
     runs-on: ubuntu-latest

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -6,6 +6,8 @@
   "commandRunner": {
     "command": "npm run test:unit"
   },
+  "incremental": false,
+  "incrementalFile": "_reports/mutation/stryker-incremental.json",
   "timeoutMS": 10000,
   "reporters": ["clear-text", "dashboard", "html", "progress"],
   "htmlReporter": {


### PR DESCRIPTION
Leverage [Stryker's incremental mode](https://stryker-mutator.io/blog/announcing-incremental-mode/#-incremental-mode) to improve the speed of the mutation testing check in the CI.

The speed up is substantial. Given no unit test is changed in a given Pull Request, the duration of the mutation tests in CI drops from [`16m 14s`](https://github.com/ericcornelissen/shescape/actions/runs/3183350563/jobs/5190475601) to [`0m 17s`](https://github.com/ericcornelissen/shescape/actions/runs/3183497538/jobs/5190799491), or about ~1.7% of the original runtime.

Note that by default incremental mode has been disabled because of poor support when using `commandRunner` (but the `--incremental` flag can still be used to enable it). In particular, changes to the unit tests won't be detected by Stryker. So, to avoid false results due to that by an inexperienced user, it's disabled by default. Experienced users are still free to use incremental mode during development.