### PR TITLE
Bump ShellCheck from v0.8.0 to v0.9.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Check out asdf at: https://asdf-vm.com/
 
 actionlint 1.6.22
-shellcheck 0.8.0
+shellcheck 0.9.0


### PR DESCRIPTION
Relates to #583, #589

## Summary

Bump ShellCheck to the latest available stable version as of this commit.