### PR TITLE
Don't run Semgrep for PRs by dependabot

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -190,6 +190,7 @@ jobs:
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       security-events: write # To upload SARIF results
     env:


### PR DESCRIPTION
Relates to #772, #774

## Summary

... since it doesn't have the access to the secret, it can't run _and_ (as a result) will fail because it can't upload the SARIF file.