### PR TITLE
Enable verbose logging when linting in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Check formatting
-        run: npm run format:check
+        run: npm run format:check -- --loglevel debug
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04
@@ -167,13 +167,13 @@ jobs:
         run: npm clean-install
       - name: Lint CI
         if: ${{ failure() || success() }}
-        run: npm run lint:ci
+        run: npm run lint:ci -- -verbose
       - name: Lint JavaScript
         if: ${{ failure() || success() }}
-        run: npm run lint:js
+        run: npm run lint:js -- --debug
       - name: Lint JSON
         if: ${{ failure() || success() }}
-        run: npm run lint:json
+        run: npm run lint:json -- --debug
       - name: Lint MarkDown
         if: ${{ failure() || success() }}
         run: npm run lint:md
@@ -182,7 +182,7 @@ jobs:
         run: npm run lint:sh
       - name: Lint YAML
         if: ${{ failure() || success() }}
-        run: npm run lint:yml
+        run: npm run lint:yml -- --debug
   test-compatibility:
     name: Compatibility
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

To get some insight into what is being linted so this can be checked without having to run things locally.

As far as I was able to tell neither `markdownlint-cli` (`lint:md`) nor `shellcheck` (`lint:sh`) offer a verbose/debug mode.