### PR TITLE
Make the "Shells" section more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ inputs to shell commands to prevent [shell injection].
 - Lightweight
 - Supports MacOS, Linux, and Windows
 
+### Shells
+
+The following shells are officially supported and extensively tested. It is
+recommended to only use shells found in this list.
+
+- **Unix**: [Bash], [Dash], [Zsh]
+- **Windows**: [cmd.exe], [PowerShell]
+
+If you want to use Shescape with another shell you can request it on GitHub by
+opening [an issue].
+
 ## Usage
 
 ### Install
@@ -46,17 +57,6 @@ View the [recipes] for examples of how to use Shescape.
 ### API
 
 View the [API] documentation of Shescape.
-
-## Shells
-
-The following shells are officially supported and extensively tested. It is
-recommended to only use shells found in this list.
-
-- **Unix**: [Bash], [Dash], [Zsh]
-- **Windows**: [cmd.exe], [PowerShell]
-
-If you want to use Shescape with another shell you can request it on GitHub by
-opening [an issue].
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary

Move "Shells" back up in the documentation (it was moved down in cf1f7e3cf4f2ebf054fcaa642fa9a0fa43f7fcc2, though it's always been after "Usage"). The intent is to make it more prominent as it's pretty important to use a supported Shell. Move it under Features as the shells that are supported are features.
