### PR TITLE
Add explicit license for documentation and snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,6 +360,9 @@ documentation:
 - Links should have descriptive text.
 - Documents and sections should have introductions.
 
+This kind of documentation is to be made available under the [CC BY-SA 4.0]
+license with code snippets available under the [MIT] license.
+
 ### Code Documentation
 
 The source code of _Shescape_ is documented following the [JSDoc] standard. In
@@ -475,6 +478,7 @@ const john = "John Doe";
 [actionlint]: https://github.com/rhysd/actionlint
 [assert package]: https://nodejs.org/api/assert.html
 [ava]: https://github.com/avajs/ava
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [bug report]: https://github.com/ericcornelissen/shescape/issues/new?labels=bug&template=bug_report.md
 [docker]: https://www.docker.com/
 [editorconfig]: https://editorconfig.org/
@@ -491,6 +495,7 @@ const john = "John Doe";
 [licensee]: https://www.npmjs.com/package/licensee
 [markdown]: https://en.wikipedia.org/wiki/Markdown
 [markdownlint]: https://github.com/DavidAnson/markdownlint
+[mit]: https://opensource.org/license/mit/
 [mocha]: https://mochajs.org/
 [mutation testing]: https://en.wikipedia.org/wiki/Mutation_testing
 [node.js]: https://nodejs.org/en/

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Read the [tips] for additional ways to protect against shell injection.
 
 ---
 
-Please [open an issue] if you found a mistake or if you have a suggestion for
-how to improve the documentation.
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
 
 [ci-url]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml
 [ci-image]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml/badge.svg
@@ -79,12 +78,13 @@ how to improve the documentation.
 [an issue]: https://github.com/ericcornelissen/shescape/issues
 [api]: docs/api.md
 [bash]: https://en.wikipedia.org/wiki/Bash_(Unix_shell) "Bourne-Again Shell"
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [changelog]: https://github.com/ericcornelissen/shescape/blob/main/CHANGELOG.md
 [cmd.exe]: https://en.wikipedia.org/wiki/Cmd.exe
 [csh]: https://en.wikipedia.org/wiki/C_shell
 [dash]: https://en.wikipedia.org/wiki/Almquist_shell#Dash "Debian Almquist Shell"
 [license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE
-[open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md
+[mit]: https://opensource.org/license/mit/
 [powershell]: https://en.wikipedia.org/wiki/PowerShell
 [recipes]: docs/recipes.md
 [security]: https://github.com/ericcornelissen/shescape/blob/main/SECURITY.md

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,4 +41,10 @@ the input array), the escaped arguments.
 Non-array inputs are converted to single-value arrays. Non-string arguments are
 converted to strings; an error is thrown if this is not possible.
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
+[mit]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -529,6 +529,10 @@ if (echo.error) {
 }
 ```
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
 [`exec`]: https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback
 [`execfile`]: https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
 [`execsync`]: https://nodejs.org/api/child_process.html#child_processexecsynccommand-options
@@ -537,5 +541,7 @@ if (echo.error) {
 [`node:child_process`]: https://nodejs.org/api/child_process.html
 [`spawn`]: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
 [`spawnsync`]: https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
+[mit]: https://opensource.org/license/mit/
 [nodejs/node#43333]: https://github.com/nodejs/node/issues/43333
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,13 @@ import { functionUnderTest } from "./my-module.js";
 assert.ok(functionUnderTest(stubscape));
 ```
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
 [jest-module-mock]: https://jestjs.io/docs/manual-mocks#mocking-node-modules
+[mit]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md
 [test stub]: https://en.wikipedia.org/wiki/Test_stub

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -74,4 +74,10 @@ against shell injection. This is because it is likely you will forget to block
 something. If you think your only option is a blocklist, use a shell escape
 library like Shescape instead.
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
+[mit]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md


### PR DESCRIPTION
Relates to #789

## Summary

Make documentation text available under CC BY-SA 4.0 and snippets under the MIT license (like most tests and scripts).