### PR TITLE
Consistently use "library" and "package"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,11 +16,11 @@ labels: bug
 
 ### Actual Behaviour
 
-<!-- Describe the actual behaviour of the package you're observing -->
+<!-- Describe the actual behaviour of the library you're observing -->
 
 ### Expected Behaviour
 
-<!-- Describe the behaviour you would have expected from the package -->
+<!-- Describe the behaviour you would have expected from the library -->
 
 ## Working Example
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For security related issues, please refer to the [security policy].
 
 ### Bug Reports
 
-If you have problems with the package or think you've found a bug, please report
+If you have problems with the library or think you've found a bug, please report
 it to the developers. We ask you to always open an issue describing the bug as
 soon as possible so that we, and others, are aware of the bug.
 
@@ -60,7 +60,7 @@ Once you have a precise problem you can report it as a [bug report].
 
 ### Feature Requests
 
-The scope of the package is intentionally limited. Please avoid implementing a
+The scope of the library is intentionally limited. Please avoid implementing a
 new feature before submitting an issue for it first. To request a feature, make
 sure you have a clear idea what you need and why. Also, make sure the feature
 has not already been requested.
@@ -288,7 +288,7 @@ the e2e tests using the command `npm run test:e2e`.
 
 ### Compatibility Testing
 
-The compatibility tests aim to test that the library as backwards compatible
+The compatibility tests aim to test that the library is backwards compatible
 with older versions of Node.js. All compatibility test suites go into the
 `test/compat` folder.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Mutation Report][mutation-image]][mutation-url]
 [![npm Package][npm-image]][npm-url]
 
-A simple shell escape package for JavaScript. Use it to escape user-controlled
+A simple shell escape library for JavaScript. Use it to escape user-controlled
 inputs to shell commands to prevent [shell injection].
 
 **Quick links**:

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 /**
- * A simple shell escape package. Use it to escape user-controlled inputs to
+ * A simple shell escape library. Use it to escape user-controlled inputs to
  * shell commands to prevent shell injection.
  *
- * @overview Entrypoint for the package.
+ * @overview Entrypoint for the library.
  * @module shescape
  * @version 1.6.2
  * @license MPL-2.0


### PR DESCRIPTION
## Summary

Update usage of the words "library" and "package" to be more consistent. The idea is that when talking about the code/API we're talking about the "library" and when we're talking about the thing that's published to npm it's a "package" (since it's the "Node _Package_ Manager").