### PR TITLE
Update Codecov config for e2e flags

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,18 +22,15 @@ flags:
   e2e-MacOS:
     carryforward: true
     paths:
-      - src/*.js
-      - index.js
+      - index.cjs
   e2e-Ubuntu:
     carryforward: true
     paths:
-      - src/*.js
-      - index.js
+      - index.cjs
   e2e-Windows:
     carryforward: true
     paths:
-      - src/*.js
-      - index.js
+      - index.cjs
   integration-MacOS:
     carryforward: true
     paths:


### PR DESCRIPTION
Relates to #448, #593

## Summary

Running e2e tests currently always uses `index.cjs`, so only that file has coverage. The Codecov e2e flags were configured to look at files not including this file, hence Codecov wasn't able to derive any coverage data for e2e tests.
