### PR TITLE
Move `testing.js` to root

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@
 !README.md
 !SECURITY.md
 !testing.cjs
+!testing.js

--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -1,5 +1,5 @@
 {
-  "entry": ["index.js", "src/testing.js"],
+  "entry": ["index.js", "testing.js"],
   "ignorePatterns": ["**/node_modules/**"],
   "ignoreUnimported": [],
   "ignoreUnused": [],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "./testing": {
       "types": "./index.d.ts",
-      "import": "./src/testing.js",
+      "import": "./testing.js",
       "require": "./testing.cjs"
     }
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ export default [
     external,
   },
   {
-    input: "src/testing.js",
+    input: "testing.js",
     output: {
       file: "testing.cjs",
       format: "cjs",

--- a/test/unit/testing/simple.test.js
+++ b/test/unit/testing/simple.test.js
@@ -9,7 +9,7 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants } from "./_.js";
 
-import { shescape as stubscape } from "../../../src/testing.js";
+import { shescape as stubscape } from "../../../testing.js";
 
 testProp(
   "escape valid arguments",

--- a/testing.js
+++ b/testing.js
@@ -3,7 +3,7 @@
  * @license MPL-2.0
  */
 
-import { isStringable, toArrayIfNecessary } from "./reflection.js";
+import { isStringable, toArrayIfNecessary } from "./src/reflection.js";
 
 /**
  * A test stub of shescape that has the same input-output profile as the real


### PR DESCRIPTION
Relates to #710

## Summary

Consolidate all entrypoints in the root of the project for consistency and clarity.