### PR TITLE
Document reasons for elevated permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - test-unit
-    permissions:
-      contents: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,7 +61,7 @@ jobs:
     name: CodeQL
     runs-on: ubuntu-22.04
     permissions:
-      security-events: write
+      security-events: write # To upload CodeQL results
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1


### PR DESCRIPTION
Closes #773

## Summary

Add a comment with an explanation for the reason of any elevated permissions in GitHub Actions workflows where it was not already present.