### PR TITLE
Reduce tooling update flakiness

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,22 +38,26 @@ jobs:
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Get latest version
-        id: version
-        run: |
-          LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
-          echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 1
+          command: |
+            LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
+            echo "latest=${LATEST_VERSION}" >> "$GITHUB_ENV"
       - name: Install new version
         run: |
-          asdf install '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
+          asdf install '${{ matrix.tool }}' '${{ env.latest }}'
       - name: Apply latest version to .tool-versions
         run: |
-          asdf local '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
+          asdf local '${{ matrix.tool }}' '${{ env.latest }}'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
         with:
-          title: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
-          branch: asdf-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
+          title: Update ${{ matrix.tool }} to ${{ env.latest }}
+          branch: asdf-${{ matrix.tool }}-${{ env.latest }}
           labels: dependencies
-          commit-message: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
+          commit-message: Update ${{ matrix.tool }} to ${{ env.latest }}
           add-paths: |
             .tool-versions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,11 +41,12 @@ jobs:
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
           max_attempts: 3
-          retry_on: error
+          retry_wait_seconds: 30
           timeout_minutes: 1
-          command: |
+          command: >-
             LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
-            echo "latest=${LATEST_VERSION}" >> "$GITHUB_ENV"
+            &&
+            echo "latest=$LATEST_VERSION" >> "$GITHUB_ENV"
       - name: Install new version
         run: |
           asdf install '${{ matrix.tool }}' '${{ env.latest }}'


### PR DESCRIPTION
Relates to #613

## Summary

Update the nightly workflow's tooling update job to automatically retry the flaky step of getting the latest available version of the tool using [`nick-fields/retry`]. Since the duration of this job doesn't matter much, and to be on the safe side, a timeout of 1 minute is configured to increase the probability of success.

Since the outputs of `nick-fields/retry` are restricted, the latest version is now stored as an environment variable.

[`nick-fields/retry`]: https://github.com/nick-fields/retry