### PR TITLE
Simplify replacements in accordance with `regexp/prefer-lookaround`

### DIFF
--- a/src/win.js
+++ b/src/win.js
@@ -66,8 +66,8 @@ function escapeArgPowerShell(arg, { interpolation, quoted }) {
   if (interpolation) {
     result = result
       .replace(/\r?\n/gu, " ")
-      .replace(/(^|[\s\u0085])([*1-6]?)(>)/gu, "$1$2`$3")
-      .replace(/(^|[\s\u0085])([#\-:<@\]])/gu, "$1`$2")
+      .replace(/(?<=^|[\s\u0085])([*1-6]?)(>)/gu, "$1`$2")
+      .replace(/(?<=^|[\s\u0085])([#\-:<@\]])/gu, "`$1")
       .replace(/(["&'(),;{|}‘’‚‛“”„])/gu, "`$1")
       .replace(/([\s\u0085])/gu, "`$1");
   } else if (quoted) {


### PR DESCRIPTION
Relates to #373, #870, #874

## Summary

Update some of the replacement in Windows specific code to equivalent replacements that preserve more of the string (i.e. replace fewer characters).

This was reported by the [`regexp/prefer-lookaround`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-lookaround.html) rule on #870. I haven't yet figured out why this problem isn't being reported by the [eslint-plugin-regexp](https://github.com/ota-meshi/eslint-plugin-regexp) with the current implementation.