### PR TITLE
Add npm scripts for auditing dependencies for vulnerabilities

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Audit npm dependencies
-        run: npm audit
+        run: npm run audit
   secrets:
     name: Secrets
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,8 @@ this file. Note that the file ignored by git.
 
 #### Auditing
 
-To scan for vulnerabilities in npm dependencies, simply run `npm audit`.
+To scan for vulnerabilities in all npm dependencies, use `npm run audit`. To
+scan only runtime npm dependencies, use `npm run audit:runtime`.
 
 #### Resetting
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "pretest:integration": "npm run transpile",
     "_coverage": "c8 --reporter=lcov --reporter=text",
     "_prettier": "prettier ./**/*.{cjs,js,json,md,yml} --ignore-path .gitignore",
+    "audit": "npm audit",
+    "audit:runtime": "npm audit --omit dev",
     "benchmark": "node test/bench/bench.js",
     "clean": "node script/clean.js",
     "coverage": "npm run coverage:unit",


### PR DESCRIPTION
- [x] Create script for auditing all dependencies.
- [x] Create script for auditing only runtime dependencies.
- [x] Use scripts where `npm audit` is currently directly called.