### PR TITLE
Bump transitive dependency simple-git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9897,9 +9897,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",


### PR DESCRIPTION
## Summary

Update simple-git from 3.15.1 to 3.16.0 following a `npm audit` warning for <3.16.0 for CVE-2022-25860.

See also [the nightly run of Jan 27, 2023](https://github.com/ericcornelissen/shescape/actions/runs/4021189573).