### PR TITLE
Add `.tool-versions`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -156,19 +156,15 @@ jobs:
             sum.golang.org:443
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           cache: npm
           node-version-file: .nvmrc
-      - name: Install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: 1.17
       - name: Install dependencies
-        run: |
-          npm ci
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
+        run: npm ci
       - name: Lint JavaScript
         if: ${{ always() }}
         run: npm run lint:js

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+actionlint 1.6.22
+shellcheck 0.8.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,4 @@
+# Check out asdf at: https://asdf-vm.com/
+
 actionlint 1.6.22
 shellcheck 0.8.0


### PR DESCRIPTION
Relates to #583

---

### Summary

Create a `.tool-versions` file with currently untracked dependencies (that we want to track). This file is first a configuration format for [asdf], but is also human-readable and thus can be used to know and track what versions of dependencies _should_ be used.

[asdf]: https://asdf-vm.com/