### PR TITLE
Bump transitive dependency http-cache-semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4885,9 +4885,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-proxy-agent": {


### PR DESCRIPTION
## Summary

Update http-cache-semantics from 4.1.0 to 4.1.1 following a `npm audit` warning for for CVE-2022-25881.

See also [the nightly run of Feb 2, 2023](https://github.com/ericcornelissen/shescape/actions/runs/4070879505).