### PR TITLE
Stop uploading coverage of end-to-end tests to Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,21 +19,6 @@ comment:
   require_head: yes
 
 flags:
-  e2e-MacOS:
-    carryforward: true
-    paths:
-      - src/*.js
-      - index.js
-  e2e-Ubuntu:
-    carryforward: true
-    paths:
-      - src/*.js
-      - index.js
-  e2e-Windows:
-    carryforward: true
-    paths:
-      - src/*.js
-      - index.js
   integration-MacOS:
     carryforward: true
     paths:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -362,12 +362,6 @@ jobs:
         run: sudo apt-get --assume-yes install csh
       - name: Run end-to-end tests
         run: npm run coverage:e2e
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # v3.1.3
-        if: ${{ always() }}
-        with:
-          file: ./_reports/coverage/e2e/lcov.info
-          flags: e2e-${{ matrix.name }}
   test-integration:
     name: Integration (${{ matrix.name }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Supersedes #840

## Summary

Remove end-to-end test coverage from the Codecov configuration file and stop uploading coverage data for the end-to-end tests to Codecov. This follows from observed errors in the Codecov dashboard, following <https://docs.codecov.com/docs/error-reference> it seems this is due to the fact that the end-to-end tests report coverage on generated files exclusively.