### PR TITLE
Fix Codecov "unit" flag

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -20,45 +20,45 @@ flags:
   e2e-macos-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
   e2e-ubuntu-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
   e2e-windows-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
   integration-macos-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
       - index.cjs
   integration-ubuntu-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
       - index.cjs
   integration-windows-latest:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
       - index.cjs
   property:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
       - index.js
-  unittest:
+  unit:
     carryforward: true
     paths:
-      - src/**/*.js
+      - src/*.js
 
 ignore:
   - script/**/*

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -55,7 +55,7 @@ flags:
     paths:
       - src/**/*.js
       - index.js
-  unit:
+  unittest:
     carryforward: true
     paths:
       - src/**/*.js

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -395,7 +395,7 @@ jobs:
         if: ${{ always() }}
         with:
           file: ./_reports/coverage/unit/lcov.info
-          flags: unit
+          flags: unittest
   transpile:
     name: Transpile
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -395,7 +395,7 @@ jobs:
         if: ${{ always() }}
         with:
           file: ./_reports/coverage/unit/lcov.info
-          flags: unittest
+          flags: unit
   transpile:
     name: Transpile
     runs-on: ubuntu-latest


### PR DESCRIPTION
The ["unit" flag](https://github.com/ericcornelissen/shescape/blob/836689791c0b8c7c9537982d81841de614f4c66d/.github/codecov.yml#L58-L61) isn't working on Codecov - the Codecov webapp suggests the "upload is empty".

This Pull Request is an attempt to fix that.