### PR TITLE
Update Codecov coverage flags for integration and e2e tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,34 +19,34 @@ comment:
   require_head: yes
 
 flags:
-  e2e-macos-latest:
+  e2e-MacOS:
     carryforward: true
     paths:
       - src/*.js
       - index.js
-  e2e-ubuntu-latest:
+  e2e-Ubuntu:
     carryforward: true
     paths:
       - src/*.js
       - index.js
-  e2e-windows-latest:
+  e2e-Windows:
     carryforward: true
     paths:
       - src/*.js
       - index.js
-  integration-macos-latest:
-    carryforward: true
-    paths:
-      - src/*.js
-      - index.js
-      - index.cjs
-  integration-ubuntu-latest:
+  integration-MacOS:
     carryforward: true
     paths:
       - src/*.js
       - index.js
       - index.cjs
-  integration-windows-latest:
+  integration-Ubuntu:
+    carryforward: true
+    paths:
+      - src/*.js
+      - index.js
+      - index.cjs
+  integration-Windows:
     carryforward: true
     paths:
       - src/*.js

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -279,7 +279,7 @@ jobs:
         if: ${{ always() }}
         with:
           file: ./_reports/coverage/e2e/lcov.info
-          flags: e2e-${{ matrix.os }}
+          flags: e2e-${{ matrix.name }}
   test-integration:
     name: Integration (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -330,7 +330,7 @@ jobs:
         if: ${{ always() }}
         with:
           file: ./_reports/coverage/integration/lcov.info
-          flags: integration-${{ matrix.os }}
+          flags: integration-${{ matrix.name }}
   test-mutation:
     name: Mutation
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Followup to #576

---

Update the Codecov configuration and integration and e2e CI jobs to 1) fix the coverage reports for per-OS tests and 2) ensure coverage is maintained when the OS runner image is updated.