### PR TITLE
Pre-format in pre-commit hook

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,6 +4,7 @@
 
 # Pre
 if [ -z "$(IS_MERGING)" ]; then
+  npm run format
   git stash push --quiet --include-untracked --keep-index
 fi
 


### PR DESCRIPTION
Relates to #128

## Summary

Update the pre-commit hook to format before stashing. This has the effect of avoiding stash-merge conflicts due to the stash pop at the end of the hook in some cases. This is considered not harmful as, eventually, all code (staged or not) must be formatted.
