### PR TITLE
Improve `format(:check)` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "pretest:integration": "npm run transpile",
     "_coverage": "c8 --reporter=lcov --reporter=text",
     "_eslint": "eslint . --report-unused-disable-directives",
-    "_prettier": "prettier ./**/*.{cjs,js,json,md,yml} --ignore-path .gitignore",
+    "_prettier": "prettier . --ignore-path .gitignore",
     "audit": "npm audit",
     "audit:runtime": "npm audit --omit dev",
     "benchmark": "node bench/bench.js",


### PR DESCRIPTION
Relates to #135

## Summary

Fix problems with the `format` and `format:check` commands not covering all files on all systems. The approach taken here is taken from [the Prettier docs](https://prettier.io/docs/en/install.html).