### PR TITLE
Set maximum number of fuzz jobs

### DIFF
--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -38,6 +38,7 @@ jobs:
       - determine-matrix
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include: ${{ fromJSON(needs.determine-matrix.outputs.jobs) }}
     steps:


### PR DESCRIPTION
## Summary

Reduce the maximum number of active fuzz job to avoid all CI resources being consumed for fuzzing purposes.

Note: due to the usage of re-usable workflows this does not have an effect on the jobs created for pushing 91c1322289ca0348cbca4da986d4902190c3065f

Relevant docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel