### PR TITLE
Set up continuous SAST with njsscan

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -213,6 +213,28 @@ jobs:
       - name: Lint YAML
         if: ${{ failure() || success() }}
         run: npm run lint:yml -- --debug
+  njsscan:
+    name: njsscan
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # To upload SARIF results
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: Perform njsscan analysis
+        id: njsscan
+        uses: ajinabraham/njsscan-action@7237412fdd36af517e2745077cedbf9d6900d711 # v7
+        with:
+          args: . --sarif --output njsscan-results.sarif
+      - name: Upload njsscan report to GitHub
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: njsscan-results.sarif
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -229,7 +229,7 @@ jobs:
         id: njsscan
         uses: ajinabraham/njsscan-action@7237412fdd36af517e2745077cedbf9d6900d711 # v7
         with:
-          args: . --sarif --output njsscan-results.sarif
+          args: . --sarif --output njsscan-results.sarif || true
       - name: Upload njsscan report to GitHub
         uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
         if: ${{ failure() || success() }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -222,7 +222,16 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
+            api.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform njsscan analysis


### PR DESCRIPTION
Relates to #734, #785, #788

## Summary

Add a new CI job that runs the SAST tool [njsscan (GitHub Action)](https://github.com/ajinabraham/njsscan-action) ([njsscan](https://github.com/ajinabraham/njsscan)). This is a tool that is a:

> Static security code scanner (SAST) for Node.js applications powered by libsast and semgrep.

The Action is based on a tool with the same name: njsscan[2]. This is also available as a CLI (not tried as of this commit). The tool is aimed at scanning Node.js code specifically.

This is mainly intended as a test for the tool, as found in GitHub's "Choose aw workflow" UI for security.

~~Yes, this project already uses [Semgrep](https://semgrep.dev/), but not [libsast](https://github.com/ajinabraham/libsast) so it's considered worth trying just for that reason. Perhaps in the long run this scanner could be removed and libsast can be used directly instead.~~ Per my understanding this scanner builds upon [Semgrep](https://semgrep.dev/) with custom patterns, for this reason we're testing it [in addition to Semgrep](https://github.com/ericcornelissen/shescape/blob/3f9d2a83cdb6c983e79243f1f0282c7d1f3702c8/.github/workflows/checks.yml#L216-L235).
