### PR TITLE
Update egress policy for the CodeQL job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,6 +73,7 @@ jobs:
             api.github.com:443
             ghcr.io:443
             github.com:443
+            objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Add `objects.githubusercontent.com:443` to the allowed endpoints of the egress policy for the "Checks / CodeQL" job. This follows unexpected failures in that job (i.e. without any changes) when it attempted to (re-)download CodeQL. Since this endpoint is already allowed for various other jobs, adding it is considered a non-issue.