### PR TITLE
Reduce availability scope of the `SEMGREP_APP_TOKEN` secret

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -193,8 +193,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       security-events: write # To upload SARIF results
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: returntocorp/semgrep
     steps:
@@ -202,6 +200,8 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform Semgrep analysis
         run: semgrep ci --sarif --output semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep report to GitHub
         uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b # v2.2.9
         if: ${{ failure() || success() }}


### PR DESCRIPTION
Relates to #734, #772

## Summary

Only make the `SEMGREP_APP_TOKEN` available in the job step that needs it, as opposed to the whole job. Following the principle of least privilege.