### PR TITLE
Bump transitive dependency `yaml`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11871,9 +11871,9 @@
       }
     },
     "node_modules/yaml-eslint-parser/node_modules/yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"


### PR DESCRIPTION
## Summary

Bump `eslint-plugin-yml`>`yaml-eslint-parser`>`yaml` from v2.2.1 to v2.2.2 given GHSA-f9xv-q969-pqx4