### PR TITLE
Update "Audit / Secrets" job

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -58,7 +58,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
+            actions-results-receiver-production.githubapp.com:80
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             github.com:443

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -58,6 +58,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             github.com:443


### PR DESCRIPTION
Relates to #317

## Summary

Update the "Audit / Secrets" job configuration. These changes follow [this GitHub blog post](https://github.blog/changelog/2023-01-31-github-actions-job-summary-updates/) which says:

> [...] need to ensure machines have appropriate network access to communicate with the GitHub hosts below so that job summaries and logs emitted from Actions workflows can work as expected.
>
> - `actions-results-receiver-production.githubapp.com`
> - [...]