### PR TITLE
Use the current commit SHA in CI artifact names

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -434,6 +434,11 @@ jobs:
             registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - name: Get git context
+        id: git
+        run: |
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
@@ -465,7 +470,7 @@ jobs:
       - name: Upload mutation report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: mutation-report-${{ github.sha }}
+          name: mutation-report-${{ steps.git.outputs.commit-sha }}
           path: _reports/mutation/index.html
   test-unit:
     name: Unit

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -66,6 +66,11 @@ jobs:
             registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - name: Get git context
+        id: git
+        run: |
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Create identifier
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: run-id
@@ -125,7 +130,7 @@ jobs:
         if: ${{ steps.fuzz.outputs.fuzz-error == 'true' }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: fuzz-crash-${{ steps.run-id.outputs.result }}-${{ github.sha }}
+          name: fuzz-crash-${{ steps.run-id.outputs.result }}-${{ steps.git.outputs.commit-sha }}
           path: |
             .corpus/
             crash-*


### PR DESCRIPTION
Relates to #854, #862

## Summary

Iterates on the related Pull Requests by using the checkout out commit SHA instead of the GitHub context SHA. The GitHub context SHA is the same regardless of the checked out commit, and for the `pull_request` target it's actually a "non-existent" commit that's a staged result of merging the `HEAD` and `BASE`.