### PR TITLE
Refactor `escapeArg` function signature (internal)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,7 @@ function escape(
 
   const argAsString = arg.toString();
   const escape = getEscapeFunction(shellName);
-  const escapedArg = escape(argAsString, interpolation, quoted);
+  const escapedArg = escape(argAsString, { interpolation, quoted });
   return escapedArg;
 }
 

--- a/src/unix.js
+++ b/src/unix.js
@@ -36,11 +36,12 @@ const binZsh = "zsh";
  * Escapes a shell argument for use in Bash(-like shells).
  *
  * @param {string} arg The argument to escape.
- * @param {boolean} interpolation Is interpolation enabled.
- * @param {boolean} quoted Is `arg` being quoted.
+ * @param {object} options The escape options.
+ * @param {boolean} options.interpolation Is interpolation enabled.
+ * @param {boolean} options.quoted Is `arg` being quoted.
  * @returns {string} The escaped argument.
  */
-function escapeArgBash(arg, interpolation, quoted) {
+function escapeArgBash(arg, { interpolation, quoted }) {
   let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
 
   if (interpolation) {
@@ -63,11 +64,12 @@ function escapeArgBash(arg, interpolation, quoted) {
  * Escapes a shell argument for use in Dash.
  *
  * @param {string} arg The argument to escape.
- * @param {boolean} interpolation Is interpolation enabled.
- * @param {boolean} quoted Is `arg` being quoted.
+ * @param {object} options The escape options.
+ * @param {boolean} options.interpolation Is interpolation enabled.
+ * @param {boolean} options.quoted Is `arg` being quoted.
  * @returns {string} The escaped argument.
  */
-function escapeArgDash(arg, interpolation, quoted) {
+function escapeArgDash(arg, { interpolation, quoted }) {
   let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
 
   if (interpolation) {
@@ -89,11 +91,12 @@ function escapeArgDash(arg, interpolation, quoted) {
  * Escapes a shell argument for use in Zsh.
  *
  * @param {string} arg The argument to escape.
- * @param {boolean} interpolation Is interpolation enabled.
- * @param {boolean} quoted Is `arg` being quoted.
+ * @param {object} options The escape options.
+ * @param {boolean} options.interpolation Is interpolation enabled.
+ * @param {boolean} options.quoted Is `arg` being quoted.
  * @returns {string} The escaped argument.
  */
-function escapeArgZsh(arg, interpolation, quoted) {
+function escapeArgZsh(arg, { interpolation, quoted }) {
   let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
 
   if (interpolation) {

--- a/src/win.js
+++ b/src/win.js
@@ -28,11 +28,12 @@ const binPowerShell = "powershell.exe";
  * Escapes a shell argument for use in Windows Command Prompt.
  *
  * @param {string} arg The argument to escape.
- * @param {boolean} interpolation Is interpolation enabled.
- * @param {boolean} quoted Is `arg` being quoted.
+ * @param {object} options The escape options.
+ * @param {boolean} options.interpolation Is interpolation enabled.
+ * @param {boolean} options.quoted Is `arg` being quoted.
  * @returns {string} The escaped argument.
  */
-function escapeArgCmd(arg, interpolation, quoted) {
+function escapeArgCmd(arg, { interpolation, quoted }) {
   let result = arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/\r?\n|\r/gu, " ");
@@ -50,11 +51,12 @@ function escapeArgCmd(arg, interpolation, quoted) {
  * Escapes a shell argument for use in Windows PowerShell.
  *
  * @param {string} arg The argument to escape.
- * @param {boolean} interpolation Is interpolation enabled.
- * @param {boolean} quoted Is `arg` being quoted.
+ * @param {object} options The escape options.
+ * @param {boolean} options.interpolation Is interpolation enabled.
+ * @param {boolean} options.quoted Is `arg` being quoted.
  * @returns {string} The escaped argument.
  */
-function escapeArgPowerShell(arg, interpolation, quoted) {
+function escapeArgPowerShell(arg, { interpolation, quoted }) {
   let result = arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/`/gu, "``")

--- a/test/bench/bench.js
+++ b/test/bench/bench.js
@@ -28,27 +28,27 @@ const suite = new Benchmark.Suite("escapeShellArg", {
 
 suite.add(`unix, ${binBash}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binBash);
-  escapeShellArg(sampleArg);
+  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
 });
 
 suite.add(`unix, ${binDash}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binDash);
-  escapeShellArg(sampleArg);
+  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
 });
 
 suite.add(`unix, ${binZsh}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binZsh);
-  escapeShellArg(sampleArg);
+  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
 });
 
 suite.add(`win, ${binCmd}, ${sampleArg}`, () => {
   const escapeShellArg = win.getEscapeFunction(binCmd);
-  escapeShellArg(sampleArg);
+  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
 });
 
 suite.add(`win, ${binPowerShell}, ${sampleArg}`, () => {
   const escapeShellArg = win.getEscapeFunction(binPowerShell);
-  escapeShellArg(sampleArg);
+  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
 });
 
 suite.run();

--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -24,7 +24,7 @@ import test from "ava";
 export const escape = test.macro({
   exec(t, { expected, input, interpolation, platform, quoted, shellName }) {
     const escapeFn = platform.getEscapeFunction(shellName);
-    const actual = escapeFn(input, interpolation, quoted);
+    const actual = escapeFn(input, { interpolation, quoted });
     t.is(actual, expected);
   },
   title(_, { input, interpolation, quoted, shellName }) {

--- a/test/unit/main/escape.test.js
+++ b/test/unit/main/escape.test.js
@@ -130,8 +130,7 @@ testProp(
     t.true(
       t.context.deps.escapeFunction.calledWithExactly(
         sinon.match.any,
-        false,
-        sinon.match.any
+        sinon.match({ interpolation: false })
       )
     );
   }
@@ -149,8 +148,7 @@ for (const interpolation of [undefined, true, false]) {
       t.true(
         t.context.deps.escapeFunction.calledWithExactly(
           sinon.match.any,
-          interpolation ? true : false,
-          sinon.match.any
+          sinon.match({ interpolation: interpolation ? true : false })
         )
       );
     }
@@ -169,8 +167,7 @@ for (const quoted of [undefined, true, false]) {
       t.true(
         t.context.deps.escapeFunction.calledWithExactly(
           sinon.match.any,
-          sinon.match.any,
-          false
+          sinon.match({ quoted: false })
         )
       );
     }

--- a/test/unit/main/quote.test.js
+++ b/test/unit/main/quote.test.js
@@ -153,8 +153,7 @@ testProp(
     t.true(
       t.context.deps.escapeFunction.calledWithExactly(
         sinon.match.any,
-        false,
-        sinon.match.any
+        sinon.match({ interpolation: false })
       )
     );
   }
@@ -170,8 +169,7 @@ testProp(
     t.true(
       t.context.deps.escapeFunction.calledWithExactly(
         sinon.match.any,
-        sinon.match.any,
-        true
+        sinon.match({ quoted: true })
       )
     );
   }

--- a/test/unit/unix/escape.test.js
+++ b/test/unit/unix/escape.test.js
@@ -50,19 +50,19 @@ Object.entries(fixtures.escape).forEach(([shellName, scenarios]) => {
 fixtures.redos().forEach((s, i) => {
   test(`bash, ReDoS #${i}`, (t) => {
     const escape = unix.getEscapeFunction("bash");
-    escape(s, true, false);
+    escape(s, { interpolation: true, quoted: false });
     t.pass();
   });
 
   test(`dash, ReDoS #${i}`, (t) => {
     const escape = unix.getEscapeFunction("dash");
-    escape(s, true, false);
+    escape(s, { interpolation: true, quoted: false });
     t.pass();
   });
 
   test(`zsh, ReDoS #${i}`, (t) => {
     const escape = unix.getEscapeFunction("zsh");
-    escape(s, true, false);
+    escape(s, { interpolation: true, quoted: false });
     t.pass();
   });
 });


### PR DESCRIPTION
Relates to #346, #452

## Summary

Combine the `interpolation` and `quoted` arguments into an `options` argument to make options more explicit and make adding more options more maintainable by avoiding many positional boolean arguments which may be confused with one-another.