### PR TITLE
Update tooling nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,43 @@ on:
 permissions: read-all
 
 jobs:
+  tooling:
+    name: Tool update ${{ matrix.tool }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - actionlint
+          - shellcheck
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Get latest version
+        id: version
+        run: |
+          LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
+          echo "latest=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Install new version
+        run: |
+          asdf install '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
+      - name: Apply latest version to .tool-versions
+        run: |
+          asdf local '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
+        with:
+          title: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
+          branch: asdf-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
+          labels: dependencies
+          commit-message: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
+          add-paths: |
+            .tool-versions
   audit:
     name: Audit
     uses: ericcornelissen/shescape/.github/workflows/reusable-audit.yml@main


### PR DESCRIPTION
Relates to #583

## Summary

Add a new job to the nightly workflow to try and update [tooling](https://github.com/ericcornelissen/shescape/blob/3aa3bfadfdd4ed76230350535d3c97fc2b0b0cea/.tool-versions) to the latest available version and open a Pull Request if there are any changes.