### PR TITLE
Improve mutation report artifact

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -465,7 +465,7 @@ jobs:
       - name: Upload mutation report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: mutation-report
+          name: mutation-report-${{ github.sha }}
           path: _reports/mutation/index.html
   test-unit:
     name: Unit


### PR DESCRIPTION
Relates to #838

## Summary

Make downloading the mutation report more convenient by making the name unique as well as identifiable from one run to the next. The commit SHA will be unique (otherwise git breaks) and also allows the user to relate the report to a particular commit, thus providing additional context on any mutants found.