### PR TITLE
Set up continuous SAST and SCA with Contrast

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,6 +83,60 @@ jobs:
           languages: javascript
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+  contrast-sast:
+    name: Contrast SAST
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # To upload SARIF results
+    needs:
+      - transpile
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Transpile to CommonJS
+        run: npm run transpile
+      - name: Perform Contrast SAST analysis
+        uses: Contrast-Security-OSS/contrastscan-action@ede6d65addebe0898291fbe640850556d914be18 # v2.0.3
+        with:
+          artifact: index.cjs
+          apiKey: ${{ secrets.CONTRAST_API_KEY }}
+          orgId: ${{ secrets.CONTRAST_ORGANIZATION_ID }}
+          authHeader: ${{ secrets.CONTRAST_AUTH_HEADER }}
+      - name: Upload Contrast report to GitHub
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: results.sarif
+  contrast-sca:
+    name: Contrast SCA
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # To upload SARIF results
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: Perform Contrast SCA analysis
+        uses: Contrast-Security-OSS/contrast-sca-action@0a234a04ffdff74336bb242f1898820c87de90e2 # v1.0.1
+        with:
+          filePath: package.json
+          apiKey: ${{ secrets.CONTRAST_API_KEY }}
+          orgId: ${{ secrets.CONTRAST_ORGANIZATION_ID }}
+          authHeader: ${{ secrets.CONTRAST_AUTH_HEADER }}
   devskim:
     name: DevSkim
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #734, #785, #788, #793

## Summary

Add a new CI job that runs the SAST tool ([`contrastscan-action`](https://github.com/Contrast-Security-OSS/contrastscan-action)) and SCA tool ([`contrast-sca-action`](https://github.com/Contrast-Security-OSS/contrast-sca-action)) of [Contrast](https://www.contrastsecurity.com/). The former is configured to upload it's result to GitHub's Security Code Scanning.

This is mainly intended as a test for the tooling.