### PR TITLE
Internally unexport shell names

### DIFF
--- a/src/unix/index.js
+++ b/src/unix/index.js
@@ -19,7 +19,7 @@ import * as zsh from "./zsh.js";
  * @constant
  * @type {string}
  */
-export const binBash = "bash";
+const binBash = "bash";
 
 /**
  * The name of the C shell (csh) binary.
@@ -27,7 +27,7 @@ export const binBash = "bash";
  * @constant
  * @type {string}
  */
-export const binCsh = "csh";
+const binCsh = "csh";
 
 /**
  * The name of the Debian Almquist shell (Dash) binary.
@@ -35,7 +35,7 @@ export const binCsh = "csh";
  * @constant
  * @type {string}
  */
-export const binDash = "dash";
+const binDash = "dash";
 
 /**
  * The name of the Z shell (Zsh) binary.
@@ -43,7 +43,7 @@ export const binDash = "dash";
  * @constant
  * @type {string}
  */
-export const binZsh = "zsh";
+const binZsh = "zsh";
 
 /**
  * Returns the default shell for Unix systems.

--- a/src/win/index.js
+++ b/src/win/index.js
@@ -17,7 +17,7 @@ import * as powershell from "./powershell.js";
  * @constant
  * @type {string}
  */
-export const binCmd = "cmd.exe";
+const binCmd = "cmd.exe";
 
 /**
  * The name of the Windows PowerShell binary.
@@ -25,7 +25,7 @@ export const binCmd = "cmd.exe";
  * @constant
  * @type {string}
  */
-export const binPowerShell = "powershell.exe";
+const binPowerShell = "powershell.exe";
 
 /**
  * Returns the default shell for Windows systems.


### PR DESCRIPTION
Followup to #919
Relates to #870

## Summary

Remove the exporting of shell names internally as they are no longer used by the facades and should never be used otherwise.