### PR TITLE
Make fuzzing with default shell explicit

### DIFF
--- a/.github/workflows/fuzz-matrix.js
+++ b/.github/workflows/fuzz-matrix.js
@@ -12,19 +12,19 @@ const systemShell = "";
 const unixShells = [systemShell, "/bin/bash", "/bin/dash", "/bin/zsh"];
 const winShells = [systemShell, "cmd.exe", "powershell.exe"];
 
-const targets = ["exec", "exec-file", "fork", "spawn"];
+const targets = ["exec", "exec-file", "spawn"];
 
 export function determineMatrix({ unix, windows }) {
   return [
     ...(unix
       ? unixShells.flatMap((shell) =>
           targets.map((target) => ({ os: unixOS, shell, target }))
-        )
+        ).concat([{ os: unixOS, shell: systemShell, target: "fork" }])
       : []),
     ...(windows
       ? winShells.flatMap((shell) =>
           targets.map((target) => ({ os: winOS, shell, target }))
-        )
+        ).concat([{ os: winOS, shell: systemShell, target: "fork" }])
       : []),
   ];
 }

--- a/.github/workflows/fuzz-matrix.js
+++ b/.github/workflows/fuzz-matrix.js
@@ -6,8 +6,11 @@
 const unixOS = "ubuntu-22.04";
 const winOS = "windows-2022";
 
-const unixShells = ["/bin/bash", "/bin/dash", "/bin/zsh"];
-const winShells = ["cmd.exe", "powershell.exe"];
+// As a falsy value, the empty string will result in the system shell being used
+const systemShell = "";
+
+const unixShells = [systemShell, "/bin/bash", "/bin/dash", "/bin/zsh"];
+const winShells = [systemShell, "cmd.exe", "powershell.exe"];
 
 const targets = ["exec", "exec-file", "fork", "spawn"];
 

--- a/.github/workflows/fuzz-matrix.js
+++ b/.github/workflows/fuzz-matrix.js
@@ -17,14 +17,18 @@ const targets = ["exec", "exec-file", "spawn"];
 export function determineMatrix({ unix, windows }) {
   return [
     ...(unix
-      ? unixShells.flatMap((shell) =>
-          targets.map((target) => ({ os: unixOS, shell, target }))
-        ).concat([{ os: unixOS, shell: systemShell, target: "fork" }])
+      ? unixShells
+          .flatMap((shell) =>
+            targets.map((target) => ({ os: unixOS, shell, target }))
+          )
+          .concat([{ os: unixOS, shell: systemShell, target: "fork" }])
       : []),
     ...(windows
-      ? winShells.flatMap((shell) =>
-          targets.map((target) => ({ os: winOS, shell, target }))
-        ).concat([{ os: winOS, shell: systemShell, target: "fork" }])
+      ? winShells
+          .flatMap((shell) =>
+            targets.map((target) => ({ os: winOS, shell, target }))
+          )
+          .concat([{ os: winOS, shell: systemShell, target: "fork" }])
       : []),
   ];
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,9 @@ with the `FUZZ_SHELL` environment variable. The easiest way to change this is
 with a `.env` file containing, for example:
 
 ```ini
+# Default system shell examples
+FUZZ_SHELL=
+
 # Unix example
 FUZZ_SHELL=/bin/sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,7 +322,7 @@ with the `FUZZ_SHELL` environment variable. The easiest way to change this is
 with a `.env` file containing, for example:
 
 ```ini
-# Default system shell examples
+# Default system shell example
 FUZZ_SHELL=
 
 # Unix example

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -94,7 +94,7 @@ function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
  * @returns {string | undefined} The configured shell name, or `undefined`.
  */
 function getFuzzShell() {
-  return process.env.FUZZ_SHELL;
+  return process.env.FUZZ_SHELL || undefined;
 }
 
 /**

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -34,7 +34,7 @@ function check(arg) {
 function checkMultipleArgs(args) {
   const shell = common.getFuzzShell();
   const argInfo = { shell, quoted: Boolean(shell) };
-  const execFileOptions = { shell };
+  const execFileOptions = { encoding: "utf8", shell };
 
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
@@ -54,7 +54,7 @@ function checkMultipleArgs(args) {
     execFileOptions
   );
 
-  const result = stdout.toString();
+  const result = stdout;
   const expected = common.getExpectedOutput({
     ...argInfo,
     arg: (common.isShellPowerShell(shell)

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -11,33 +11,18 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function checkWithoutShell(arg) {
-  const argInfo = { arg, shell: undefined, quoted: false };
-  const execFileOptions = { encoding: "utf8" };
-
-  const preparedArg = common.prepareArg(argInfo, true);
-
-  const stdout = execFileSync(
-    "node",
-    shescape.escapeAll([common.ECHO_SCRIPT, preparedArg]),
-    execFileOptions
-  );
-
-  const result = stdout;
-  const expected = common.getExpectedOutput(argInfo);
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShell(arg) {
-  const shell = common.getFuzzShell() || true;
-  const argInfo = { arg, shell, quoted: true };
+function check(arg) {
+  const shell = common.getFuzzShell();
+  const argInfo = { arg, shell, quoted: Boolean(shell) };
   const execFileOptions = { encoding: "utf8", shell };
 
   const preparedArg = common.prepareArg(argInfo);
 
   const stdout = execFileSync(
     "node",
-    shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], execFileOptions),
+    execFileOptions.shell
+      ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], execFileOptions)
+      : shescape.escapeAll([common.ECHO_SCRIPT, preparedArg], execFileOptions),
     execFileOptions
   );
 
@@ -46,38 +31,26 @@ function checkWithShell(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkWithoutShellMultipleArgs(args) {
-  const argInfo = { shell: undefined, quoted: false };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, true)
-  );
-
-  const stdout = execFileSync(
-    "node",
-    shescape.escapeAll([common.ECHO_SCRIPT, ...preparedArgs])
-  );
-
-  const result = stdout.toString();
-  const expected = common.getExpectedOutput({
-    ...argInfo,
-    arg: args.join(" "),
-  });
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShellMultipleArgs(args) {
-  const shell = common.getFuzzShell() || true;
-  const argInfo = { shell, quoted: true };
+function checkMultipleArgs(args) {
+  const shell = common.getFuzzShell();
+  const argInfo = { shell, quoted: Boolean(shell) };
   const execFileOptions = { shell };
 
   const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, false)
+    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
   );
 
   const stdout = execFileSync(
     "node",
-    shescape.quoteAll([common.ECHO_SCRIPT, ...preparedArgs], execFileOptions),
+    execFileOptions.shell
+      ? shescape.quoteAll(
+          [common.ECHO_SCRIPT, ...preparedArgs],
+          execFileOptions
+        )
+      : shescape.escapeAll(
+          [common.ECHO_SCRIPT, ...preparedArgs],
+          execFileOptions
+        ),
     execFileOptions
   );
 
@@ -98,10 +71,8 @@ function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
-  checkWithoutShell(arg);
-  checkWithoutShellMultipleArgs(args);
-  checkWithShell(arg);
-  checkWithShellMultipleArgs(args);
+  check(arg);
+  checkMultipleArgs(args);
 }
 
 module.exports = {

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -16,7 +16,7 @@ function check(arg) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const execFileOptions = { encoding: "utf8", shell };
 
-  const preparedArg = common.prepareArg(argInfo);
+  const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
 
   const stdout = execFileSync(
     "node",

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -11,30 +11,15 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function checkWithoutShell(arg) {
-  const argInfo = { arg, shell: undefined, quoted: true };
-  const execOptions = { encoding: "utf8" };
-
-  const preparedArg = common.prepareArg(argInfo);
-  const quotedArg = shescape.quote(preparedArg);
-
-  const stdout = execSync(
-    `node ${common.ECHO_SCRIPT} ${quotedArg}`,
-    execOptions
-  );
-
-  const result = stdout;
-  const expected = common.getExpectedOutput(argInfo);
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShell(arg) {
-  const shell = common.getFuzzShell() || true;
+function check(arg) {
+  const shell = common.getFuzzShell();
   const argInfo = { arg, shell, quoted: true };
   const execOptions = { encoding: "utf8", shell };
 
   const preparedArg = common.prepareArg(argInfo);
-  const quotedArg = shescape.quote(preparedArg, execOptions);
+  const quotedArg = shescape.quote(preparedArg, {
+    ...execOptions,
+  });
 
   const stdout = execSync(
     `node ${common.ECHO_SCRIPT} ${quotedArg}`,
@@ -46,27 +31,8 @@ function checkWithShell(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkWithoutShellUsingInterpolation(arg) {
-  const argInfo = { arg, shell: undefined, quoted: false };
-  const execOptions = { encoding: "utf8" };
-
-  const preparedArg = common.prepareArg(argInfo);
-  const escapedArg = shescape.escape(preparedArg, {
-    interpolation: true,
-  });
-
-  const stdout = execSync(
-    `node ${common.ECHO_SCRIPT} ${escapedArg}`,
-    execOptions
-  );
-
-  const result = stdout;
-  const expected = common.getExpectedOutput(argInfo, true);
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShellUsingInterpolation(arg) {
-  const shell = common.getFuzzShell() || true;
+function checkUsingInterpolation(arg) {
+  const shell = common.getFuzzShell();
   const argInfo = { arg, shell, quoted: false };
   const execOptions = { encoding: "utf8", shell };
 
@@ -89,10 +55,8 @@ function checkWithShellUsingInterpolation(arg) {
 function fuzz(buf) {
   const arg = buf.toString();
 
-  checkWithoutShell(arg);
-  checkWithShell(arg);
-  checkWithoutShellUsingInterpolation(arg);
-  checkWithShellUsingInterpolation(arg);
+  check(arg);
+  checkUsingInterpolation(arg);
 }
 
 module.exports = {

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -12,7 +12,7 @@ const common = require("./_common.cjs");
 const shescape = require("../../index.cjs");
 
 function check(arg) {
-  const argInfo = { arg, shell: undefined, quoted: false };
+  const argInfo = { arg, quoted: false };
   const forkOptions = { silent: true };
 
   const preparedArg = common.prepareArg(argInfo, true);
@@ -38,7 +38,7 @@ function check(arg) {
 }
 
 function checkMultipleArgs(args) {
-  const argInfo = { shell: undefined, quoted: false };
+  const argInfo = { quoted: false };
 
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, true)

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -39,15 +39,18 @@ function check(arg) {
 
 function checkMultipleArgs(args) {
   const argInfo = { quoted: false };
+  const forkOptions = { silent: true };
 
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, true)
   );
 
   return new Promise((resolve, reject) => {
-    const echo = fork(common.ECHO_SCRIPT, shescape.escapeAll(preparedArgs), {
-      silent: true,
-    });
+    const echo = fork(
+      common.ECHO_SCRIPT,
+      shescape.escapeAll(preparedArgs),
+      forkOptions
+    );
 
     echo.stdout.on("data", (data) => {
       const result = data.toString();

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -16,7 +16,7 @@ function check(arg) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
-  const preparedArg = common.prepareArg(argInfo);
+  const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
 
   const child = spawnSync(
     "node",

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -11,33 +11,18 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function checkWithoutShell(arg) {
-  const argInfo = { arg, shell: undefined, quoted: false };
-  const spawnOptions = { encoding: "utf8" };
-
-  const preparedArg = common.prepareArg(argInfo, true);
-
-  const child = spawnSync(
-    "node",
-    shescape.escapeAll([common.ECHO_SCRIPT, preparedArg]),
-    spawnOptions
-  );
-
-  const result = child.stdout;
-  const expected = common.getExpectedOutput(argInfo);
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShell(arg) {
-  const shell = common.getFuzzShell() || true;
-  const argInfo = { arg, shell, quoted: true };
+function check(arg) {
+  const shell = common.getFuzzShell();
+  const argInfo = { arg, shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
   const preparedArg = common.prepareArg(argInfo);
 
   const child = spawnSync(
     "node",
-    shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], spawnOptions),
+    spawnOptions.shell
+      ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], spawnOptions)
+      : shescape.escapeAll([common.ECHO_SCRIPT, preparedArg], spawnOptions),
     spawnOptions
   );
 
@@ -46,38 +31,20 @@ function checkWithShell(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkWithoutShellMultipleArgs(args) {
-  const argInfo = { shell: undefined, quoted: false };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, true)
-  );
-
-  const child = spawnSync(
-    "node",
-    shescape.escapeAll([common.ECHO_SCRIPT, ...preparedArgs])
-  );
-
-  const result = child.stdout.toString();
-  const expected = common.getExpectedOutput({
-    ...argInfo,
-    arg: args.join(" "),
-  });
-  assert.strictEqual(result, expected);
-}
-
-function checkWithShellMultipleArgs(args) {
-  const shell = common.getFuzzShell() || true;
-  const argInfo = { shell, quoted: true };
+function checkMultipleArgs(args) {
+  const shell = common.getFuzzShell();
+  const argInfo = { shell, quoted: Boolean(shell) };
   const spawnOptions = { shell };
 
   const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, false)
+    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
   );
 
   const child = spawnSync(
     "node",
-    shescape.quoteAll([common.ECHO_SCRIPT, ...preparedArgs], spawnOptions),
+    spawnOptions.shell
+      ? shescape.quoteAll([common.ECHO_SCRIPT, ...preparedArgs], spawnOptions)
+      : shescape.escapeAll([common.ECHO_SCRIPT, ...preparedArgs], spawnOptions),
     spawnOptions
   );
 
@@ -98,10 +65,8 @@ function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
-  checkWithoutShell(arg);
-  checkWithShell(arg);
-  checkWithoutShellMultipleArgs(args);
-  checkWithShellMultipleArgs(args);
+  check(arg);
+  checkMultipleArgs(args);
 }
 
 module.exports = {

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -34,7 +34,7 @@ function check(arg) {
 function checkMultipleArgs(args) {
   const shell = common.getFuzzShell();
   const argInfo = { shell, quoted: Boolean(shell) };
-  const spawnOptions = { shell };
+  const spawnOptions = { encoding: "utf8", shell };
 
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
@@ -48,7 +48,7 @@ function checkMultipleArgs(args) {
     spawnOptions
   );
 
-  const result = child.stdout.toString();
+  const result = child.stdout;
   const expected = common.getExpectedOutput({
     ...argInfo,
     arg: (common.isShellPowerShell(shell)


### PR DESCRIPTION
## Summary

Update the fuzz targets so that fuzzing with the default/system shell is explicit - that is to fuzz is to use either a specific shell or the system shell. This is in contrast to the current situation where the system shell is tested regardless of any configured shell.