### PR TITLE
Update fuzz targets

### DIFF
--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -68,95 +68,13 @@ function checkSync({ arg, shell }) {
   assert.strictEqual(result, expected);
 }
 
-function checkMultipleArgs({ args, shell }) {
-  const argInfo = { shell, quoted: Boolean(shell) };
-  const execFileOptions = { encoding: "utf8", shell };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
-  );
-  const safeArgs = execFileOptions.shell
-    ? shescape.quoteAll(preparedArgs, execFileOptions)
-    : shescape.escapeAll(preparedArgs, execFileOptions);
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      "node",
-      [common.ECHO_SCRIPT, ...safeArgs],
-      execFileOptions,
-      (error, stdout) => {
-        if (error) {
-          reject(`an unexpected error occurred: ${error}`);
-        } else {
-          const result = stdout;
-          const expected = common.getExpectedOutput({
-            ...argInfo,
-            arg: (common.isShellPowerShell(shell)
-              ? args.filter(
-                  (arg) =>
-                    arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
-                )
-              : args
-            ).join(" "),
-          });
-          try {
-            assert.strictEqual(result, expected);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        }
-      }
-    );
-  });
-}
-
-function checkMultipleArgsSync({ args, shell }) {
-  const argInfo = { shell, quoted: Boolean(shell) };
-  const execFileOptions = { encoding: "utf8", shell };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
-  );
-  const safeArgs = execFileOptions.shell
-    ? shescape.quoteAll(preparedArgs, execFileOptions)
-    : shescape.escapeAll(preparedArgs, execFileOptions);
-
-  let stdout;
-  try {
-    stdout = execFileSync(
-      "node",
-      [common.ECHO_SCRIPT, ...safeArgs],
-      execFileOptions
-    );
-  } catch (error) {
-    assert.fail(`an unexpected error occurred: ${error}`);
-  }
-
-  const result = stdout;
-  const expected = common.getExpectedOutput({
-    ...argInfo,
-    arg: (common.isShellPowerShell(shell)
-      ? args.filter(
-          (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
-        )
-      : args
-    ).join(" "),
-  });
-  assert.strictEqual(result, expected);
-}
-
 async function fuzz(buf) {
   const arg = buf.toString();
-  const args = arg.split(/[\n\r]+/u);
-
   const shell = common.getFuzzShell();
 
   try {
     await check({ arg, shell });
-    await checkMultipleArgs({ args, shell });
     checkSync({ arg, shell });
-    checkMultipleArgsSync({ args, shell });
   } catch (e) {
     throw e;
   }

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -11,8 +11,7 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function check(arg) {
-  const shell = common.getFuzzShell();
+function check({ arg, shell }) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const execFileOptions = { encoding: "utf8", shell };
 
@@ -31,8 +30,7 @@ function check(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkMultipleArgs(args) {
-  const shell = common.getFuzzShell();
+function checkMultipleArgs({ args, shell }) {
   const argInfo = { shell, quoted: Boolean(shell) };
   const execFileOptions = { encoding: "utf8", shell };
 
@@ -71,8 +69,10 @@ function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
-  check(arg);
-  checkMultipleArgs(args);
+  const shell = common.getFuzzShell();
+
+  check({ arg, shell });
+  checkMultipleArgs({ args, shell });
 }
 
 module.exports = {

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -17,13 +17,21 @@ function check({ arg, shell }) {
 
   const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
 
-  const stdout = execFileSync(
-    "node",
-    execFileOptions.shell
-      ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], execFileOptions)
-      : shescape.escapeAll([common.ECHO_SCRIPT, preparedArg], execFileOptions),
-    execFileOptions
-  );
+  let stdout;
+  try {
+    stdout = execFileSync(
+      "node",
+      execFileOptions.shell
+        ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], execFileOptions)
+        : shescape.escapeAll(
+            [common.ECHO_SCRIPT, preparedArg],
+            execFileOptions
+          ),
+      execFileOptions
+    );
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
 
   const result = stdout;
   const expected = common.getExpectedOutput(argInfo);
@@ -38,19 +46,24 @@ function checkMultipleArgs({ args, shell }) {
     common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
   );
 
-  const stdout = execFileSync(
-    "node",
-    execFileOptions.shell
-      ? shescape.quoteAll(
-          [common.ECHO_SCRIPT, ...preparedArgs],
-          execFileOptions
-        )
-      : shescape.escapeAll(
-          [common.ECHO_SCRIPT, ...preparedArgs],
-          execFileOptions
-        ),
-    execFileOptions
-  );
+  let stdout;
+  try {
+    stdout = execFileSync(
+      "node",
+      execFileOptions.shell
+        ? shescape.quoteAll(
+            [common.ECHO_SCRIPT, ...preparedArgs],
+            execFileOptions
+          )
+        : shescape.escapeAll(
+            [common.ECHO_SCRIPT, ...preparedArgs],
+            execFileOptions
+          ),
+      execFileOptions
+    );
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
 
   const result = stdout;
   const expected = common.getExpectedOutput({

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -5,13 +5,45 @@
  */
 
 const assert = require("node:assert");
-const { execFileSync } = require("node:child_process");
+const { execFile, execFileSync } = require("node:child_process");
 
 const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
 function check({ arg, shell }) {
+  const argInfo = { arg, shell, quoted: Boolean(shell) };
+  const execFileOptions = { encoding: "utf8", shell };
+
+  const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
+  const safeArg = execFileOptions.shell
+    ? shescape.quote(preparedArg, execFileOptions)
+    : shescape.escape(preparedArg, execFileOptions);
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      "node",
+      [common.ECHO_SCRIPT, safeArg],
+      execFileOptions,
+      (error, stdout) => {
+        if (error) {
+          reject(`an unexpected error occurred: ${error}`);
+        } else {
+          const result = stdout;
+          const expected = common.getExpectedOutput(argInfo);
+          try {
+            assert.strictEqual(result, expected);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      }
+    );
+  });
+}
+
+function checkSync({ arg, shell }) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const execFileOptions = { encoding: "utf8", shell };
 
@@ -47,6 +79,49 @@ function checkMultipleArgs({ args, shell }) {
     ? shescape.quoteAll(preparedArgs, execFileOptions)
     : shescape.escapeAll(preparedArgs, execFileOptions);
 
+  return new Promise((resolve, reject) => {
+    execFile(
+      "node",
+      [common.ECHO_SCRIPT, ...safeArgs],
+      execFileOptions,
+      (error, stdout) => {
+        if (error) {
+          reject(`an unexpected error occurred: ${error}`);
+        } else {
+          const result = stdout;
+          const expected = common.getExpectedOutput({
+            ...argInfo,
+            arg: (common.isShellPowerShell(shell)
+              ? args.filter(
+                  (arg) =>
+                    arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
+                )
+              : args
+            ).join(" "),
+          });
+          try {
+            assert.strictEqual(result, expected);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      }
+    );
+  });
+}
+
+function checkMultipleArgsSync({ args, shell }) {
+  const argInfo = { shell, quoted: Boolean(shell) };
+  const execFileOptions = { encoding: "utf8", shell };
+
+  const preparedArgs = args.map((arg) =>
+    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
+  );
+  const safeArgs = execFileOptions.shell
+    ? shescape.quoteAll(preparedArgs, execFileOptions)
+    : shescape.escapeAll(preparedArgs, execFileOptions);
+
   let stdout;
   try {
     stdout = execFileSync(
@@ -71,14 +146,20 @@ function checkMultipleArgs({ args, shell }) {
   assert.strictEqual(result, expected);
 }
 
-function fuzz(buf) {
+async function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
   const shell = common.getFuzzShell();
 
-  check({ arg, shell });
-  checkMultipleArgs({ args, shell });
+  try {
+    await check({ arg, shell });
+    await checkMultipleArgs({ args, shell });
+    checkSync({ arg, shell });
+    checkMultipleArgsSync({ args, shell });
+  } catch (e) {
+    throw e;
+  }
 }
 
 module.exports = {

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -16,17 +16,15 @@ function check({ arg, shell }) {
   const execFileOptions = { encoding: "utf8", shell };
 
   const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
+  const safeArg = execFileOptions.shell
+    ? shescape.quote(preparedArg, execFileOptions)
+    : shescape.escape(preparedArg, execFileOptions);
 
   let stdout;
   try {
     stdout = execFileSync(
       "node",
-      execFileOptions.shell
-        ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], execFileOptions)
-        : shescape.escapeAll(
-            [common.ECHO_SCRIPT, preparedArg],
-            execFileOptions
-          ),
+      [common.ECHO_SCRIPT, safeArg],
       execFileOptions
     );
   } catch (error) {
@@ -45,20 +43,15 @@ function checkMultipleArgs({ args, shell }) {
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
   );
+  const safeArgs = execFileOptions.shell
+    ? shescape.quoteAll(preparedArgs, execFileOptions)
+    : shescape.escapeAll(preparedArgs, execFileOptions);
 
   let stdout;
   try {
     stdout = execFileSync(
       "node",
-      execFileOptions.shell
-        ? shescape.quoteAll(
-            [common.ECHO_SCRIPT, ...preparedArgs],
-            execFileOptions
-          )
-        : shescape.escapeAll(
-            [common.ECHO_SCRIPT, ...preparedArgs],
-            execFileOptions
-          ),
+      [common.ECHO_SCRIPT, ...safeArgs],
       execFileOptions
     );
   } catch (error) {

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -11,8 +11,7 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function check(arg) {
-  const shell = common.getFuzzShell();
+function check({ arg, shell }) {
   const argInfo = { arg, shell, quoted: true };
   const execOptions = { encoding: "utf8", shell };
 
@@ -31,8 +30,7 @@ function check(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkUsingInterpolation(arg) {
-  const shell = common.getFuzzShell();
+function checkUsingInterpolation({ arg, shell }) {
   const argInfo = { arg, shell, quoted: false };
   const execOptions = { encoding: "utf8", shell };
 
@@ -55,8 +53,10 @@ function checkUsingInterpolation(arg) {
 function fuzz(buf) {
   const arg = buf.toString();
 
-  check(arg);
-  checkUsingInterpolation(arg);
+  const shell = common.getFuzzShell();
+
+  check({ arg, shell });
+  checkUsingInterpolation({ arg, shell });
 }
 
 module.exports = {

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -119,7 +119,6 @@ function checkUsingInterpolationSync({ arg, shell }) {
 
 async function fuzz(buf) {
   const arg = buf.toString();
-
   const shell = common.getFuzzShell();
 
   try {

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -29,7 +29,7 @@ function check({ arg, shell }) {
           reject(`an unexpected error occurred: ${error}`);
         } else {
           const result = stdout;
-          const expected = common.getExpectedOutput(argInfo, true);
+          const expected = common.getExpectedOutput(argInfo);
           try {
             assert.strictEqual(result, expected);
             resolve();
@@ -59,7 +59,7 @@ function checkSync({ arg, shell }) {
   }
 
   const result = stdout;
-  const expected = common.getExpectedOutput(argInfo, true);
+  const expected = common.getExpectedOutput(argInfo);
   assert.strictEqual(result, expected);
 }
 

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -20,13 +20,15 @@ function check({ arg, shell }) {
     ...execOptions,
   });
 
-  const stdout = execSync(
-    `node ${common.ECHO_SCRIPT} ${quotedArg}`,
-    execOptions
-  );
+  let stdout;
+  try {
+    stdout = execSync(`node ${common.ECHO_SCRIPT} ${quotedArg}`, execOptions);
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
 
   const result = stdout;
-  const expected = common.getExpectedOutput(argInfo);
+  const expected = common.getExpectedOutput(argInfo, true);
   assert.strictEqual(result, expected);
 }
 
@@ -40,10 +42,12 @@ function checkUsingInterpolation({ arg, shell }) {
     interpolation: true,
   });
 
-  const stdout = execSync(
-    `node ${common.ECHO_SCRIPT} ${escapedArg}`,
-    execOptions
-  );
+  let stdout;
+  try {
+    stdout = execSync(`node ${common.ECHO_SCRIPT} ${escapedArg}`, execOptions);
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
 
   const result = stdout;
   const expected = common.getExpectedOutput(argInfo, true);

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -24,6 +24,10 @@ function check(arg) {
       forkOptions
     );
 
+    echo.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
+
     echo.stdout.on("data", (data) => {
       const result = data.toString();
       const expected = common.getExpectedOutput(argInfo);
@@ -51,6 +55,10 @@ function checkMultipleArgs(args) {
       shescape.escapeAll(preparedArgs),
       forkOptions
     );
+
+    echo.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
 
     echo.stdout.on("data", (data) => {
       const result = data.toString();

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -38,45 +38,11 @@ function check(arg) {
   });
 }
 
-function checkMultipleArgs(args) {
-  const argInfo = { quoted: false };
-  const forkOptions = { silent: true };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, true)
-  );
-  const safeArgs = shescape.escapeAll(preparedArgs);
-
-  return new Promise((resolve, reject) => {
-    const echo = fork(common.ECHO_SCRIPT, safeArgs, forkOptions);
-
-    echo.on("error", (error) => {
-      reject(`an unexpected error occurred: ${error}`);
-    });
-
-    echo.stdout.on("data", (data) => {
-      const result = data.toString();
-      const expected = common.getExpectedOutput({
-        ...argInfo,
-        arg: args.join(" "),
-      });
-      try {
-        assert.strictEqual(result, expected);
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
-}
-
 async function fuzz(buf) {
   const arg = buf.toString();
-  const args = arg.split(/[\n\r]+/u);
 
   try {
     await check(arg);
-    await checkMultipleArgs(args);
   } catch (e) {
     throw e;
   }

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -16,13 +16,10 @@ function check(arg) {
   const forkOptions = { silent: true };
 
   const preparedArg = common.prepareArg(argInfo, true);
+  const safeArg = shescape.escape(preparedArg);
 
   return new Promise((resolve, reject) => {
-    const echo = fork(
-      common.ECHO_SCRIPT,
-      shescape.escapeAll([preparedArg]),
-      forkOptions
-    );
+    const echo = fork(common.ECHO_SCRIPT, [safeArg], forkOptions);
 
     echo.on("error", (error) => {
       reject(`an unexpected error occurred: ${error}`);
@@ -48,13 +45,10 @@ function checkMultipleArgs(args) {
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, true)
   );
+  const safeArgs = shescape.escapeAll(preparedArgs);
 
   return new Promise((resolve, reject) => {
-    const echo = fork(
-      common.ECHO_SCRIPT,
-      shescape.escapeAll(preparedArgs),
-      forkOptions
-    );
+    const echo = fork(common.ECHO_SCRIPT, safeArgs, forkOptions);
 
     echo.on("error", (error) => {
       reject(`an unexpected error occurred: ${error}`);

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -16,14 +16,11 @@ function check({ arg, shell }) {
   const spawnOptions = { encoding: "utf8", shell };
 
   const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
+  const safeArg = spawnOptions.shell
+    ? shescape.quote(preparedArg, spawnOptions)
+    : shescape.escape(preparedArg, spawnOptions);
 
-  const child = spawnSync(
-    "node",
-    spawnOptions.shell
-      ? shescape.quoteAll([common.ECHO_SCRIPT, preparedArg], spawnOptions)
-      : shescape.escapeAll([common.ECHO_SCRIPT, preparedArg], spawnOptions),
-    spawnOptions
-  );
+  const child = spawnSync("node", [common.ECHO_SCRIPT, safeArg], spawnOptions);
 
   if (child.error) {
     assert.fail(`an unexpected error occurred: ${child.error}`);
@@ -41,12 +38,13 @@ function checkMultipleArgs({ args, shell }) {
   const preparedArgs = args.map((arg) =>
     common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
   );
+  const safeArgs = spawnOptions.shell
+    ? shescape.quoteAll(preparedArgs, spawnOptions)
+    : shescape.escapeAll(preparedArgs, spawnOptions);
 
   const child = spawnSync(
     "node",
-    spawnOptions.shell
-      ? shescape.quoteAll([common.ECHO_SCRIPT, ...preparedArgs], spawnOptions)
-      : shescape.escapeAll([common.ECHO_SCRIPT, ...preparedArgs], spawnOptions),
+    [common.ECHO_SCRIPT, ...safeArgs],
     spawnOptions
   );
 

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -11,8 +11,7 @@ const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
-function check(arg) {
-  const shell = common.getFuzzShell();
+function check({ arg, shell }) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
@@ -31,8 +30,7 @@ function check(arg) {
   assert.strictEqual(result, expected);
 }
 
-function checkMultipleArgs(args) {
-  const shell = common.getFuzzShell();
+function checkMultipleArgs({ args, shell }) {
   const argInfo = { shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
@@ -65,8 +63,10 @@ function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
-  check(arg);
-  checkMultipleArgs(args);
+  const shell = common.getFuzzShell();
+
+  check({ arg, shell });
+  checkMultipleArgs({ args, shell });
 }
 
 module.exports = {

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -25,9 +25,13 @@ function check({ arg, shell }) {
     spawnOptions
   );
 
-  const result = child.stdout;
-  const expected = common.getExpectedOutput(argInfo);
-  assert.strictEqual(result, expected);
+  if (child.error) {
+    assert.fail(`an unexpected error occurred: ${child.error}`);
+  } else {
+    const result = child.stdout;
+    const expected = common.getExpectedOutput(argInfo);
+    assert.strictEqual(result, expected);
+  }
 }
 
 function checkMultipleArgs({ args, shell }) {
@@ -46,17 +50,21 @@ function checkMultipleArgs({ args, shell }) {
     spawnOptions
   );
 
-  const result = child.stdout;
-  const expected = common.getExpectedOutput({
-    ...argInfo,
-    arg: (common.isShellPowerShell(shell)
-      ? args.filter(
-          (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
-        )
-      : args
-    ).join(" "),
-  });
-  assert.strictEqual(result, expected);
+  if (child.error) {
+    assert.fail(`an unexpected error occurred: ${child.error}`);
+  } else {
+    const result = child.stdout;
+    const expected = common.getExpectedOutput({
+      ...argInfo,
+      arg: (common.isShellPowerShell(shell)
+        ? args.filter(
+            (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
+          )
+        : args
+      ).join(" "),
+    });
+    assert.strictEqual(result, expected);
+  }
 }
 
 function fuzz(buf) {

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -60,94 +60,13 @@ function checkSync({ arg, shell }) {
   }
 }
 
-function checkMultipleArgs({ args, shell }) {
-  const argInfo = { shell, quoted: Boolean(shell) };
-  const spawnOptions = { encoding: "utf8", shell };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
-  );
-  const safeArgs = spawnOptions.shell
-    ? shescape.quoteAll(preparedArgs, spawnOptions)
-    : shescape.escapeAll(preparedArgs, spawnOptions);
-
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      "node",
-      [common.ECHO_SCRIPT, ...safeArgs],
-      spawnOptions
-    );
-
-    child.on("error", (error) => {
-      reject(`an unexpected error occurred: ${error}`);
-    });
-
-    child.stdout.on("data", (data) => {
-      const result = data.toString();
-      const expected = common.getExpectedOutput({
-        ...argInfo,
-        arg: (common.isShellPowerShell(shell)
-          ? args.filter(
-              (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
-            )
-          : args
-        ).join(" "),
-      });
-      try {
-        assert.strictEqual(result, expected);
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
-}
-
-function checkMultipleArgsSync({ args, shell }) {
-  const argInfo = { shell, quoted: Boolean(shell) };
-  const spawnOptions = { encoding: "utf8", shell };
-
-  const preparedArgs = args.map((arg) =>
-    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
-  );
-  const safeArgs = spawnOptions.shell
-    ? shescape.quoteAll(preparedArgs, spawnOptions)
-    : shescape.escapeAll(preparedArgs, spawnOptions);
-
-  const child = spawnSync(
-    "node",
-    [common.ECHO_SCRIPT, ...safeArgs],
-    spawnOptions
-  );
-
-  if (child.error) {
-    assert.fail(`an unexpected error occurred: ${child.error}`);
-  } else {
-    const result = child.stdout;
-    const expected = common.getExpectedOutput({
-      ...argInfo,
-      arg: (common.isShellPowerShell(shell)
-        ? args.filter(
-            (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
-          )
-        : args
-      ).join(" "),
-    });
-    assert.strictEqual(result, expected);
-  }
-}
-
 async function fuzz(buf) {
   const arg = buf.toString();
-  const args = arg.split(/[\n\r]+/u);
-
   const shell = common.getFuzzShell();
 
   try {
     await check({ arg, shell });
-    await checkMultipleArgs({ args, shell });
     checkSync({ arg, shell });
-    checkMultipleArgsSync({ args, shell });
   } catch (e) {
     throw e;
   }

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -5,13 +5,42 @@
  */
 
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 
 const common = require("./_common.cjs");
 
 const shescape = require("../../index.cjs");
 
 function check({ arg, shell }) {
+  const argInfo = { arg, shell, quoted: Boolean(shell) };
+  const spawnOptions = { encoding: "utf8", shell };
+
+  const preparedArg = common.prepareArg(argInfo, !Boolean(shell));
+  const safeArg = spawnOptions.shell
+    ? shescape.quote(preparedArg, spawnOptions)
+    : shescape.escape(preparedArg, spawnOptions);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [common.ECHO_SCRIPT, safeArg], spawnOptions);
+
+    child.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
+
+    child.stdout.on("data", (data) => {
+      const result = data.toString();
+      const expected = common.getExpectedOutput(argInfo);
+      try {
+        assert.strictEqual(result, expected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+function checkSync({ arg, shell }) {
   const argInfo = { arg, shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
@@ -32,6 +61,49 @@ function check({ arg, shell }) {
 }
 
 function checkMultipleArgs({ args, shell }) {
+  const argInfo = { shell, quoted: Boolean(shell) };
+  const spawnOptions = { encoding: "utf8", shell };
+
+  const preparedArgs = args.map((arg) =>
+    common.prepareArg({ ...argInfo, arg }, !Boolean(shell))
+  );
+  const safeArgs = spawnOptions.shell
+    ? shescape.quoteAll(preparedArgs, spawnOptions)
+    : shescape.escapeAll(preparedArgs, spawnOptions);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "node",
+      [common.ECHO_SCRIPT, ...safeArgs],
+      spawnOptions
+    );
+
+    child.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
+
+    child.stdout.on("data", (data) => {
+      const result = data.toString();
+      const expected = common.getExpectedOutput({
+        ...argInfo,
+        arg: (common.isShellPowerShell(shell)
+          ? args.filter(
+              (arg) => arg.replace(/[\0\u0008\u001B\u009B]/gu, "").length !== 0
+            )
+          : args
+        ).join(" "),
+      });
+      try {
+        assert.strictEqual(result, expected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+function checkMultipleArgsSync({ args, shell }) {
   const argInfo = { shell, quoted: Boolean(shell) };
   const spawnOptions = { encoding: "utf8", shell };
 
@@ -65,14 +137,20 @@ function checkMultipleArgs({ args, shell }) {
   }
 }
 
-function fuzz(buf) {
+async function fuzz(buf) {
   const arg = buf.toString();
   const args = arg.split(/[\n\r]+/u);
 
   const shell = common.getFuzzShell();
 
-  check({ arg, shell });
-  checkMultipleArgs({ args, shell });
+  try {
+    await check({ arg, shell });
+    await checkMultipleArgs({ args, shell });
+    checkSync({ arg, shell });
+    checkMultipleArgsSync({ args, shell });
+  } catch (e) {
+    throw e;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Relates to #361, #688

## Summary

Update fuzz targets in various ways:

- Refactor for performance. (169c9c66bd697e80df5e4a9892b3ee2a667a5896)
- Refactor for improved readability. (343c9db4e7eb5234743c964cf220969719c63b03)
- Handle errors explicitly. (eb57fe4502be99eddbe7a6d6d6fd4e52416f4bd6)
- Test non-sync versions of `execFileSync`, `execSync`, and `spawnSync`. (ccdc4b605ca9a12172b80b695f42306ef245231d)
- Don't test multiple args. (5ab274048281fab3a74e44702c32f7db4c24e4d8)