### PR TITLE
Use `shell: bash` in reusable fuzz workflow for Windows support

### DIFF
--- a/.github/workflows/checks-windows.yml
+++ b/.github/workflows/checks-windows.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   fuzz:
     name: Fuzz
-    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@fix-fuzz-job-windows
+    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
     with:
       duration: 5m
       platform: windows

--- a/.github/workflows/checks-windows.yml
+++ b/.github/workflows/checks-windows.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   fuzz:
     name: Fuzz
-    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
+    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@fix-fuzz-job-windows
     with:
       duration: 5m
       platform: windows

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Get git context
+        shell: bash
         id: git
         run: |
           COMMIT_SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
Relates to #862, #864

## Summary

Addresses failure in CI run <https://github.com/ericcornelissen/shescape/actions/runs/4883357188>

Use `shell: bash` to ["Get git context"](https://github.com/ericcornelissen/shescape/blob/2105379debd9adc8c0e8ad04734ab732c5e1aa9f/.github/workflows/reusable-fuzz.yml#L69-L73), otherwise the step fails as the syntax being used isn't supported by PowerShell.
