### PR TITLE
Update nightly tooling update workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,12 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Create token to create Pull Request
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        id: release-token
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Get latest version
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
@@ -65,7 +71,14 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
         with:
-          title: Update ${{ matrix.tool }} to ${{ env.latest }}
+          token: ${{ steps.release-token.outputs.token }}
+          title: Update ${{ matrix.tool }} to v${{ env.latest }}
+          body: |
+            _This Pull Request was created automatically_
+
+            ---
+
+            Bump ${{ matrix.tool }} to v${{ env.latest }}
           branch: asdf-${{ matrix.tool }}-${{ env.latest }}
           labels: dependencies
           commit-message: Update ${{ matrix.tool }} to ${{ env.latest }}


### PR DESCRIPTION
Relates to #667

## Summary

- Use GitHub Application token to enable CI on tooling update Pull Requests.
- Add explicit Pull Request body. The default isn't empty but instead links to the Action used to create the Pull Request. Since this isn't helpful to the reader, we'll just mention the Pull Request was created automatically (similar to release Pull Requests) and what it changes.