### PR TITLE
Improve link text for the MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,7 +361,7 @@ documentation:
 - Documents and sections should have introductions.
 
 This kind of documentation is to be made available under the [CC BY-SA 4.0]
-license with code snippets available under the [MIT] license.
+license with code snippets available under the [MIT license].
 
 ### Code Documentation
 
@@ -495,7 +495,7 @@ const john = "John Doe";
 [licensee]: https://www.npmjs.com/package/licensee
 [markdown]: https://en.wikipedia.org/wiki/Markdown
 [markdownlint]: https://github.com/DavidAnson/markdownlint
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [mocha]: https://mochajs.org/
 [mutation testing]: https://en.wikipedia.org/wiki/Mutation_testing
 [node.js]: https://nodejs.org/en/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Read the [tips] for additional ways to protect against shell injection.
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [ci-url]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml
 [ci-image]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml/badge.svg
@@ -84,7 +84,7 @@ _Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
 [csh]: https://en.wikipedia.org/wiki/C_shell
 [dash]: https://en.wikipedia.org/wiki/Almquist_shell#Dash "Debian Almquist Shell"
 [license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [powershell]: https://en.wikipedia.org/wiki/PowerShell
 [recipes]: docs/recipes.md
 [security]: https://github.com/ericcornelissen/shescape/blob/main/SECURITY.md

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,8 +43,8 @@ converted to strings; an error is thrown if this is not possible.
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -531,7 +531,7 @@ if (echo.error) {
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [`exec`]: https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback
 [`execfile`]: https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
@@ -542,6 +542,6 @@ _Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
 [`spawn`]: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
 [`spawnsync`]: https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [nodejs/node#43333]: https://github.com/nodejs/node/issues/43333
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,11 +36,11 @@ assert.ok(functionUnderTest(stubscape));
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
 [jest-module-mock]: https://jestjs.io/docs/manual-mocks#mocking-node-modules
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md
 [test stub]: https://en.wikipedia.org/wiki/Test_stub

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -76,8 +76,8 @@ library like Shescape instead.
 
 ---
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT] license._
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 
 [cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
-[mit]: https://opensource.org/license/mit/
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md


### PR DESCRIPTION
Relates to #852

## Summary

Change the link text for the MIT license from "MIT" to "MIT license" as _"MIT"_ could just as easily refer to MIT the institute.