### PR TITLE
Publish with provenance from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,6 +121,8 @@ jobs:
     name: npm
     runs-on: ubuntu-22.04
     if: ${{ needs.check.outputs.released == 'false' }}
+    permissions:
+      id-token: write # To attach provenance to the published package
     environment:
       name: npm
       url: https://www.npmjs.com/package/shescape
@@ -135,9 +137,13 @@ jobs:
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
             api.github.com:443
+            fulcio.sigstore.dev:443
             github.com:443
+            nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            rekor.sigstore.dev:443
+            sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install Node.js
@@ -151,4 +157,4 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+        run: npm publish --provenance


### PR DESCRIPTION
Relates to #559

## Summary

Update the CI-based publishing strategy for this project to use the new `--provenance` option - setup based on the [official npm docs on the provenance](https://docs.npmjs.com/generating-provenance-statements).

The goal here is to increase linkability between the npm package and the GitHub repository as well as the specific commit and CI workflow that resulted in a specific version.
