### PR TITLE
Improve mutation report artifact

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -469,6 +469,7 @@ jobs:
         run: npm run test:mutation -- --incremental --force
       - name: Upload mutation report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ failure() || success() }}
         with:
           name: mutation-report-${{ steps.git.outputs.commit-sha }}
           path: _reports/mutation/index.html

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -472,7 +472,9 @@ jobs:
         if: ${{ failure() || success() }}
         with:
           name: mutation-report-${{ steps.git.outputs.commit-sha }}
-          path: _reports/mutation/index.html
+          path: |
+            _reports/mutation/index.html
+            .cache/stryker-incremental.json
   test-unit:
     name: Unit
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #854

## Summary

Further improve the mutation report artifact uploaded from the CI to:

1. Be created even if mutation testing fails (e.g. because the 100% threshold isn't met).
2. Include the incremental data for local use.