### PR TITLE
Simplify getting the shell path's basename for every platform

### DIFF
--- a/src/unix/index.js
+++ b/src/unix/index.js
@@ -46,16 +46,6 @@ export const binDash = "dash";
 export const binZsh = "zsh";
 
 /**
- * Returns the basename of a directory or file path on a Unix system.
- *
- * @param {string} fullPath A Unix-style directory or file path.
- * @returns {string} The basename of `fullPath`.
- */
-function getBasename(fullPath) {
-  return path.basename(fullPath);
-}
-
-/**
  * Returns the default shell for Unix systems.
  *
  * For more information, see `options.shell` in:
@@ -122,7 +112,7 @@ export function getShellName({ shell }, { resolveExecutable }) {
     { exists: fs.existsSync, readlink: fs.readlinkSync, which: which.sync }
   );
 
-  const shellName = getBasename(shell);
+  const shellName = path.basename(shell);
   if (getEscapeFunction(shellName, {}) === undefined) {
     return binBash;
   }

--- a/src/win/index.js
+++ b/src/win/index.js
@@ -28,16 +28,6 @@ export const binCmd = "cmd.exe";
 export const binPowerShell = "powershell.exe";
 
 /**
- * Returns the basename of a directory or file path on a Windows system.
- *
- * @param {string} fullPath A Windows-style directory or file path.
- * @returns {string} The basename of `fullPath`.
- */
-function getBasename(fullPath) {
-  return path.win32.basename(fullPath);
-}
-
-/**
  * Returns the default shell for Windows systems.
  *
  * For more information, see:
@@ -103,7 +93,7 @@ export function getShellName({ shell }, { resolveExecutable }) {
     { exists: fs.existsSync, readlink: fs.readlinkSync, which: which.sync }
   );
 
-  const shellName = getBasename(shell);
+  const shellName = path.win32.basename(shell);
   if (getEscapeFunction(shellName, {}) === undefined) {
     return binCmd;
   }


### PR DESCRIPTION
## Summary

Refactor to simplify the platform-specific modules by using Node.js' `path(.win32).basename` functionality directly. The abstraction serves no purpose (anymore).