### PR TITLE
Provide injection strings for testing purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Provide injection strings for testing purposes. ([#902])
 - Update the package homepage. ([#827])
 
 ## [1.6.6] - 2023-04-20
@@ -244,6 +245,7 @@ Versioning].
 [#761]: https://github.com/ericcornelissen/shescape/pull/761
 [#823]: https://github.com/ericcornelissen/shescape/pull/823
 [#827]: https://github.com/ericcornelissen/shescape/pull/827
+[#902]: https://github.com/ericcornelissen/shescape/pull/902
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,23 +6,14 @@ utilities in your tests.
 Please [open an issue] if you found a mistake or if you have a suggestion for
 how to improve the documentation.
 
-## Why
-
-The behaviour of Shescape depends on external factors such as the operating
-system it is running on and environment variables. This may not be desirable in
-your tests, especially in unit tests.
-
-To avoid unexpected behavior you can use the [test stub]s provided by Shescape
-as a drop-in replacement during testing.
-
-> **Warning**: If the code under test invokes a command you should **not** use
-> these stubs.
-
-## How
+## Stubs
 
 Shescape [test stub]s are provided as named imports at `"shescape/testing"`. Use
 them in your tests through [dependency injection] (example below) or module
 mocking ([for example with Jest][jest-module-mock]).
+
+> **Warning**: If the code under test invokes a command you should **not** use
+> these stubs.
 
 ```javascript
 // my-module.test.js
@@ -32,6 +23,36 @@ import { shescape as stubscape } from "shescape/testing";
 import { functionUnderTest } from "./my-module.js";
 
 assert.ok(functionUnderTest(stubscape));
+```
+
+### Why Stubs
+
+The behaviour of Shescape depends on external factors such as the operating
+system it is running on and environment variables. This may not be desirable in
+your tests, especially in unit tests.
+
+To avoid unexpected behavior you can use the [test stub]s provided by Shescape
+as a drop-in replacement during testing.
+
+## Fixtures
+
+Test fixtures are provided to help you write tests that ensure Shescape is used
+correctly to avoid shell injection. Use these fixtures carefully, as incorrect
+usage may lead to a false belief that Shescape is being used effectively.
+
+In contrast to stubs, these values should be used in tests that invoke Shescape.
+
+```javascript
+// my-module.test.js
+
+import assert from "node:assert";
+import { injectionStrings } from "shescape/testing";
+import { functionThatIsUsingShescape } from "./my-module.js";
+
+for (const injectionString of injectionStrings) {
+  const result = functionThatIsUsingShescape(injectionString);
+  assert.equal(result, "no injection");
+}
 ```
 
 ---

--- a/test/e2e/_.js
+++ b/test/e2e/_.js
@@ -3,8 +3,8 @@
  * @license MIT
  */
 
+import { injectionStrings } from "../../testing.js";
 import * as constants from "../_constants.cjs";
 import * as macros from "./_macros.js";
-import { injectionString } from "../../testing.js";
 
-export { constants, macros, injectionString };
+export { constants, macros, injectionStrings };

--- a/test/e2e/_.js
+++ b/test/e2e/_.js
@@ -5,5 +5,6 @@
 
 import * as constants from "../_constants.cjs";
 import * as macros from "./_macros.js";
+import { injectionString } from "../../testing.js";
 
-export { constants, macros };
+export { constants, macros, injectionString };

--- a/test/e2e/child_process.test.js
+++ b/test/e2e/child_process.test.js
@@ -8,13 +8,13 @@ import test from "ava";
 import isCI from "is-ci";
 import which from "which";
 
-import { constants, macros, injectionString } from "./_.js";
+import { constants, macros, injectionStrings } from "./_.js";
 
 const systemShells = constants.isWindows
   ? constants.shellsWindows
   : constants.shellsUnix;
 
-const testArgs = ["harmless", ...injectionString];
+const testArgs = ["harmless", ...injectionStrings];
 const testShells = [false, true, ...systemShells];
 
 for (const arg of testArgs) {

--- a/test/e2e/child_process.test.js
+++ b/test/e2e/child_process.test.js
@@ -8,13 +8,13 @@ import test from "ava";
 import isCI from "is-ci";
 import which from "which";
 
-import { constants, macros } from "./_.js";
+import { constants, macros, injectionString } from "./_.js";
 
 const systemShells = constants.isWindows
   ? constants.shellsWindows
   : constants.shellsUnix;
 
-const testArgs = ["&& ls", "' ls", '" ls'];
+const testArgs = ["harmless", ...injectionString];
 const testShells = [false, true, ...systemShells];
 
 for (const arg of testArgs) {

--- a/testing.js
+++ b/testing.js
@@ -10,12 +10,12 @@ import { isStringable, toArrayIfNecessary } from "./src/reflection.js";
  * is vulnerable to shell injection.
  *
  * @example
- * for (const injection of injections) {
- *   const result = functionThatShouldBeUsingShescape(injection);
+ * for (const injectionString of injectionStrings) {
+ *   const result = functionThatIsUsingShescape(injectionString);
  *   assert.equal(result, "no injection");
  * }
  */
-export const injectionString = ["\x00world", "&& ls", "'; ls #", '"; ls #'];
+export const injectionStrings = ["\x00world", "&& ls", "'; ls #", '"; ls #'];
 
 /**
  * A test stub of shescape that has the same input-output profile as the real

--- a/testing.js
+++ b/testing.js
@@ -6,6 +6,18 @@
 import { isStringable, toArrayIfNecessary } from "./src/reflection.js";
 
 /**
+ * A list of example shell injection strings to test whether or not a function
+ * is vulnerable to shell injection.
+ *
+ * @example
+ * for (const injection of injections) {
+ *   const result = functionThatShouldBeUsingShescape(injection);
+ *   assert.equal(result, "no injection");
+ * }
+ */
+export const injectionString = ["\x00world", "&& ls", "'; ls #", '"; ls #'];
+
+/**
  * A test stub of shescape that has the same input-output profile as the real
  * shescape implementation.
  *


### PR DESCRIPTION
Relates to #710

## Summary

Include an exported value in the `shescape/testing` module that is a list of example shell injection strings for use in testing to get limited guarantee that shell injection is not possible.