### PR TITLE
Property test transpiled CJS against ESM input-output

### DIFF
--- a/test/integration/escape-all.test.js
+++ b/test/integration/escape-all.test.js
@@ -83,3 +83,13 @@ for (const { escapeAll, type } of cases) {
     escapeAll(["a"], payload);
   });
 }
+
+testProp(
+  'esm === cjs',
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const resultEsm = escapeAllEsm(args, options);
+    const resultCjs = escapeAllCjs(args, options);
+    t.deepEqual(resultEsm, resultCjs);
+  }
+);

--- a/test/integration/escape-all.test.js
+++ b/test/integration/escape-all.test.js
@@ -85,7 +85,7 @@ for (const { escapeAll, type } of cases) {
 }
 
 testProp(
-  'esm === cjs',
+  "esm === cjs",
   [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
   (t, args, options) => {
     const resultEsm = escapeAllEsm(args, options);

--- a/test/integration/escape.test.js
+++ b/test/integration/escape.test.js
@@ -40,7 +40,7 @@ for (const { escape, type } of cases) {
 }
 
 testProp(
-  'esm === cjs',
+  "esm === cjs",
   [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
     const resultEsm = escapeEsm(arg, options);

--- a/test/integration/escape.test.js
+++ b/test/integration/escape.test.js
@@ -38,3 +38,13 @@ for (const { escape, type } of cases) {
     escape("a", payload);
   });
 }
+
+testProp(
+  'esm === cjs',
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const resultEsm = escapeEsm(arg, options);
+    const resultCjs = escapeCjs(arg, options);
+    t.is(resultEsm, resultCjs);
+  }
+);

--- a/test/integration/quote-all.test.js
+++ b/test/integration/quote-all.test.js
@@ -82,7 +82,7 @@ for (const { quoteAll, type } of cases) {
 }
 
 testProp(
-  'esm === cjs',
+  "esm === cjs",
   [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
   (t, args, options) => {
     const resultEsm = quoteAllEsm(args, options);

--- a/test/integration/quote-all.test.js
+++ b/test/integration/quote-all.test.js
@@ -80,3 +80,13 @@ for (const { quoteAll, type } of cases) {
     quoteAll(["a"], payload);
   });
 }
+
+testProp(
+  'esm === cjs',
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const resultEsm = quoteAllEsm(args, options);
+    const resultCjs = quoteAllCjs(args, options);
+    t.deepEqual(resultEsm, resultCjs);
+  }
+);

--- a/test/integration/quote.test.js
+++ b/test/integration/quote.test.js
@@ -37,3 +37,13 @@ for (const { quote, type } of cases) {
     quote("a", payload);
   });
 }
+
+testProp(
+  'esm === cjs',
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const resultEsm = quoteEsm(arg, options);
+    const resultCjs = quoteCjs(arg, options);
+    t.is(resultEsm, resultCjs);
+  }
+);

--- a/test/integration/quote.test.js
+++ b/test/integration/quote.test.js
@@ -39,7 +39,7 @@ for (const { quote, type } of cases) {
 }
 
 testProp(
-  'esm === cjs',
+  "esm === cjs",
   [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
     const resultEsm = quoteEsm(arg, options);


### PR DESCRIPTION
## Summary

Create new integration property tests that run the ESM as well as transpiled CJS on the same input (argument(s)+options) and asserts the outputs are the same for all public API functions.