### PR TITLE
Update metadata homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Update the package homepage. ([#827])
 
 ## [1.6.6] - 2023-04-20
 
@@ -243,6 +243,7 @@ Versioning].
 [#710]: https://github.com/ericcornelissen/shescape/pull/710
 [#761]: https://github.com/ericcornelissen/shescape/pull/761
 [#823]: https://github.com/ericcornelissen/shescape/pull/823
+[#827]: https://github.com/ericcornelissen/shescape/pull/827
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shescape",
   "version": "1.6.6",
   "description": "simple shell escape library",
-  "homepage": "https://ericcornelissen.github.io/shescape/",
+  "homepage": "https://github.com/ericcornelissen/shescape#readme",
   "license": "MPL-2.0",
   "type": "module",
   "main": "./index.cjs",


### PR DESCRIPTION
## Summary

Update the [homepage for the package](https://github.com/ericcornelissen/shescape/blob/5d1de2a868d6f6c41108c23dbb085be6a63b6b42/package.json#L5). The old URL is for a GitHub Pages page that has been offline for a while now. Instead, just refer to the project README as a homepage.