### PR TITLE
Refactor internal logic for escaping strings when using `quote(All)`

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -30,12 +30,11 @@ const suite = new Benchmark.Suite("escapeShellArg", {
 
 suite.add(`unix, ${binBash}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binBash);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 const escapeShellArgBashNew = unixNew.getEscapeFunction(binBash, {
   interpolation: false,
-  quoted: false,
 });
 suite.add(`unix (new), ${binBash}, ${sampleArg}`, () => {
   escapeShellArgBashNew(sampleArg);
@@ -43,12 +42,11 @@ suite.add(`unix (new), ${binBash}, ${sampleArg}`, () => {
 
 suite.add(`unix, ${binCsh}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binCsh);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 const escapeShellArgCshNew = unixNew.getEscapeFunction(binCsh, {
   interpolation: false,
-  quoted: false,
 });
 suite.add(`unix (new), ${binCsh}, ${sampleArg}`, () => {
   escapeShellArgCshNew(sampleArg);
@@ -56,12 +54,11 @@ suite.add(`unix (new), ${binCsh}, ${sampleArg}`, () => {
 
 suite.add(`unix, ${binDash}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binDash);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 const escapeShellArgDashNew = unixNew.getEscapeFunction(binDash, {
   interpolation: false,
-  quoted: false,
 });
 suite.add(`unix (new), ${binDash}, ${sampleArg}`, () => {
   escapeShellArgDashNew(sampleArg);
@@ -69,12 +66,11 @@ suite.add(`unix (new), ${binDash}, ${sampleArg}`, () => {
 
 suite.add(`unix, ${binZsh}, ${sampleArg}`, () => {
   const escapeShellArg = unix.getEscapeFunction(binZsh);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 const escapeShellArgZshNew = unixNew.getEscapeFunction(binZsh, {
   interpolation: false,
-  quoted: false,
 });
 suite.add(`unix (new), ${binZsh}, ${sampleArg}`, () => {
   escapeShellArgZshNew(sampleArg);
@@ -82,12 +78,12 @@ suite.add(`unix (new), ${binZsh}, ${sampleArg}`, () => {
 
 suite.add(`win, ${binCmd}, ${sampleArg}`, () => {
   const escapeShellArg = win.getEscapeFunction(binCmd);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 suite.add(`win, ${binPowerShell}, ${sampleArg}`, () => {
   const escapeShellArg = win.getEscapeFunction(binPowerShell);
-  escapeShellArg(sampleArg, { interpolation: false, quoted: false });
+  escapeShellArg(sampleArg, { interpolation: false });
 });
 
 suite.run();

--- a/bench/unix.js
+++ b/bench/unix.js
@@ -12,10 +12,7 @@ import * as unixNew from "../src/unix/index.js";
 
 const targetArg = "foobar";
 const targetShell = binZsh;
-const targetOptions = {
-  interpolation: false,
-  quoted: false,
-};
+const targetOptions = { interpolation: false };
 
 const suite = new Benchmark.Suite();
 

--- a/bench/win.js
+++ b/bench/win.js
@@ -12,10 +12,7 @@ import * as winNew from "../src/win/index.js";
 
 const targetArg = "foobar";
 const targetShell = binCmd;
-const targetOptions = {
-  interpolation: false,
-  quoted: false,
-};
+const targetOptions = { interpolation: false };
 
 const suite = new Benchmark.Suite();
 

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,22 @@ const typeError =
   "Shescape requires strings or values that can be converted into a string using .toString()";
 
 /**
+ * Convert a value into a string if that is possible.
+ *
+ * @param {any} value The value to convert into a string.
+ * @returns {string} The `value` as a string.
+ * @throws {TypeError} The `value` is not stringable.
+ */
+function checkedToString(value) {
+  if (!isStringable(value)) {
+    throw new TypeError(typeError);
+  }
+
+  const valueAsString = value.toString();
+  return valueAsString;
+}
+
+/**
  * Parses options provided to {@link escapeShellArg} or {@link quoteShellArg}.
  *
  * @param {object} args The arguments for this function.
@@ -54,11 +70,7 @@ function parseOptions(
  * @throws {TypeError} The argument to escape is not stringable.
  */
 function escape({ arg, interpolation, shellName }, { getEscapeFunction }) {
-  if (!isStringable(arg)) {
-    throw new TypeError(typeError);
-  }
-
-  const argAsString = arg.toString();
+  const argAsString = checkedToString(arg);
   const escape = getEscapeFunction(shellName);
   const escapedArg = escape(argAsString, { interpolation });
   return escapedArg;
@@ -76,11 +88,7 @@ function escape({ arg, interpolation, shellName }, { getEscapeFunction }) {
  * @throws {TypeError} The argument to escape is not stringable.
  */
 function quote({ arg, shellName }, { getQuoteFunction }) {
-  if (!isStringable(arg)) {
-    throw new TypeError(typeError);
-  }
-
-  const argAsString = arg.toString();
+  const argAsString = checkedToString(arg);
   const quote = getQuoteFunction(shellName);
   const escapedAndQuotedArg = quote(argAsString);
   return escapedAndQuotedArg;

--- a/src/main.js
+++ b/src/main.js
@@ -47,24 +47,20 @@ function parseOptions(
  * @param {object} args The arguments for this function.
  * @param {string} args.arg The argument to escape.
  * @param {boolean} args.interpolation Is interpolation enabled.
- * @param {boolean} args.quoted Is `arg` being quoted.
  * @param {string} args.shellName The name of the shell to escape `arg` for.
  * @param {object} deps The dependencies for this function.
  * @param {Function} deps.getEscapeFunction Get the escape function for a shell.
  * @returns {string} The escaped argument.
  * @throws {TypeError} The argument to escape is not stringable.
  */
-function escape(
-  { arg, interpolation, quoted, shellName },
-  { getEscapeFunction }
-) {
+function escape({ arg, interpolation, shellName }, { getEscapeFunction }) {
   if (!isStringable(arg)) {
     throw new TypeError(typeError);
   }
 
   const argAsString = arg.toString();
   const escape = getEscapeFunction(shellName);
-  const escapedArg = escape(argAsString, { interpolation, quoted });
+  const escapedArg = escape(argAsString, { interpolation });
   return escapedArg;
 }
 
@@ -75,18 +71,18 @@ function escape(
  * @param {string} args.arg The argument to escape.
  * @param {string} args.shellName The name of the shell to escape `arg` for.
  * @param {object} deps The dependencies for this function.
- * @param {Function} deps.getEscapeFunction Get the escape function for a shell.
  * @param {Function} deps.getQuoteFunction Get the quote function for a shell.
  * @returns {string} The quoted and escaped argument.
  * @throws {TypeError} The argument to escape is not stringable.
  */
-function quote({ arg, shellName }, { getEscapeFunction, getQuoteFunction }) {
-  const escapedArg = escape(
-    { arg, interpolation: false, quoted: true, shellName },
-    { getEscapeFunction }
-  );
+function quote({ arg, shellName }, { getQuoteFunction }) {
+  if (!isStringable(arg)) {
+    throw new TypeError(typeError);
+  }
+
+  const argAsString = arg.toString();
   const quote = getQuoteFunction(shellName);
-  const escapedAndQuotedArg = quote(escapedArg);
+  const escapedAndQuotedArg = quote(argAsString);
   return escapedAndQuotedArg;
 }
 
@@ -118,7 +114,6 @@ export function escapeShellArg(
     {
       arg,
       interpolation: options.interpolation,
-      quoted: false,
       shellName: options.shellName,
     },
     { getEscapeFunction }
@@ -136,21 +131,17 @@ export function escapeShellArg(
  * @param {object} args.process.env The environment variables.
  * @param {object} deps The dependencies for this function.
  * @param {Function} deps.getDefaultShell Function to get the default shell.
- * @param {Function} deps.getEscapeFunction Get an escape function for a shell.
  * @param {Function} deps.getQuoteFunction Get a quote function for a shell.
  * @param {Function} deps.getShellName Function to get the name of a shell.
  * @returns {string} The quoted and escaped argument.
  */
 export function quoteShellArg(
   { arg, options: { shell }, process: { env } },
-  { getDefaultShell, getEscapeFunction, getQuoteFunction, getShellName }
+  { getDefaultShell, getQuoteFunction, getShellName }
 ) {
   const options = parseOptions(
     { options: { shell }, process: { env } },
     { getDefaultShell, getShellName }
   );
-  return quote(
-    { arg, shellName: options.shellName },
-    { getEscapeFunction, getQuoteFunction }
-  );
+  return quote({ arg, shellName: options.shellName }, { getQuoteFunction });
 }

--- a/src/unix/bash.js
+++ b/src/unix/bash.js
@@ -51,14 +51,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -67,11 +64,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in Bash.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `'${arg}'`;
+  const escapedArg = escapeForQuoted(arg);
+  return `'${escapedArg}'`;
 }
 
 /**

--- a/src/unix/bash.js
+++ b/src/unix/bash.js
@@ -22,19 +22,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in Bash when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
-    .replace(/'/gu, `'\\''`);
-}
-
-/**
  * Escape an argument for use in Bash when the argument is not being quoted (but
  * interpolation is inactive).
  *
@@ -68,7 +55,10 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "")
+    .replace(/'/gu, `'\\''`);
   return `'${escapedArg}'`;
 }
 

--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -66,14 +66,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -82,11 +79,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in csh.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `'${arg}'`;
+  const escapedArg = escapeForQuoted(arg);
+  return `'${escapedArg}'`;
 }
 
 /**

--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -32,21 +32,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in csh when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
-    .replace(/\\!$/gu, "\\\\!")
-    .replace(/'/gu, `'\\''`)
-    .replace(/!(?!$)/gu, "\\!");
-}
-
-/**
  * Escape an argument for use in csh when the argument is not being quoted (but
  * interpolation is inactive).
  *
@@ -83,7 +68,12 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r?\n|\r/gu, " ")
+    .replace(/\\!$/gu, "\\\\!")
+    .replace(/'/gu, `'\\''`)
+    .replace(/!(?!$)/gu, "\\!");
   return `'${escapedArg}'`;
 }
 

--- a/src/unix/dash.js
+++ b/src/unix/dash.js
@@ -21,19 +21,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in Dash when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
-    .replace(/'/gu, `'\\''`);
-}
-
-/**
  * Escape an argument for use in Dash when the argument is not being quoted (but
  * interpolation is inactive).
  *
@@ -67,7 +54,10 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "")
+    .replace(/'/gu, `'\\''`);
   return `'${escapedArg}'`;
 }
 

--- a/src/unix/dash.js
+++ b/src/unix/dash.js
@@ -50,14 +50,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -66,11 +63,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in Dash.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `'${arg}'`;
+  const escapedArg = escapeForQuoted(arg);
+  return `'${escapedArg}'`;
 }
 
 /**

--- a/src/unix/index.js
+++ b/src/unix/index.js
@@ -73,7 +73,6 @@ export function getDefaultShell() {
  * @param {string} shellName The name of a Unix shell.
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName, options) {
@@ -93,7 +92,7 @@ export function getEscapeFunction(shellName, options) {
  * Returns a function to quote arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Unix shell.
- * @returns {Function | undefined} A function to quote arguments.
+ * @returns {Function | undefined} A function to quote and escape arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {

--- a/src/unix/zsh.js
+++ b/src/unix/zsh.js
@@ -21,19 +21,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in Zsh when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
-    .replace(/'/gu, `'\\''`);
-}
-
-/**
  * Escape an argument for use in Zsh when the argument is not being quoted (but
  * interpolation is inactive).
  *
@@ -66,7 +53,10 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r(?!\n)/gu, "")
+    .replace(/'/gu, `'\\''`);
   return `'${escapedArg}'`;
 }
 

--- a/src/unix/zsh.js
+++ b/src/unix/zsh.js
@@ -49,14 +49,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -65,11 +62,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in Zsh.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `'${arg}'`;
+  const escapedArg = escapeForQuoted(arg);
+  return `'${escapedArg}'`;
 }
 
 /**

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -18,19 +18,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in CMD when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
-    .replace(/"/gu, `""`);
-}
-
-/**
  * Escape an argument for use in CMD when the argument is not being quoted (but
  * interpolation is inactive).
  *
@@ -63,7 +50,10 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/\r?\n|\r/gu, " ")
+    .replace(/"/gu, `""`);
   return `"${escapedArg}"`;
 }
 

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -46,14 +46,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -62,11 +59,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in CMD.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `"${arg}"`;
+  const escapedArg = escapeForQuoted(arg);
+  return `"${escapedArg}"`;
 }
 
 /**

--- a/src/win/index.js
+++ b/src/win/index.js
@@ -62,7 +62,6 @@ export function getDefaultShell({ env: { ComSpec } }) {
  * @param {string} shellName The name of a Windows shell.
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName, options) {
@@ -78,7 +77,7 @@ export function getEscapeFunction(shellName, options) {
  * Returns a function to quote arguments for use in a particular shell.
  *
  * @param {string} shellName The name of a Windows shell.
- * @returns {Function | undefined} A function to quote arguments.
+ * @returns {Function | undefined} A function to quote and escape arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -23,21 +23,6 @@ function escapeForInterpolation(arg) {
 }
 
 /**
- * Escape an argument for use in PowerShell when the argument is being quoted.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
- */
-function escapeForQuoted(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/`/gu, "``")
-    .replace(/\$/gu, "`$$")
-    .replace(/\r(?!\n)/gu, "")
-    .replace(/(["“”„])/gu, "$1$1");
-}
-
-/**
  * Escape an argument for use in PowerShell when the argument is not being
  * quoted (but interpolation is inactive).
  *
@@ -75,7 +60,12 @@ export function getEscapeFunction(options) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  const escapedArg = escapeForQuoted(arg);
+  const escapedArg = arg
+    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/`/gu, "``")
+    .replace(/\$/gu, "`$$")
+    .replace(/\r(?!\n)/gu, "")
+    .replace(/(["“”„])/gu, "$1$1");
   return `"${escapedArg}"`;
 }
 

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -58,14 +58,11 @@ function escapeForUnquoted(arg) {
  *
  * @param {object} options The options for escaping arguments.
  * @param {boolean} options.interpolation Is interpolation enabled.
- * @param {boolean} options.quoted Will the arguments be quoted.
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction(options) {
   if (options.interpolation) {
     return escapeForInterpolation;
-  } else if (options.quoted) {
-    return escapeForQuoted;
   } else {
     return escapeForUnquoted;
   }
@@ -74,11 +71,12 @@ export function getEscapeFunction(options) {
 /**
  * Quotes an argument for use in PowerShell.
  *
- * @param {string} arg The argument to quote.
- * @returns {string} The quoted argument.
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `"${arg}"`;
+  const escapedArg = escapeForQuoted(arg);
+  return `"${escapedArg}"`;
 }
 
 /**

--- a/test/fixtures/unix.js
+++ b/test/fixtures/unix.js
@@ -5143,24 +5143,36 @@ export const quote = {
     ],
     "exclamation marks ('!')": [
       {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a!",
+        expected: "'\\!a!'",
+      },
+      {
         input: "a!b",
         expected: "'a\\!b'",
+      },
+      {
+        input: "a!b!",
+        expected: "'a\\!b!'",
       },
       {
         input: "a!b!c",
         expected: "'a\\!b\\!c'",
       },
       {
-        input: "a!",
-        expected: "'a!'",
-      },
-      {
-        input: "!a",
-        expected: "'\\!a'",
-      },
-      {
         input: "a\\!",
         expected: "'a\\\\!'",
+      },
+      {
+        input: "\\!a",
+        expected: "'\\\\!a'",
+      },
+      {
+        input: "a\\!b",
+        expected: "'a\\\\!b'",
       },
     ],
   },

--- a/test/fixtures/unix.js
+++ b/test/fixtures/unix.js
@@ -773,7 +773,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b",
           noInterpolation: "a'b",
-          quoted: "a'\\''b",
         },
       },
       {
@@ -781,7 +780,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b\\'c",
           noInterpolation: "a'b'c",
-          quoted: "a'\\''b'\\''c",
         },
       },
     ],
@@ -2057,7 +2055,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b",
           noInterpolation: "a'b",
-          quoted: "a'\\''b",
         },
       },
       {
@@ -2065,7 +2062,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b\\'c",
           noInterpolation: "a'b'c",
-          quoted: "a'\\''b'\\''c",
         },
       },
     ],
@@ -3324,7 +3320,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b",
           noInterpolation: "a'b",
-          quoted: "a'\\''b",
         },
       },
       {
@@ -3332,7 +3327,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b\\'c",
           noInterpolation: "a'b'c",
-          quoted: "a'\\''b'\\''c",
         },
       },
     ],
@@ -4560,7 +4554,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b",
           noInterpolation: "a'b",
-          quoted: "a'\\''b",
         },
       },
       {
@@ -4568,7 +4561,6 @@ export const escape = {
         expected: {
           interpolation: "a\\'b\\'c",
           noInterpolation: "a'b'c",
-          quoted: "a'\\''b'\\''c",
         },
       },
     ],
@@ -4876,7 +4868,147 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: "'a'", notEscaped: "'a'" },
+        expected: "'a'",
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: "'ab'",
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: "'abc'",
+      },
+      {
+        input: "a\x00",
+        expected: "'a'",
+      },
+      {
+        input: "\x00a",
+        expected: "'a'",
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\bb\bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\b",
+        expected: "'a'",
+      },
+      {
+        input: "\ba",
+        expected: "'a'",
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: "'a\nb'",
+      },
+      {
+        input: "a\nb\nc",
+        expected: "'a\nb\nc'",
+      },
+      {
+        input: "a\n",
+        expected: "'a\n'",
+      },
+      {
+        input: "\na",
+        expected: "'\na'",
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\rb\rc",
+        expected: "'abc'",
+      },
+      {
+        input: "\ra",
+        expected: "'a'",
+      },
+      {
+        input: "a\r",
+        expected: "'a'",
+      },
+      {
+        input: "a\r\nb",
+        expected: "'a\r\nb'",
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u001B",
+        expected: "'a'",
+      },
+      {
+        input: "\u001Ba",
+        expected: "'a'",
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u009B",
+        expected: "'a'",
+      },
+      {
+        input: "\u009Ba",
+        expected: "'a'",
+      },
+    ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: "'a'\\''b'",
+      },
+      {
+        input: "a'b'c",
+        expected: "'a'\\''b'\\''c'",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "'a!b'",
+      },
+      {
+        input: "a!b!c",
+        expected: "'a!b!c'",
+      },
+      {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a",
+        expected: "'!a'",
       },
     ],
   },
@@ -4884,7 +5016,151 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: "'a'", notEscaped: "'a'" },
+        expected: "'a'",
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: "'ab'",
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: "'abc'",
+      },
+      {
+        input: "a\x00",
+        expected: "'a'",
+      },
+      {
+        input: "\x00a",
+        expected: "'a'",
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\bb\bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\b",
+        expected: "'a'",
+      },
+      {
+        input: "\ba",
+        expected: "'a'",
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: "'a b'",
+      },
+      {
+        input: "a\nb\nc",
+        expected: "'a b c'",
+      },
+      {
+        input: "a\n",
+        expected: "'a '",
+      },
+      {
+        input: "\na",
+        expected: "' a'",
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: "'a b'",
+      },
+      {
+        input: "a\rb\rc",
+        expected: "'a b c'",
+      },
+      {
+        input: "\ra",
+        expected: "' a'",
+      },
+      {
+        input: "a\r",
+        expected: "'a '",
+      },
+      {
+        input: "a\r\nb",
+        expected: "'a b'",
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u001B",
+        expected: "'a'",
+      },
+      {
+        input: "\u001Ba",
+        expected: "'a'",
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u009B",
+        expected: "'a'",
+      },
+      {
+        input: "\u009Ba",
+        expected: "'a'",
+      },
+    ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: "'a'\\''b'",
+      },
+      {
+        input: "a'b'c",
+        expected: "'a'\\''b'\\''c'",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "'a\\!b'",
+      },
+      {
+        input: "a!b!c",
+        expected: "'a\\!b\\!c'",
+      },
+      {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a",
+        expected: "'\\!a'",
+      },
+      {
+        input: "a\\!",
+        expected: "'a\\\\!'",
       },
     ],
   },
@@ -4892,7 +5168,147 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: "'a'", notEscaped: "'a'" },
+        expected: "'a'",
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: "'ab'",
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: "'abc'",
+      },
+      {
+        input: "a\x00",
+        expected: "'a'",
+      },
+      {
+        input: "\x00a",
+        expected: "'a'",
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\bb\bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\b",
+        expected: "'a'",
+      },
+      {
+        input: "\ba",
+        expected: "'a'",
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: "'a\nb'",
+      },
+      {
+        input: "a\nb\nc",
+        expected: "'a\nb\nc'",
+      },
+      {
+        input: "a\n",
+        expected: "'a\n'",
+      },
+      {
+        input: "\na",
+        expected: "'\na'",
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\rb\rc",
+        expected: "'abc'",
+      },
+      {
+        input: "\ra",
+        expected: "'a'",
+      },
+      {
+        input: "a\r",
+        expected: "'a'",
+      },
+      {
+        input: "a\r\nb",
+        expected: "'a\r\nb'",
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u001B",
+        expected: "'a'",
+      },
+      {
+        input: "\u001Ba",
+        expected: "'a'",
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u009B",
+        expected: "'a'",
+      },
+      {
+        input: "\u009Ba",
+        expected: "'a'",
+      },
+    ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: "'a'\\''b'",
+      },
+      {
+        input: "a'b'c",
+        expected: "'a'\\''b'\\''c'",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "'a!b'",
+      },
+      {
+        input: "a!b!c",
+        expected: "'a!b!c'",
+      },
+      {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a",
+        expected: "'!a'",
       },
     ],
   },
@@ -4900,7 +5316,147 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: "'a'", notEscaped: "'a'" },
+        expected: "'a'",
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: "'ab'",
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: "'abc'",
+      },
+      {
+        input: "a\x00",
+        expected: "'a'",
+      },
+      {
+        input: "\x00a",
+        expected: "'a'",
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\bb\bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\b",
+        expected: "'a'",
+      },
+      {
+        input: "\ba",
+        expected: "'a'",
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: "'a\nb'",
+      },
+      {
+        input: "a\nb\nc",
+        expected: "'a\nb\nc'",
+      },
+      {
+        input: "a\n",
+        expected: "'a\n'",
+      },
+      {
+        input: "\na",
+        expected: "'\na'",
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\rb\rc",
+        expected: "'abc'",
+      },
+      {
+        input: "\ra",
+        expected: "'a'",
+      },
+      {
+        input: "a\r",
+        expected: "'a'",
+      },
+      {
+        input: "a\r\nb",
+        expected: "'a\r\nb'",
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u001B",
+        expected: "'a'",
+      },
+      {
+        input: "\u001Ba",
+        expected: "'a'",
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: "'ab'",
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: "'abc'",
+      },
+      {
+        input: "a\u009B",
+        expected: "'a'",
+      },
+      {
+        input: "\u009Ba",
+        expected: "'a'",
+      },
+    ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: "'a'\\''b'",
+      },
+      {
+        input: "a'b'c",
+        expected: "'a'\\''b'\\''c'",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "'a!b'",
+      },
+      {
+        input: "a!b!c",
+        expected: "'a!b!c'",
+      },
+      {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a",
+        expected: "'!a'",
       },
     ],
   },

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -778,7 +778,6 @@ export const escape = {
         expected: {
           interpolation: 'a^"b',
           noInterpolation: 'a"b',
-          quoted: 'a""b',
         },
       },
       {
@@ -786,7 +785,6 @@ export const escape = {
         expected: {
           interpolation: 'a^"b^"c',
           noInterpolation: 'a"b"c',
-          quoted: 'a""b""c',
         },
       },
     ],
@@ -1906,7 +1904,6 @@ export const escape = {
         expected: {
           interpolation: 'a`"b',
           noInterpolation: 'a"b',
-          quoted: 'a""b',
         },
       },
       {
@@ -1914,7 +1911,6 @@ export const escape = {
         expected: {
           interpolation: 'a`"b`"c',
           noInterpolation: 'a"b"c',
-          quoted: 'a""b""c',
         },
       },
     ],
@@ -2435,7 +2431,6 @@ export const escape = {
         expected: {
           interpolation: "a`“b",
           noInterpolation: "a“b",
-          quoted: "a““b",
         },
       },
       {
@@ -2443,7 +2438,6 @@ export const escape = {
         expected: {
           interpolation: "a`“b`“c",
           noInterpolation: "a“b“c",
-          quoted: "a““b““c",
         },
       },
     ],
@@ -2453,7 +2447,6 @@ export const escape = {
         expected: {
           interpolation: "a`”b",
           noInterpolation: "a”b",
-          quoted: "a””b",
         },
       },
       {
@@ -2461,7 +2454,6 @@ export const escape = {
         expected: {
           interpolation: "a`”b`”c",
           noInterpolation: "a”b”c",
-          quoted: "a””b””c",
         },
       },
     ],
@@ -2471,7 +2463,6 @@ export const escape = {
         expected: {
           interpolation: "a`„b",
           noInterpolation: "a„b",
-          quoted: "a„„b",
         },
       },
       {
@@ -2479,7 +2470,6 @@ export const escape = {
         expected: {
           interpolation: "a`„b`„c",
           noInterpolation: "a„b„c",
-          quoted: "a„„b„„c",
         },
       },
     ],
@@ -2543,7 +2533,179 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: '"a"', notEscaped: '"a"' },
+        expected: '"a"',
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: '"ab"',
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: '"abc"',
+      },
+      {
+        input: "a\x00",
+        expected: '"a"',
+      },
+      {
+        input: "\x00a",
+        expected: '"a"',
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\bb\bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\b",
+        expected: '"a"',
+      },
+      {
+        input: "\ba",
+        expected: '"a"',
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: '"a b"',
+      },
+      {
+        input: "a\nb\nc",
+        expected: '"a b c"',
+      },
+      {
+        input: "a\n",
+        expected: '"a "',
+      },
+      {
+        input: "\na",
+        expected: '" a"',
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: '"a b"',
+      },
+      {
+        input: "a\rb\rc",
+        expected: '"a b c"',
+      },
+      {
+        input: "\ra",
+        expected: '" a"',
+      },
+      {
+        input: "a\r",
+        expected: '"a "',
+      },
+      {
+        input: "a\r\nb",
+        expected: '"a b"',
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\u001B",
+        expected: '"a"',
+      },
+      {
+        input: "\u001Ba",
+        expected: '"a"',
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\u009B",
+        expected: '"a"',
+      },
+      {
+        input: "\u009Ba",
+        expected: '"a"',
+      },
+    ],
+    "double quotes ('\"')": [
+      {
+        input: 'a"b',
+        expected: '"a""b"',
+      },
+      {
+        input: 'a"b"c',
+        expected: '"a""b""c"',
+      },
+    ],
+    "backticks ('`')": [
+      {
+        input: "a`b",
+        expected: '"a`b"',
+      },
+      {
+        input: "a`b`c",
+        expected: '"a`b`c"',
+      },
+    ],
+    "dollar signs ('$')": [
+      {
+        input: "a$b",
+        expected: '"a$b"',
+      },
+      {
+        input: "a$b$c",
+        expected: '"a$b$c"',
+      },
+    ],
+    "left double quotation mark ('“')": [
+      {
+        input: "a“b",
+        expected: '"a“b"',
+      },
+      {
+        input: "a“b“c",
+        expected: '"a“b“c"',
+      },
+    ],
+    "right double quotation mark ('”')": [
+      {
+        input: "a”b",
+        expected: '"a”b"',
+      },
+      {
+        input: "a”b”c",
+        expected: '"a”b”c"',
+      },
+    ],
+    "double low-9 quotation mark ('„')": [
+      {
+        input: "a„b",
+        expected: '"a„b"',
+      },
+      {
+        input: "a„b„c",
+        expected: '"a„b„c"',
       },
     ],
   },
@@ -2551,7 +2713,179 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: { escaped: '"a"', notEscaped: '"a"' },
+        expected: '"a"',
+      },
+    ],
+    "<null> (\\0)": [
+      {
+        input: "a\x00b",
+        expected: '"ab"',
+      },
+      {
+        input: "a\x00b\x00c",
+        expected: '"abc"',
+      },
+      {
+        input: "a\x00",
+        expected: '"a"',
+      },
+      {
+        input: "\x00a",
+        expected: '"a"',
+      },
+    ],
+    "<backspace> (\\b)": [
+      {
+        input: "a\bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\bb\bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\b",
+        expected: '"a"',
+      },
+      {
+        input: "\ba",
+        expected: '"a"',
+      },
+    ],
+    "<end of line> ('\\n')": [
+      {
+        input: "a\nb",
+        expected: '"a\nb"',
+      },
+      {
+        input: "a\nb\nc",
+        expected: '"a\nb\nc"',
+      },
+      {
+        input: "a\n",
+        expected: '"a\n"',
+      },
+      {
+        input: "\na",
+        expected: '"\na"',
+      },
+    ],
+    "<carriage return> ('\\r')": [
+      {
+        input: "a\rb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\rb\rc",
+        expected: '"abc"',
+      },
+      {
+        input: "\ra",
+        expected: '"a"',
+      },
+      {
+        input: "a\r",
+        expected: '"a"',
+      },
+      {
+        input: "a\r\nb",
+        expected: '"a\r\nb"',
+      },
+    ],
+    "<escape> ('\\u001B')": [
+      {
+        input: "a\u001Bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\u001Bb\u001Bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\u001B",
+        expected: '"a"',
+      },
+      {
+        input: "\u001Ba",
+        expected: '"a"',
+      },
+    ],
+    "<control sequence introducer> ('\\u009B')": [
+      {
+        input: "a\u009Bb",
+        expected: '"ab"',
+      },
+      {
+        input: "a\u009Bb\u009Bc",
+        expected: '"abc"',
+      },
+      {
+        input: "a\u009B",
+        expected: '"a"',
+      },
+      {
+        input: "\u009Ba",
+        expected: '"a"',
+      },
+    ],
+    "double quotes ('\"')": [
+      {
+        input: 'a"b',
+        expected: '"a""b"',
+      },
+      {
+        input: 'a"b"c',
+        expected: '"a""b""c"',
+      },
+    ],
+    "backticks ('`')": [
+      {
+        input: "a`b",
+        expected: '"a``b"',
+      },
+      {
+        input: "a`b`c",
+        expected: '"a``b``c"',
+      },
+    ],
+    "dollar signs ('$')": [
+      {
+        input: "a$b",
+        expected: '"a`$b"',
+      },
+      {
+        input: "a$b$c",
+        expected: '"a`$b`$c"',
+      },
+    ],
+    "left double quotation mark ('“')": [
+      {
+        input: "a“b",
+        expected: '"a““b"',
+      },
+      {
+        input: "a“b“c",
+        expected: '"a““b““c"',
+      },
+    ],
+    "right double quotation mark ('”')": [
+      {
+        input: "a”b",
+        expected: '"a””b"',
+      },
+      {
+        input: "a”b”c",
+        expected: '"a””b””c"',
+      },
+    ],
+    "double low-9 quotation mark ('„')": [
+      {
+        input: "a„b",
+        expected: '"a„„b"',
+      },
+      {
+        input: "a„b„c",
+        expected: '"a„„b„„c"',
       },
     ],
   },

--- a/test/integration/_macros.js
+++ b/test/integration/_macros.js
@@ -54,15 +54,10 @@ function getPlatformExamples(shell) {
  *
  * @param {object} example The example object.
  * @param {boolean} interpolation To get the expected interpolation value.
- * @param {boolean} quoted To get the expected quoted value.
  * @returns {string} The expected value for the given example.
  */
-function getExpectedValue(example, interpolation, quoted) {
-  if (quoted === true) {
-    return example.expected.quoted || example.expected.noInterpolation;
-  } else if (interpolation === false) {
-    return example.expected.noInterpolation;
-  } else if (interpolation === true) {
+function getExpectedValue(example, interpolation) {
+  if (interpolation === true) {
     return example.expected.interpolation;
   } else {
     return example.expected.noInterpolation;
@@ -73,16 +68,15 @@ function getExpectedValue(example, interpolation, quoted) {
  * Generate example fixtures for escaping.
  *
  * @param {boolean} interpolation The `interpolation` option's value.
- * @param {boolean} quoted The `quoted` option's value.
  * @yields Examples of the form `{ expected, input, shell }`.
  */
-function* escapeFixtures(interpolation, quoted) {
+function* escapeFixtures(interpolation) {
   const shells = getPlatformShells();
   for (const shell of shells) {
     const { escapeExamples } = getPlatformExamples(shell);
     for (const example of escapeExamples) {
       const input = example.input;
-      const expected = getExpectedValue(example, interpolation, quoted);
+      const expected = getExpectedValue(example, interpolation);
       yield { expected, input, shell };
     }
   }

--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -15,16 +15,15 @@ import test from "ava";
  * @param {Function} args.getEscapeFunction The escape function builder to test.
  * @param {string} args.input The string to be escaped.
  * @param {boolean} args.interpolation Is interpolation enabled when escaping.
- * @param {boolean} args.quoted Is `input` going to be quoted.
  * @param {string} args.shellName The name of the shell to test.
  */
 export const escape = test.macro({
-  exec(t, { expected, getEscapeFunction, input, interpolation, quoted }) {
-    const escapeFn = getEscapeFunction({ interpolation, quoted });
+  exec(t, { expected, getEscapeFunction, input, interpolation }) {
+    const escapeFn = getEscapeFunction({ interpolation });
     const actual = escapeFn(input);
     t.is(actual, expected);
   },
-  title(_, { input, interpolation, quoted, shellName }) {
+  title(_, { input, interpolation, shellName }) {
     input = input
       .replace(/\0/gu, "\\u{0000}")
       .replace(/\t/gu, "\\t")
@@ -56,9 +55,8 @@ export const escape = test.macro({
       .replace(/\u3000/gu, "\\u{3000}")
       .replace(/\uFEFF/gu, "\\u{FEFF}");
     interpolation = interpolation ? "interpolation" : "no interpolation";
-    quoted = quoted ? "quoted" : "not quoted";
 
-    return `escape '${input}' for ${shellName} (${interpolation}, ${quoted})`;
+    return `escape '${input}' for ${shellName} (${interpolation})`;
   },
 });
 
@@ -81,6 +79,37 @@ export const quote = test.macro({
     t.is(actual, expected);
   },
   title(_, { input, shellName }) {
+    input = input
+      .replace(/\0/gu, "\\u{0000}")
+      .replace(/\t/gu, "\\t")
+      .replace(/\n/gu, "\\n")
+      .replace(/\v/gu, "\\v")
+      .replace(/\f/gu, "\\f")
+      .replace(/\r/gu, "\\r")
+      .replace(/\u0008/gu, "\\u{0008}")
+      .replace(/\u001B/gu, "\\u{001B}")
+      .replace(/\u0085/gu, "\\u{0085}")
+      .replace(/\u009B/gu, "\\u{009B}")
+      .replace(/\u00A0/gu, "\\u{00A0}")
+      .replace(/\u1680/gu, "\\u{1680}")
+      .replace(/\u2000/gu, "\\u{2000}")
+      .replace(/\u2001/gu, "\\u{2001}")
+      .replace(/\u2002/gu, "\\u{2002}")
+      .replace(/\u2003/gu, "\\u{2003}")
+      .replace(/\u2004/gu, "\\u{2004}")
+      .replace(/\u2005/gu, "\\u{2005}")
+      .replace(/\u2006/gu, "\\u{2006}")
+      .replace(/\u2007/gu, "\\u{2007}")
+      .replace(/\u2008/gu, "\\u{2008}")
+      .replace(/\u2009/gu, "\\u{2009}")
+      .replace(/\u200A/gu, "\\u{200A}")
+      .replace(/\u2028/gu, "\\u{2028}")
+      .replace(/\u2029/gu, "\\u{2029}")
+      .replace(/\u202F/gu, "\\u{202F}")
+      .replace(/\u205F/gu, "\\u{205F}")
+      .replace(/\u3000/gu, "\\u{3000}")
+      .replace(/\uFEFF/gu, "\\u{FEFF}");
+
     return `quote '${input}' for ${shellName}`;
   },
 });

--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -6,6 +6,46 @@
 import test from "ava";
 
 /**
+ * Edit a string by replacing control characters with unicode point codes (e.g.
+ * `\u{0000}`) or common text shorthands (e.g. `\t`).
+ *
+ * @param {string} string The string to escape control characters on.
+ * @returns {string} The `string` with control characters escaped.
+ */
+function escapeControlCharacters(string) {
+  return string
+    .replace(/\0/gu, "\\u{0000}")
+    .replace(/\t/gu, "\\t")
+    .replace(/\n/gu, "\\n")
+    .replace(/\v/gu, "\\v")
+    .replace(/\f/gu, "\\f")
+    .replace(/\r/gu, "\\r")
+    .replace(/\u0008/gu, "\\u{0008}")
+    .replace(/\u001B/gu, "\\u{001B}")
+    .replace(/\u0085/gu, "\\u{0085}")
+    .replace(/\u009B/gu, "\\u{009B}")
+    .replace(/\u00A0/gu, "\\u{00A0}")
+    .replace(/\u1680/gu, "\\u{1680}")
+    .replace(/\u2000/gu, "\\u{2000}")
+    .replace(/\u2001/gu, "\\u{2001}")
+    .replace(/\u2002/gu, "\\u{2002}")
+    .replace(/\u2003/gu, "\\u{2003}")
+    .replace(/\u2004/gu, "\\u{2004}")
+    .replace(/\u2005/gu, "\\u{2005}")
+    .replace(/\u2006/gu, "\\u{2006}")
+    .replace(/\u2007/gu, "\\u{2007}")
+    .replace(/\u2008/gu, "\\u{2008}")
+    .replace(/\u2009/gu, "\\u{2009}")
+    .replace(/\u200A/gu, "\\u{200A}")
+    .replace(/\u2028/gu, "\\u{2028}")
+    .replace(/\u2029/gu, "\\u{2029}")
+    .replace(/\u202F/gu, "\\u{202F}")
+    .replace(/\u205F/gu, "\\u{205F}")
+    .replace(/\u3000/gu, "\\u{3000}")
+    .replace(/\uFEFF/gu, "\\u{FEFF}");
+}
+
+/**
  * The escape macro tests the behaviour of the function returned by the provided
  * `getEscapeFunction`.
  *
@@ -24,36 +64,7 @@ export const escape = test.macro({
     t.is(actual, expected);
   },
   title(_, { input, interpolation, shellName }) {
-    input = input
-      .replace(/\0/gu, "\\u{0000}")
-      .replace(/\t/gu, "\\t")
-      .replace(/\n/gu, "\\n")
-      .replace(/\v/gu, "\\v")
-      .replace(/\f/gu, "\\f")
-      .replace(/\r/gu, "\\r")
-      .replace(/\u0008/gu, "\\u{0008}")
-      .replace(/\u001B/gu, "\\u{001B}")
-      .replace(/\u0085/gu, "\\u{0085}")
-      .replace(/\u009B/gu, "\\u{009B}")
-      .replace(/\u00A0/gu, "\\u{00A0}")
-      .replace(/\u1680/gu, "\\u{1680}")
-      .replace(/\u2000/gu, "\\u{2000}")
-      .replace(/\u2001/gu, "\\u{2001}")
-      .replace(/\u2002/gu, "\\u{2002}")
-      .replace(/\u2003/gu, "\\u{2003}")
-      .replace(/\u2004/gu, "\\u{2004}")
-      .replace(/\u2005/gu, "\\u{2005}")
-      .replace(/\u2006/gu, "\\u{2006}")
-      .replace(/\u2007/gu, "\\u{2007}")
-      .replace(/\u2008/gu, "\\u{2008}")
-      .replace(/\u2009/gu, "\\u{2009}")
-      .replace(/\u200A/gu, "\\u{200A}")
-      .replace(/\u2028/gu, "\\u{2028}")
-      .replace(/\u2029/gu, "\\u{2029}")
-      .replace(/\u202F/gu, "\\u{202F}")
-      .replace(/\u205F/gu, "\\u{205F}")
-      .replace(/\u3000/gu, "\\u{3000}")
-      .replace(/\uFEFF/gu, "\\u{FEFF}");
+    input = escapeControlCharacters(input);
     interpolation = interpolation ? "interpolation" : "no interpolation";
 
     return `escape '${input}' for ${shellName} (${interpolation})`;
@@ -79,36 +90,7 @@ export const quote = test.macro({
     t.is(actual, expected);
   },
   title(_, { input, shellName }) {
-    input = input
-      .replace(/\0/gu, "\\u{0000}")
-      .replace(/\t/gu, "\\t")
-      .replace(/\n/gu, "\\n")
-      .replace(/\v/gu, "\\v")
-      .replace(/\f/gu, "\\f")
-      .replace(/\r/gu, "\\r")
-      .replace(/\u0008/gu, "\\u{0008}")
-      .replace(/\u001B/gu, "\\u{001B}")
-      .replace(/\u0085/gu, "\\u{0085}")
-      .replace(/\u009B/gu, "\\u{009B}")
-      .replace(/\u00A0/gu, "\\u{00A0}")
-      .replace(/\u1680/gu, "\\u{1680}")
-      .replace(/\u2000/gu, "\\u{2000}")
-      .replace(/\u2001/gu, "\\u{2001}")
-      .replace(/\u2002/gu, "\\u{2002}")
-      .replace(/\u2003/gu, "\\u{2003}")
-      .replace(/\u2004/gu, "\\u{2004}")
-      .replace(/\u2005/gu, "\\u{2005}")
-      .replace(/\u2006/gu, "\\u{2006}")
-      .replace(/\u2007/gu, "\\u{2007}")
-      .replace(/\u2008/gu, "\\u{2008}")
-      .replace(/\u2009/gu, "\\u{2009}")
-      .replace(/\u200A/gu, "\\u{200A}")
-      .replace(/\u2028/gu, "\\u{2028}")
-      .replace(/\u2029/gu, "\\u{2029}")
-      .replace(/\u202F/gu, "\\u{202F}")
-      .replace(/\u205F/gu, "\\u{205F}")
-      .replace(/\u3000/gu, "\\u{3000}")
-      .replace(/\uFEFF/gu, "\\u{FEFF}");
+    input = escapeControlCharacters(input);
 
     return `quote '${input}' for ${shellName}`;
   },

--- a/test/unit/main/escape.test.js
+++ b/test/unit/main/escape.test.js
@@ -59,6 +59,16 @@ testProp("getting the escape function", [fc.string()], (t, shellName) => {
   t.true(t.context.deps.getEscapeFunction.alwaysCalledWithExactly(shellName));
 });
 
+testProp("escaping", [fc.string()], (t, inputArg) => {
+  t.context.args.arg = inputArg;
+
+  escapeShellArg(t.context.args, t.context.deps);
+
+  t.true(
+    t.context.deps.escapeFunction.calledWithExactly(inputArg, sinon.match.any)
+  );
+});
+
 for (const shell of [undefined, true, false]) {
   testProp(
     `shell is \`${shell}\``,
@@ -149,25 +159,6 @@ for (const interpolation of [undefined, true, false]) {
         t.context.deps.escapeFunction.calledWithExactly(
           sinon.match.any,
           sinon.match({ interpolation: interpolation ? true : false })
-        )
-      );
-    }
-  );
-}
-
-for (const quoted of [undefined, true, false]) {
-  testProp(
-    `quoted is ${quoted}`,
-    [arbitrary.shescapeOptions()],
-    (t, options = {}) => {
-      options.quoted = quoted;
-      t.context.args.options = options;
-
-      escapeShellArg(t.context.args, t.context.deps);
-      t.true(
-        t.context.deps.escapeFunction.calledWithExactly(
-          sinon.match.any,
-          sinon.match({ quoted: false })
         )
       );
     }

--- a/test/unit/main/quote.test.js
+++ b/test/unit/main/quote.test.js
@@ -16,14 +16,11 @@ import { quoteShellArg } from "../../../src/main.js";
 
 test.beforeEach((t) => {
   const getDefaultShell = sinon.stub();
-  const getEscapeFunction = sinon.stub();
   const getQuoteFunction = sinon.stub();
   const getShellName = sinon.stub();
 
-  const escapeFunction = sinon.stub();
   const quoteFunction = sinon.stub();
 
-  getEscapeFunction.returns(escapeFunction);
   getQuoteFunction.returns(quoteFunction);
 
   t.context.args = {
@@ -37,11 +34,9 @@ test.beforeEach((t) => {
   };
   t.context.deps = {
     getDefaultShell,
-    getEscapeFunction,
     getQuoteFunction,
     getShellName,
 
-    escapeFunction,
     quoteFunction,
   };
 });
@@ -51,17 +46,6 @@ testProp("the return value", [fc.string()], (t, escapedArg) => {
 
   const result = quoteShellArg(t.context.args, t.context.deps);
   t.is(result, escapedArg);
-});
-
-testProp("getting the escape function", [fc.string()], (t, shellName) => {
-  t.context.deps.getEscapeFunction.resetHistory();
-
-  t.context.deps.getShellName.returns(shellName);
-
-  quoteShellArg(t.context.args, t.context.deps);
-
-  t.is(t.context.deps.getEscapeFunction.callCount, 1);
-  t.true(t.context.deps.getEscapeFunction.alwaysCalledWithExactly(shellName));
 });
 
 testProp("getting the quote function", [fc.string()], (t, shellName) => {
@@ -75,12 +59,12 @@ testProp("getting the quote function", [fc.string()], (t, shellName) => {
   t.true(t.context.deps.getQuoteFunction.alwaysCalledWithExactly(shellName));
 });
 
-testProp("quoting", [fc.string()], (t, escapedArg) => {
-  t.context.deps.escapeFunction.returns(escapedArg);
+testProp("quoting", [fc.string()], (t, inputArg) => {
+  t.context.args.arg = inputArg;
 
   quoteShellArg(t.context.args, t.context.deps);
 
-  t.true(t.context.deps.quoteFunction.calledWithExactly(escapedArg));
+  t.true(t.context.deps.quoteFunction.calledWithExactly(inputArg));
 });
 
 for (const shell of [undefined, true, false]) {
@@ -142,38 +126,6 @@ test("shell name helpers", (t) => {
     })
   );
 });
-
-testProp(
-  "the used interpolation value",
-  [arbitrary.shescapeOptions()],
-  (t, options = {}) => {
-    t.context.args.options = options;
-
-    quoteShellArg(t.context.args, t.context.deps);
-    t.true(
-      t.context.deps.escapeFunction.calledWithExactly(
-        sinon.match.any,
-        sinon.match({ interpolation: false })
-      )
-    );
-  }
-);
-
-testProp(
-  "the used quoted value",
-  [arbitrary.shescapeOptions()],
-  (t, options = {}) => {
-    t.context.args.options = options;
-
-    quoteShellArg(t.context.args, t.context.deps);
-    t.true(
-      t.context.deps.escapeFunction.calledWithExactly(
-        sinon.match.any,
-        sinon.match({ quoted: true })
-      )
-    );
-  }
-);
 
 testProp(
   "the escaping of the argument",

--- a/test/unit/unix/csh.test.js
+++ b/test/unit/unix/csh.test.js
@@ -40,10 +40,7 @@ testProp(
       testCharacter +
       baseString.substring(insertIndex);
 
-    const escapeFn = csh.getEscapeFunction({
-      interpolation: true,
-      quoted: false,
-    });
+    const escapeFn = csh.getEscapeFunction({ interpolation: true });
     const result = escapeFn(testStr);
     t.assert(result.includes(`'${testCharacter}'`));
   }

--- a/test/unit/unix/facade.test.js
+++ b/test/unit/unix/facade.test.js
@@ -15,19 +15,13 @@ testProp(
   "escape function for supported shell",
   [arbitrary.unixShell(), fc.string()],
   (t, shellName, arg) => {
-    let options = { interpolation: false, quoted: false };
+    let options = { interpolation: false };
     t.is(
       facade.getEscapeFunction(shellName)(arg, options),
       unix.getEscapeFunction(shellName, options)(arg)
     );
 
-    options = { interpolation: true, quoted: false };
-    t.is(
-      facade.getEscapeFunction(shellName)(arg, options),
-      unix.getEscapeFunction(shellName, options)(arg)
-    );
-
-    options = { interpolation: false, quoted: true };
+    options = { interpolation: true };
     t.is(
       facade.getEscapeFunction(shellName)(arg, options),
       unix.getEscapeFunction(shellName, options)(arg)
@@ -52,7 +46,6 @@ testProp(
     t.is(typeof quoteFn, "function");
     const result = quoteFn(arg);
     t.is(typeof result, "string");
-    t.is(result.substring(1, arg.length + 1), arg);
     t.regex(result, /^(".*"|'.*')$/u);
   }
 );

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -24,19 +24,13 @@ test("the default shell", (t) => {
 });
 
 test("escape function for bash", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     unix.getEscapeFunction(constants.binBash, options),
     bash.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    unix.getEscapeFunction(constants.binBash, options),
-    bash.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     unix.getEscapeFunction(constants.binBash, options),
     bash.getEscapeFunction(options)
@@ -44,19 +38,13 @@ test("escape function for bash", (t) => {
 });
 
 test("escape function for csh", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     unix.getEscapeFunction(constants.binCsh, options),
     csh.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    unix.getEscapeFunction(constants.binCsh, options),
-    csh.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     unix.getEscapeFunction(constants.binCsh, options),
     csh.getEscapeFunction(options)
@@ -64,19 +52,13 @@ test("escape function for csh", (t) => {
 });
 
 test("escape function for dash", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     unix.getEscapeFunction(constants.binDash, options),
     dash.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    unix.getEscapeFunction(constants.binDash, options),
-    dash.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     unix.getEscapeFunction(constants.binDash, options),
     dash.getEscapeFunction(options)
@@ -84,19 +66,13 @@ test("escape function for dash", (t) => {
 });
 
 test("escape function for zsh", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     unix.getEscapeFunction(constants.binZsh, options),
     zsh.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    unix.getEscapeFunction(constants.binZsh, options),
-    zsh.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     unix.getEscapeFunction(constants.binZsh, options),
     zsh.getEscapeFunction(options)
@@ -105,9 +81,9 @@ test("escape function for zsh", (t) => {
 
 testProp(
   "escape function for unsupported shell",
-  [arbitrary.unsupportedUnixShell(), fc.boolean(), fc.boolean()],
-  (t, shellName, interpolation, quoted) => {
-    const result = unix.getEscapeFunction(shellName, { interpolation, quoted });
+  [arbitrary.unsupportedUnixShell(), fc.boolean()],
+  (t, shellName, interpolation) => {
+    const result = unix.getEscapeFunction(shellName, { interpolation });
     t.is(result, undefined);
   }
 );

--- a/test/unit/unix/shells.test.js
+++ b/test/unit/unix/shells.test.js
@@ -30,7 +30,6 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       input,
       getEscapeFunction: shellExports.getEscapeFunction,
       interpolation: false,
-      quoted: false,
       shellName,
     });
 
@@ -39,23 +38,13 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       input,
       getEscapeFunction: shellExports.getEscapeFunction,
       interpolation: true,
-      quoted: false,
-      shellName,
-    });
-
-    test(macros.escape, {
-      expected: expected.quoted || expected.noInterpolation,
-      input,
-      getEscapeFunction: shellExports.getEscapeFunction,
-      interpolation: false,
-      quoted: true,
       shellName,
     });
   });
 
   quoteFixtures.forEach(({ input, expected }) => {
     test(macros.quote, {
-      expected: expected.notEscaped,
+      expected,
       input,
       getQuoteFunction: shellExports.getQuoteFunction,
       shellName,
@@ -64,10 +53,7 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
 
   redosFixtures.forEach((input, id) => {
     test(`${shellName}, ReDoS #${id}`, (t) => {
-      const escape = shellExports.getEscapeFunction({
-        interpolation: true,
-        quoted: false,
-      });
+      const escape = shellExports.getEscapeFunction({ interpolation: true });
       escape(input);
       t.pass();
     });

--- a/test/unit/win/facade.test.js
+++ b/test/unit/win/facade.test.js
@@ -15,19 +15,13 @@ testProp(
   "escape function for supported shell",
   [arbitrary.windowsShell(), fc.string()],
   (t, shellName, arg) => {
-    let options = { interpolation: false, quoted: false };
+    let options = { interpolation: false };
     t.is(
       facade.getEscapeFunction(shellName)(arg, options),
       win.getEscapeFunction(shellName, options)(arg)
     );
 
-    options = { interpolation: true, quoted: false };
-    t.is(
-      facade.getEscapeFunction(shellName)(arg, options),
-      win.getEscapeFunction(shellName, options)(arg)
-    );
-
-    options = { interpolation: false, quoted: true };
+    options = { interpolation: true };
     t.is(
       facade.getEscapeFunction(shellName)(arg, options),
       win.getEscapeFunction(shellName, options)(arg)
@@ -52,7 +46,6 @@ testProp(
     t.is(typeof quoteFn, "function");
     const result = quoteFn(arg);
     t.is(typeof result, "string");
-    t.is(result.substring(1, arg.length + 1), arg);
     t.regex(result, /^(".*"|'.*')$/u);
   }
 );

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -47,19 +47,13 @@ testProp(
 );
 
 test("escape function for CMD", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     win.getEscapeFunction(constants.binCmd, options),
     cmd.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    win.getEscapeFunction(constants.binCmd, options),
-    cmd.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     win.getEscapeFunction(constants.binCmd, options),
     cmd.getEscapeFunction(options)
@@ -67,19 +61,13 @@ test("escape function for CMD", (t) => {
 });
 
 test("escape function for PowerShell", (t) => {
-  let options = { interpolation: false, quoted: false };
+  let options = { interpolation: false };
   t.is(
     win.getEscapeFunction(constants.binPowerShell, options),
     powershell.getEscapeFunction(options)
   );
 
-  options = { interpolation: true, quoted: false };
-  t.is(
-    win.getEscapeFunction(constants.binPowerShell, options),
-    powershell.getEscapeFunction(options)
-  );
-
-  options = { interpolation: false, quoted: true };
+  options = { interpolation: true };
   t.is(
     win.getEscapeFunction(constants.binPowerShell, options),
     powershell.getEscapeFunction(options)
@@ -88,9 +76,9 @@ test("escape function for PowerShell", (t) => {
 
 testProp(
   "escape function for unsupported shell",
-  [arbitrary.unsupportedWindowsShell(), fc.boolean(), fc.boolean()],
-  (t, shellName, interpolation, quoted) => {
-    const result = win.getEscapeFunction(shellName, { interpolation, quoted });
+  [arbitrary.unsupportedWindowsShell(), fc.boolean()],
+  (t, shellName, interpolation) => {
+    const result = win.getEscapeFunction(shellName, { interpolation });
     t.is(result, undefined);
   }
 );

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -25,7 +25,6 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       input,
       getEscapeFunction: shellExports.getEscapeFunction,
       interpolation: false,
-      quoted: false,
       shellName,
     });
 
@@ -34,23 +33,13 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       input,
       getEscapeFunction: shellExports.getEscapeFunction,
       interpolation: true,
-      quoted: false,
-      shellName,
-    });
-
-    test(macros.escape, {
-      expected: expected.quoted || expected.noInterpolation,
-      input,
-      getEscapeFunction: shellExports.getEscapeFunction,
-      interpolation: false,
-      quoted: true,
       shellName,
     });
   });
 
   quoteFixtures.forEach(({ input, expected }) => {
     test(macros.quote, {
-      expected: expected.notEscaped,
+      expected,
       input,
       getQuoteFunction: shellExports.getQuoteFunction,
       shellName,


### PR DESCRIPTION
Relates to #856, #870

## Summary

Refactoring to simplify and optimize the internal flow of calling `shescape.quote()` or `shescape.quoteAll()`. Before this would partly involve the flow for `shescape.escape()`/`shescape.escapeAll()`, complicating that flow and making the quoting flow harder to understand. This separates the two flows, simplifying both (making them easier to understand) and actually improving performance slightly by having fewer conditions.

Somewhat incidentally, this also improves the test fixtures when it comes to quoting. Previously the implicit expected quoted value was the `noInterpolation` one. Now this is more explicit (for relevant input characters).