### PR TITLE
Harden `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
           app_id: ${{ secrets.AUTOMATION_APP_ID }}
           private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Bump version
-        run: npm version '${{ github.event.inputs.update_type }}' --no-git-tag-version
+        env:
+          UPDATE_TYPE: ${{ github.event.inputs.update_type }}
+        run: npm version "$UPDATE_TYPE" --no-git-tag-version
       - name: Update index.js
         run: node script/bump-jsdoc.js
       - name: Update CHANGELOG


### PR DESCRIPTION
Relates to #621, #734 

## Summary

Prevent shell injection in this workflow by capturing the update type as an environment variable and using the environment variable. This way, the expansion of the input in the command can't result in shell injection, whereas before a `'` in the input could unquote the current argument and something like `&&` could start a new command.