### PR TITLE
Relicense tests and scripts

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -121,8 +121,8 @@ rules:
   jsdoc/check-values:
     - error
     - allowedLicenses:
-        - MPL-2.0
         - MIT
+        - MPL-2.0
       numericOnlyVariation: false
   jsdoc/empty-tags:
     - error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -122,7 +122,7 @@ rules:
     - error
     - allowedLicenses:
         - MPL-2.0
-        - Unlicense
+        - MIT
       numericOnlyVariation: false
   jsdoc/empty-tags:
     - error

--- a/.github/workflows/fuzz-matrix.js
+++ b/.github/workflows/fuzz-matrix.js
@@ -1,6 +1,6 @@
 /**
  * @overview Computes a matrix of fuzz jobs for `reusable-fuzz.yml`.
- * @license Unlicense
+ * @license MIT
  */
 
 const unixOS = "ubuntu-22.04";

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,7 +374,7 @@ file should follow the following guidelines:
 - `@overview`: Should describe the contents of the file. Must be written in the
   present tense with an active voice. In the first sentence, the subject must be
   omitted for brevity.
-- `@license`: Must be `MPL-2.0` for all source code files. Must be `Unlicense`
+- `@license`: Must be `MPL-2.0` for all source code files. Must be either `MIT`
   (preferred) or `MPL-2.0` for all test files.
 
 ##### Structure

--- a/script/check-runtime-deps.js
+++ b/script/check-runtime-deps.js
@@ -1,7 +1,7 @@
 /**
  * @overview Check if the version of runtime dependencies being depended upon
  * match the minimum version of the supported versions.
- * @license Unlicense
+ * @license MIT
  */
 
 import cp from "node:child_process";

--- a/script/clean.js
+++ b/script/clean.js
@@ -1,7 +1,7 @@
 /**
  * @overview Reset the repository to a clean state, removing any generated
  * files.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as fs from "node:fs";

--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -1,7 +1,7 @@
 /**
  * @overview Start fuzzing using a specific fuzz target. Use the first argument
  * to specify the fuzz target, for example: `npm run fuzz exec`.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as cp from "node:child_process";

--- a/script/release/bump-changelog.js
+++ b/script/release/bump-changelog.js
@@ -1,7 +1,7 @@
 /**
  * @overview Sets the current version in the manifest as the latest release in
  * the CHANGELOG.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as fs from "node:fs";

--- a/script/release/bump-jsdoc.js
+++ b/script/release/bump-jsdoc.js
@@ -1,7 +1,7 @@
 /**
  * @overview Sets the current version in the manifest as the version in the
  * JSDoc of `index.js`.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as fs from "node:fs";

--- a/script/release/get-release-notes.js
+++ b/script/release/get-release-notes.js
@@ -1,7 +1,7 @@
 /**
  * @overview Outputs the release notes for the version currently specified in
  * the manifest.
- * @license Unlicense
+ * @license MIT
  */
 
 import fs from "node:fs";

--- a/script/run-compatibility-tests.js
+++ b/script/run-compatibility-tests.js
@@ -1,7 +1,7 @@
 /**
  * @overview Runs the project's compatibility tests on all supported Node.js
  * version using Docker.
- * @license Unlicense
+ * @license MIT
  */
 
 import cp from "node:child_process";

--- a/test/_arbitraries.js
+++ b/test/_arbitraries.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides custom fast-check arbitraries for tests.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as fc from "fast-check";

--- a/test/_constants.cjs
+++ b/test/_constants.cjs
@@ -1,6 +1,6 @@
 /**
  * @overview Provides values common to all tests.
- * @license Unlicense
+ * @license MIT
  */
 
 const os = require("node:os");

--- a/test/_echo.js
+++ b/test/_echo.js
@@ -1,7 +1,7 @@
 /**
  * @overview Echos back all arguments to standard out. Expects to be invoked as
  * `node echo.js arg1 arg2 ... argN`.
- * @license Unlicense
+ * @license MIT
  */
 
 import process from "node:process";

--- a/test/_macros.js
+++ b/test/_macros.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides AVA test macros.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/bench/bench.js
+++ b/test/bench/bench.js
@@ -1,6 +1,6 @@
 /**
  * @overview A benchmark suite for detecting performance regression.
- * @license Unlicense
+ * @license MIT
  */
 
 import Benchmark from "benchmark";

--- a/test/compat/index.test.cjs
+++ b/test/compat/index.test.cjs
@@ -1,7 +1,7 @@
 /**
  * @overview Contains smoke tests for Shescape to verify compatibility with Node
  * versions.
- * @license Unlicense
+ * @license MIT
  */
 
 const assert = require("assert");

--- a/test/e2e/_.js
+++ b/test/e2e/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as constants from "../_constants.cjs";

--- a/test/e2e/_macros.js
+++ b/test/e2e/_macros.js
@@ -1,7 +1,7 @@
 /**
  * @overview Provides AVA test macros for end-to-end tests of using Shescape
  * with child_process.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as cp from "node:child_process";

--- a/test/e2e/child_process.test.js
+++ b/test/e2e/child_process.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains end-to-end tests of using Shescape with the child_process
  * package.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -1,6 +1,6 @@
 /**
  * @overview Provides utilities for fuzzing.
- * @license Unlicense
+ * @license MIT
  */
 
 const process = require("node:process");

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -1,7 +1,7 @@
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `execFile` / `execFileSync`.
- * @license Unlicense
+ * @license MIT
  */
 
 const assert = require("node:assert");

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -1,7 +1,7 @@
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `exec` / `execSync`.
- * @license Unlicense
+ * @license MIT
  */
 
 const assert = require("node:assert");

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -1,7 +1,7 @@
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `fork`.
- * @license Unlicense
+ * @license MIT
  */
 
 const assert = require("node:assert");

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -1,7 +1,7 @@
 /**
  * @overview Contains fuzz tests for using Shescape with the child_process
  * function `spawn` / `spawnSync`.
- * @license Unlicense
+ * @license MIT
  */
 
 const assert = require("node:assert");

--- a/test/integration/_.js
+++ b/test/integration/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../_arbitraries.js";

--- a/test/integration/_macros.js
+++ b/test/integration/_macros.js
@@ -1,7 +1,7 @@
 /**
  * @overview Provides AVA test macros for integration testing to enable running
  * the same suite of tests for both ESModule and CommonJS.
- * @license Unlicense
+ * @license MIT
  */
 
 import os from "node:os";

--- a/test/integration/escape-all.test.js
+++ b/test/integration/escape-all.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains integration tests for `shescape.escapeAll`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/integration/escape.test.js
+++ b/test/integration/escape.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains integration tests for `shescape.escape`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/integration/quote-all.test.js
+++ b/test/integration/quote-all.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains integration tests for `shescape.quoteAll`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/integration/quote.test.js
+++ b/test/integration/quote.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains integration tests for `shescape.quote`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides AVA test macros for unit tests.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the functionality to resolve executables.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/unit/main/_.js
+++ b/test/unit/main/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../../_arbitraries.js";

--- a/test/unit/main/_macros.js
+++ b/test/unit/main/_macros.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides AVA test macros for `./src/main.js` unit tests.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/unit/main/escape.test.js
+++ b/test/unit/main/escape.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests the escaping logic of `./src/main.js`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/main/quote.test.js
+++ b/test/unit/main/quote.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests the quoting logic of `./src/main.js`.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/platforms/_.js
+++ b/test/unit/platforms/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../../_arbitraries.js";

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains unit tests for the functionality to get helpers functions
  * for a given platform.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/testing/_.js
+++ b/test/unit/testing/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../../_arbitraries.js";

--- a/test/unit/testing/simple.test.js
+++ b/test/unit/testing/simple.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the simple test stub of shescape.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/unix/_.js
+++ b/test/unit/unix/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../../_arbitraries.js";

--- a/test/unit/unix/csh.test.js
+++ b/test/unit/unix/csh.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains (additional) unit tests for the escaping functionality for
  * the C shell.
- * @license Unlicense
+ * @license MIT
  */
 
 import { TextDecoder } from "node:util";

--- a/test/unit/unix/default-shell.test.js
+++ b/test/unit/unix/default-shell.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the default shell on Unix systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import test from "ava";

--- a/test/unit/unix/escape.test.js
+++ b/test/unit/unix/escape.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the escaping functionality on Unix systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/unix/quote.test.js
+++ b/test/unit/unix/quote.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the quoting functionality on Unix systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/unix/shell-name.test.js
+++ b/test/unit/unix/shell-name.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the getting a shell's name on Unix systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/win/_.js
+++ b/test/unit/win/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides testing utilities.
- * @license Unlicense
+ * @license MIT
  */
 
 import * as arbitrary from "../../_arbitraries.js";

--- a/test/unit/win/default-shell.test.js
+++ b/test/unit/win/default-shell.test.js
@@ -1,6 +1,6 @@
 /**
  * @overview Contains unit tests for the default shell on Windows systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/win/escape.test.js
+++ b/test/unit/win/escape.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains unit tests for the escaping functionality on Windows
  * systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/win/quote.test.js
+++ b/test/unit/win/quote.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains unit tests for the quoting functionality on Windows
  * systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";

--- a/test/unit/win/shell-name.test.js
+++ b/test/unit/win/shell-name.test.js
@@ -1,7 +1,7 @@
 /**
  * @overview Contains unit tests for the getting a shell's name on Windows
  * systems.
- * @license Unlicense
+ * @license MIT
  */
 
 import { testProp } from "@fast-check/ava";


### PR DESCRIPTION
Closes #780

## Summary

Change the license of all tests and scripts that used to use [The Unlicense] license to the [MIT] license. Both are permissive licenses, but the MIT license has both clearer language (from a legal perspective) and is _more_ permissive - per the [Blue Oak Council].

All of these files have only edited by me (@ericcornelissen) and there's therefor no other people with a claim to the license used. Not to mention (again) that both licenses are permissive.

[The Unlicense]: https://opensource.org/license/unlicense/
[MIT]: https://opensource.org/license/mit/
[Blue Oak Council]: https://blueoakcouncil.org