### PR TITLE
Fix allowed endpoints for "Publish / GitHub" job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
       - name: Create GitHub release
         uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0


### PR DESCRIPTION
Relates to #645, #671

## Summary

Fix for the failure in https://github.com/ericcornelissen/shescape/actions/runs/3975149410