### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,9 @@ jobs:
     name: npm
     runs-on: ubuntu-22.04
     if: ${{ needs.check.outputs.released == 'false' }}
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/shescape
     needs:
       - check
     steps:


### PR DESCRIPTION
Relates to #559

## Summary

Use an [environment for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) in order to limit the scope of the `NPM_TOKEN` secret from all workflows to workflows with the right environment.