### PR TITLE
Set up auditing of latest released version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     name: Audit
     uses: ericcornelissen/shescape/.github/workflows/reusable-audit.yml@main
     with:
-      refs: '["main"]'
+      refs: '["main", "v1"]'
   fuzz:
     name: Fuzz
     uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,37 @@ jobs:
         run: npm run test
       - name: Transpile to CommonJS
         run: npm run transpile
+  git:
+    name: git
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    needs:
+      - check
+    permissions:
+      contents: write # To push a ref
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Get release version
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        id: major_version
+        with:
+          result-encoding: string
+          script: |
+            const ref = context.ref
+            const tag = ref.replace(/^refs\/tags\//, "")
+            const majorVersion = tag.split(".")[0]
+            return majorVersion
+      - name: Update major version branch
+        run: |
+          git push origin HEAD:${{ steps.major_version.outputs.result }}
   github:
     name: GitHub
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -41,8 +41,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci
-      - name: Audit npm dependencies
+      - name: Audit all npm dependencies
+        if: ${{ !startsWith(matrix.ref, 'v') }}
         run: npm run audit
+      - name: Audit production npm dependencies
+        if: ${{ startsWith(matrix.ref, 'v') }}
+        run: npm run audit:runtime
   secrets:
     name: Secrets
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #454

---

### Summary

Add monitoring of runtime dependencies in the latest released version of supported major versions.

#### TODO

- [x] CI job to keep `vX` branch up-to-date
- [x] Audit supported `vX` branches nightly (currently only `v1`)
- [x] Create `v0` and `v1` branch
- [x] Protect `vX` branches on GitHub