### PR TITLE
Update egress policy for "OSSF / Scorecard" job

### DIFF
--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -25,9 +25,13 @@ jobs:
             actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             api.osv.dev:443
+            bestpractices.coreinfrastructure.org:443
+            codeload.github.com
             ghcr.io:443
             github.com:443
+            oauth2.sigstore.dev:443
             objects.githubusercontent.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:433
             pkg-containers.githubusercontent.com:443
             uploads.github.com:443
       - name: Checkout repository


### PR DESCRIPTION
Relates to #802

## Summary

Update the "OSSF / Scorecard" job with a new egress policy following a [failed run](https://github.com/ericcornelissen/shescape/actions/runs/4657972447) on the `main` branch.