### PR TITLE
Enable (some) optional ShellCheck checks

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,6 +1,8 @@
 # Check out ShellCheck at: https://www.shellcheck.net/
 
-disable=SC1090,SC1091,SC2155
+disable=SC1090
+disable=SC1091
+disable=SC2155
 
 enable=avoid-nullary-conditions
 enable=deprecate-which

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,8 @@
 # Check out ShellCheck at: https://www.shellcheck.net/
 
 disable=SC1090,SC1091,SC2155
+
+enable=avoid-nullary-conditions
+enable=deprecate-which
+enable=quote-safe-variables
+enable=require-variable-braces

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -2,17 +2,17 @@
 
 get_stash_count () {
   readonly count="$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)"
-  if [ "$count" = "" ]; then
+  if [ "${count}" = "" ]; then
     echo "0"
   else
-    echo "$count"
+    echo "${count}"
   fi
 }
 
 STASH_COUNT_BEFORE="$(get_stash_count)"
 DID_STASH () {
   readonly STASH_COUNT_AFTER="$(get_stash_count)"
-  if [ "$STASH_COUNT_BEFORE" != "$STASH_COUNT_AFTER" ]; then
+  if [ "${STASH_COUNT_BEFORE}" != "${STASH_COUNT_AFTER}" ]; then
     echo "x"  # true
   else
     echo ""  # false

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,7 +3,7 @@
 . "$(dirname "$0")/common.sh"
 
 # Pre
-if [ ! "$(IS_MERGING)" ]; then
+if [ -z "$(IS_MERGING)" ]; then
   git stash push --quiet --include-untracked --keep-index
 fi
 
@@ -27,6 +27,6 @@ if command -v shellcheck > /dev/null; then
 fi
 
 # Post
-if [ "$(DID_STASH)" ]; then
+if [ -n "$(DID_STASH)" ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -3,7 +3,7 @@
 . "$(dirname "$0")/common.sh"
 
 # Pre
-if [ ! "$(IS_MERGING)" ]; then
+if [ -z "$(IS_MERGING)" ]; then
   git stash push --quiet --include-untracked
 fi
 
@@ -27,6 +27,6 @@ if command -v shellcheck > /dev/null; then
 fi
 
 # Post
-if [ "$(DID_STASH)" ]; then
+if [ -n "$(DID_STASH)" ]; then
   git stash pop --quiet --index
 fi


### PR DESCRIPTION
Relates to #392

## Summary

Update the `.shellcheckrc` configuration to enable some "optional" checks that seem to have obvious benefits. Other "optional" checks may be enabled in the future.