### PR TITLE
Stop using Stryker Dashboard

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -464,14 +464,15 @@ jobs:
         run: npm clean-install
       - name: Run mutation tests (incremental)
         if: ${{ steps.changes.outputs.unit-tests == 'false' }}
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: npm run test:mutation -- --incremental
       - name: Run mutation tests (non-incremental)
         if: ${{ steps.changes.outputs.unit-tests == 'true' }}
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: npm run test:mutation -- --incremental --force
+      - name: Upload mutation report
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: mutation-report
+          path: _reports/mutation/index.html
   test-unit:
     name: Unit
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![GitHub Actions][ci-image]][ci-url]
 [![Coverage Report][coverage-image]][coverage-url]
-[![Mutation Report][mutation-image]][mutation-url]
 [![npm Package][npm-image]][npm-url]
 
 A simple shell escape library for JavaScript. Use it to escape user-controlled
@@ -75,8 +74,6 @@ how to improve the documentation.
 [ci-image]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml/badge.svg
 [coverage-url]: https://codecov.io/gh/ericcornelissen/shescape
 [coverage-image]: https://codecov.io/gh/ericcornelissen/shescape/branch/main/graph/badge.svg
-[mutation-url]: https://dashboard.stryker-mutator.io/reports/github.com/ericcornelissen/shescape/main
-[mutation-image]: https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fericcornelissen%2Fshescape%2Fmain
 [npm-url]: https://www.npmjs.com/package/shescape
 [npm-image]: https://img.shields.io/npm/v/shescape.svg
 [an issue]: https://github.com/ericcornelissen/shescape/issues

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -10,7 +10,7 @@ export default {
   incremental: false,
   incrementalFile: ".cache/stryker-incremental.json",
   timeoutMS: 10000,
-  reporters: ["clear-text", "dashboard", "html", "progress"],
+  reporters: ["clear-text", "html", "progress"],
   htmlReporter: {
     fileName: "_reports/mutation/index.html",
   },


### PR DESCRIPTION
Closes #777
Relates to #117

## Summary

Remove the use of the Stryker Dashboard. In the CI, replace this by uploading the report as artifact so that it isn't necessary to rerun mutation tests locally to reproduce the report.

## Post-merge checklist

- [ ] Remove `STRYKER_DASHBOARD_API_KEY` secret
- [ ] Disconnect Stryker Dashboard integration