### PR TITLE
Set up continuous scanning with Trivy

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -550,7 +550,16 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
+            api.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform Trivy analysis

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -541,6 +541,33 @@ jobs:
         with:
           name: index-common-js
           path: index.cjs
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # To upload SARIF results
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: Perform Trivy analysis
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # 0.9.2
+        with:
+          exit-code: 1
+          format: sarif
+          output: trivy-results.sarif
+          scanners: vuln,secret
+          scan-type: fs
+          scan-ref: .
+          template: "@/contrib/sarif.tpl"
+      - name: Upload Trivy report to GitHub
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: trivy-results.sarif
   vet:
     name: Vet
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #734, #785, #788, #793, #796

## Summary

Add a new CI job to continuously run [Trivy](https://github.com/aquasecurity/trivy) using the official [Trivy Action](https://github.com/aquasecurity/trivy-action).

Trivy provides SBOM generation, known vulnerability scanning, infrastucture as code misconfiguration detection, secrets detection, and license detection and compliance. Here, vulnerability scanning and secrets detection are enabled. IaC not because this project has none. License scanning not because it requires configuration (and this project already uses licensee for this topic). And yes, secret scanning is already done [with gitleaks](https://github.com/ericcornelissen/shescape/blob/ff92fff6a825c3e6439d8ffc8f60937a4bb9714a/.github/workflows/reusable-audit.yml#L52-L88) and vulnerability scanning (at least) [with `npm audit`](https://github.com/ericcornelissen/shescape/blob/ff92fff6a825c3e6439d8ffc8f60937a4bb9714a/.github/workflows/reusable-audit.yml#L13-L51), but...

This is mainly intended as a test for the tool.
