### PR TITLE
Refactor `unix.js` and `win.js`

### DIFF
--- a/src/unix.js
+++ b/src/unix.js
@@ -207,7 +207,7 @@ export function getDefaultShell() {
  * Returns a function to escape arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Unix shell.
- * @returns {Function?} A function to escape arguments for use in the shell.
+ * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
@@ -219,8 +219,6 @@ export function getEscapeFunction(shellName) {
       return escapeArgDash;
     case binZsh:
       return escapeArgZsh;
-    default:
-      return null;
   }
 }
 
@@ -228,7 +226,7 @@ export function getEscapeFunction(shellName) {
  * Returns a function to quote arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Unix shell.
- * @returns {Function?} A function to quote arguments for use in the shell.
+ * @returns {Function | undefined} A function to quote arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
@@ -237,8 +235,6 @@ export function getQuoteFunction(shellName) {
     case binDash:
     case binZsh:
       return quoteArg;
-    default:
-      return null;
   }
 }
 
@@ -258,7 +254,7 @@ export function getShellName({ shell }, { resolveExecutable }) {
   );
 
   const shellName = getBasename(shell);
-  if (getEscapeFunction(shellName) === null) {
+  if (getEscapeFunction(shellName) === undefined) {
     return binBash;
   }
 

--- a/src/win.js
+++ b/src/win.js
@@ -120,7 +120,7 @@ export function getDefaultShell({ env: { ComSpec } }) {
  * Returns a function to escape arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Windows shell.
- * @returns {Function?} A function to escape arguments for use in the shell.
+ * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
@@ -128,8 +128,6 @@ export function getEscapeFunction(shellName) {
       return escapeArgCmd;
     case binPowerShell:
       return escapeArgPowerShell;
-    default:
-      return null;
   }
 }
 
@@ -137,15 +135,13 @@ export function getEscapeFunction(shellName) {
  * Returns a function to quote arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Windows shell.
- * @returns {Function?} A function to quote arguments for use in the shell.
+ * @returns {Function | undefined} A function to quote arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
     case binCmd:
     case binPowerShell:
       return quoteArg;
-    default:
-      return null;
   }
 }
 
@@ -165,7 +161,7 @@ export function getShellName({ shell }, { resolveExecutable }) {
   );
 
   const shellName = getBasename(shell);
-  if (getEscapeFunction(shellName) === null) {
+  if (getEscapeFunction(shellName) === undefined) {
     return binCmd;
   }
 

--- a/test/unit/unix/escape.test.js
+++ b/test/unit/unix/escape.test.js
@@ -62,6 +62,6 @@ testProp(
   [arbitrary.unsupportedUnixShell()],
   (t, shellName) => {
     const result = unix.getEscapeFunction(shellName);
-    t.is(result, null);
+    t.is(result, undefined);
   }
 );

--- a/test/unit/unix/quote.test.js
+++ b/test/unit/unix/quote.test.js
@@ -41,6 +41,6 @@ testProp(
   [arbitrary.unsupportedUnixShell()],
   (t, shellName) => {
     const result = unix.getQuoteFunction(shellName);
-    t.is(result, null);
+    t.is(result, undefined);
   }
 );

--- a/test/unit/win/escape.test.js
+++ b/test/unit/win/escape.test.js
@@ -53,6 +53,6 @@ testProp(
   [arbitrary.unsupportedWindowsShell()],
   (t, shellName) => {
     const result = win.getEscapeFunction(shellName);
-    t.is(result, null);
+    t.is(result, undefined);
   }
 );

--- a/test/unit/win/quote.test.js
+++ b/test/unit/win/quote.test.js
@@ -42,6 +42,6 @@ testProp(
   [arbitrary.unsupportedWindowsShell()],
   (t, shellName) => {
     const result = win.getQuoteFunction(shellName);
-    t.is(result, null);
+    t.is(result, undefined);
   }
 );


### PR DESCRIPTION
## Summary

Avoid explicitly returning `null` when an (implicit) `undefined` return value does just fine.