### PR TITLE
Separate benchmarking from testing

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -639,6 +639,7 @@ overrides:
   # Unpublished code
   - files:
       - .github/**
+      - bench/**
       - script/**
       - test/**
     rules:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 # Check out Labeler at: https://github.com/actions/labeler
 
+benchmark:
+  - bench/**
+
 ci/cd:
   - .github/workflows/*
   - .github/codecov.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,8 +155,8 @@ The project is vetted using a small collection of static analysis tools. Run
 
 #### Benchmarking
 
-The project has a simple benchmarking suite that can be found at `test/bench`.
-It is used to detect performance regressions in the escaping logic. To this end
+The project has a simple benchmarking suite that can be found at `bench/`. It is
+used to detect performance regressions in the escaping logic. To this end
 they're run continuously in the project's continuous integration. You can run
 the benchmarks locally using `npm run benchmark`.
 

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -12,10 +12,10 @@ import {
   binDash,
   binPowerShell,
   binZsh,
-} from "../_constants.cjs";
+} from "../test/_constants.cjs";
 
-import * as unix from "../../src/unix.js";
-import * as win from "../../src/win.js";
+import * as unix from "../src/unix.js";
+import * as win from "../src/win.js";
 
 const sampleArg = "foobar";
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "_prettier": "prettier ./**/*.{cjs,js,json,md,yml} --ignore-path .gitignore",
     "audit": "npm audit",
     "audit:runtime": "npm audit --omit dev",
-    "benchmark": "node test/bench/bench.js",
+    "benchmark": "node bench/bench.js",
     "clean": "node script/clean.js",
     "coverage": "npm run coverage:unit",
     "coverage:compat": "npm run _coverage -- --reports-dir=_reports/coverage/compat npm run test:compat",


### PR DESCRIPTION
Relates to #273, #798

## Summary

Move benchmarking code out of the testing directory and into a new top-level directory dedicated to benchmarking called 'bench'. Also use this change to add a new rule to the Labeler Action for automatically assigning the "benchmark" label.