### PR TITLE
Run compatibility test on lowest supported version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -247,12 +247,12 @@ jobs:
       matrix:
         node-version:
           - 10.13.0
-          - 12
-          - 14
-          - 16
-          - 18
-          - 19
-          - 20
+          - 12.0.0
+          - 14.0.0
+          - 16.0.0
+          - 18.0.0
+          - 19.0.0
+          - 20.0.0
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lint:yml": "npm run _eslint -- --ext .yml",
     "test": "npm run test:unit",
     "test:compat": "mocha test/compat/**/*.test.cjs",
-    "test:compat-all": "nve 10.13.0,12,14,16,18,19,20 mocha test/compat/**/*.test.cjs",
+    "test:compat-all": "nve 10.13.0,12.0.0,14.0.0,16.0.0,18.0.0,19.0.0,20.0.0 mocha test/compat/**/*.test.cjs",
     "test:e2e": "ava test/e2e/**/*.test.js --timeout 1m",
     "test:integration": "ava test/integration/**/*.test.js --timeout 1m",
     "test:mutation": "stryker run stryker.config.js",


### PR DESCRIPTION
Relates to #199

## Summary

Update how compatibility tests are run to use the earliest supported release instead of the latest available release for any given major version of Node.js. This aligns compatibility testing for all supported versions (previously testing was different between `10.13.0` and anything `>12`).

Compatibility testing was first introduced in #199 without a motivation for the specified versions. At this point in time I think it makes more sense to test the earliest stated supported versions and rely on Node.js for not introducing breaking changes for each major version.