### PR TITLE
Set `retention-days` for the index-common-js artifact

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -537,6 +537,7 @@ jobs:
         with:
           name: index-common-js
           path: index.cjs
+          retention-days: 1
   trivy:
     name: Trivy
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #472

## Summary

The artifact is only intended for re-use across jobs. As such, it can be deleted as soon as the workflow ends/possible.

See also [the `actions/upload-artifact` docs on Retention Period](https://github.com/actions/upload-artifact/tree/65d862660abb392b8c4a3d1195a2108db131dd05#retention-period).