### PR TITLE
Allow `sudo` for reusable-fuzz workflow

### DIFF
--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5
         with:
-          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443


### PR DESCRIPTION
Relates to #525
Fixes https://github.com/ericcornelissen/shescape/actions/runs/3433825413

---

### Summary

The workflow uses `sudo` to install Zsh for fuzzing, so `disable-sudo` can't be enabled.