### PR TITLE
Update the "Labeler / Label" job

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - name: Set labels on Pull Request
         uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
         with:
           configuration-path: .github/labeler.yml
-          sync-labels: false
+          sync-labels: true


### PR DESCRIPTION
Relates to #798, #799

## Summary

- Configure `harden-runner` for the labeling job ([ref](https://github.com/ericcornelissen/shescape/pull/798#discussion_r1161164965)).
- Try to configure it to not remove pre-assigned labels (as seen in #799).