### PR TITLE
Simplify replacements in accordance with `regexp/prefer-lookaround`

### DIFF
--- a/src/unix.js
+++ b/src/unix.js
@@ -59,7 +59,7 @@ function escapeArgBash(arg, { interpolation, quoted }) {
     result = result
       .replace(/\\/gu, "\\\\")
       .replace(/\r?\n/gu, " ")
-      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/(?<=^|\s)([#~])/gu, "\\$1")
       .replace(/(["$&'()*;<>?`{|])/gu, "\\$1")
       .replace(/(?<=[:=])(~)(?=[\s+\-/0:=]|$)/gu, "\\$1")
       .replace(/([\t ])/gu, "\\$1");
@@ -87,7 +87,7 @@ function escapeArgCsh(arg, { interpolation, quoted }) {
   if (interpolation) {
     result = result
       .replace(/\\/gu, "\\\\")
-      .replace(/(^|\s)(~)/gu, "$1\\$2")
+      .replace(/(?<=^|\s)(~)/gu, "\\$1")
       .replace(/(["#$&'()*;<>?[`{|])/gu, "\\$1")
       .replace(/([\t ])/gu, "\\$1");
 
@@ -133,7 +133,7 @@ function escapeArgDash(arg, { interpolation, quoted }) {
     result = result
       .replace(/\\/gu, "\\\\")
       .replace(/\r?\n/gu, " ")
-      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/(?<=^|\s)([#~])/gu, "\\$1")
       .replace(/(["$&'()*;<>?`|])/gu, "\\$1")
       .replace(/([\t\n ])/gu, "\\$1");
   } else if (quoted) {
@@ -161,7 +161,7 @@ function escapeArgZsh(arg, { interpolation, quoted }) {
     result = result
       .replace(/\\/gu, "\\\\")
       .replace(/\r?\n/gu, " ")
-      .replace(/(^|\s)([#=~])/gu, "$1\\$2")
+      .replace(/(?<=^|\s)([#=~])/gu, "\\$1")
       .replace(/(["$&'()*;<>?[\]`{|}])/gu, "\\$1")
       .replace(/([\t ])/gu, "\\$1");
   } else if (quoted) {


### PR DESCRIPTION
Relates to #373, #870

## Summary

Update some of the replacement in Unix specific code to equivalent replacements that preserve more of the string (i.e. replace fewer characters).

This was reported by the [`regexp/prefer-lookaround`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-lookaround.html) rule on #870. I haven't yet figured out why this problem isn't being reported by the [eslint-plugin-regexp](https://github.com/ota-meshi/eslint-plugin-regexp) with the current implementation.