### PR TITLE
Update "Publish / Check" job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
             actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             github.com:443
+            nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
       - name: Checkout repository


### PR DESCRIPTION
Relates to #824

## Summary

Allow downloading Node.js in "Publish / Check".

All jobs that install Node.js were checked to include this endpoint in their egress policy.