### PR TITLE
Create script to check runtime dependency versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -453,3 +453,5 @@ jobs:
         run: npm ci
       - name: Vet
         run: npm run vet
+      - name: Check runtime dependency versions
+        run: node script/check-runtime-deps.js

--- a/script/check-runtime-deps.js
+++ b/script/check-runtime-deps.js
@@ -1,0 +1,68 @@
+/**
+ * @overview Check if the version of runtime dependencies being depended upon
+ * match the minimum version of the supported versions.
+ * @license Unlicense
+ */
+
+import cp from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+function getInstalledVersion(dependency) {
+  const { stdout } = cp.spawnSync(
+    "npm",
+    [
+      "ls",
+      // Get a parsable output
+      "--json",
+      // Only look at direct dependencies
+      "--depth",
+      "0",
+      // The dependency to get
+      dependency,
+    ],
+    { encoding: "utf-8" }
+  );
+
+  const dependenciesInfo = JSON.parse(stdout);
+  const installedVersion = dependenciesInfo.dependencies[dependency].version;
+  return installedVersion;
+}
+
+const projectRoot = path.resolve(
+  path.dirname(url.fileURLToPath(new URL(import.meta.url))),
+  ".."
+);
+const manifestPath = path.resolve(projectRoot, "package.json");
+const rawManifest = fs.readFileSync(manifestPath, { encoding: "utf-8" });
+const manifest = JSON.parse(rawManifest);
+const runtimeDeps = manifest.dependencies;
+
+const violations = Object.entries(runtimeDeps)
+  .map(([dependency, versionRange]) => ({
+    dependency,
+    installedVersion: getInstalledVersion(dependency),
+    versionRange,
+  }))
+  .filter(
+    ({ installedVersion, versionRange }) =>
+      !versionRange.endsWith(installedVersion)
+  );
+
+if (violations.length > 0) {
+  violations.forEach(({ dependency, installedVersion, versionRange }) => {
+    console.log("Dependency:", dependency);
+    console.log("  supported:", versionRange);
+    console.log("  installed:", installedVersion);
+  });
+
+  console.log("");
+  console.log(
+    violations.length,
+    "violation(s) found.",
+    "Update either the version range or installed version of each violation."
+  );
+} else {
+  console.log("No problems detected");
+}


### PR DESCRIPTION
Relates to #482

---

### Summary

Create a script that, for each runtime dependency, checks that the installed version is the same as the minimum supported version. Having this guarantee on installed runtime dependencies guarantees that the library is actually compatible with the lowest version it claims to be compatible with.