### PR TITLE
Update and align newline replacements

### DIFF
--- a/src/unix.js
+++ b/src/unix.js
@@ -42,12 +42,14 @@ const binZsh = "zsh";
  * @returns {string} The escaped argument.
  */
 function escapeArgBash(arg, { interpolation, quoted }) {
-  let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
+  let result = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "");
 
   if (interpolation) {
     result = result
       .replace(/\\/gu, "\\\\")
-      .replace(/\n/gu, " ")
+      .replace(/\r?\n/gu, " ")
       .replace(/(^|\s)([#~])/gu, "$1\\$2")
       .replace(/(["$&'()*;<>?`{|])/gu, "\\$1")
       .replace(/(?<=[:=])(~)(?=[\s+\-/0:=]|$)/gu, "\\$1")
@@ -55,8 +57,6 @@ function escapeArgBash(arg, { interpolation, quoted }) {
   } else if (quoted) {
     result = result.replace(/'/gu, `'\\''`);
   }
-
-  result = result.replace(/\r(?!\n)/gu, "");
 
   return result;
 }
@@ -71,20 +71,20 @@ function escapeArgBash(arg, { interpolation, quoted }) {
  * @returns {string} The escaped argument.
  */
 function escapeArgDash(arg, { interpolation, quoted }) {
-  let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
+  let result = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "");
 
   if (interpolation) {
     result = result
       .replace(/\\/gu, "\\\\")
-      .replace(/\n/gu, " ")
+      .replace(/\r?\n/gu, " ")
       .replace(/(^|\s)([#~])/gu, "$1\\$2")
       .replace(/(["$&'()*;<>?`|])/gu, "\\$1")
       .replace(/([\t\n ])/gu, "\\$1");
   } else if (quoted) {
     result = result.replace(/'/gu, `'\\''`);
   }
-
-  result = result.replace(/\r(?!\n)/gu, "");
 
   return result;
 }
@@ -99,20 +99,20 @@ function escapeArgDash(arg, { interpolation, quoted }) {
  * @returns {string} The escaped argument.
  */
 function escapeArgZsh(arg, { interpolation, quoted }) {
-  let result = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
+  let result = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "");
 
   if (interpolation) {
     result = result
       .replace(/\\/gu, "\\\\")
-      .replace(/\n/gu, " ")
+      .replace(/\r?\n/gu, " ")
       .replace(/(^|\s)([#=~])/gu, "$1\\$2")
       .replace(/(["$&'()*;<>?[\]`{|}])/gu, "\\$1")
       .replace(/([\t ])/gu, "\\$1");
   } else if (quoted) {
     result = result.replace(/'/gu, `'\\''`);
   }
-
-  result = result.replace(/\r(?!\n)/gu, "");
 
   return result;
 }

--- a/src/win.js
+++ b/src/win.js
@@ -65,7 +65,7 @@ function escapeArgPowerShell(arg, { interpolation, quoted }) {
 
   if (interpolation) {
     result = result
-      .replace(/\r?\n|\r/gu, " ")
+      .replace(/\r?\n/gu, " ")
       .replace(/(^|[\s\u0085])([*1-6]?)(>)/gu, "$1$2`$3")
       .replace(/(^|[\s\u0085])([#\-:<@\]])/gu, "$1`$2")
       .replace(/(["&'(),;{|}‘’‚‛“”„])/gu, "`$1")

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -64,7 +64,7 @@ function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
   if (normalizeWhitespace) {
     // Replace newline characters, like Shescape
     if (!isShellCmd(shell)) {
-      arg = arg.replace(/\r?\n|\r/gu, " ");
+      arg = arg.replace(/\r?\n/gu, " ");
     }
 
     // Convert whitespace between arguments, like the shell


### PR DESCRIPTION
## Summary

Update escaping for Bash, Dash, PowerShell, and Zsh to make it easier to understand how newlines (`\n` and `\r`) are escaped.
