### PR TITLE
Fix Unix and Windows CI triggers

### DIFF
--- a/.github/workflows/checks-unix.yml
+++ b/.github/workflows/checks-unix.yml
@@ -4,13 +4,13 @@ on:
     paths:
       - .github/workflows/checks-unix.yml
       - .github/workflows/reusable-fuzz.yml
-      - src/unix.js
+      - src/unix/**
       - test/fuzz/**
   push:
     paths:
       - .github/workflows/checks-unix.yml
       - .github/workflows/reusable-fuzz.yml
-      - src/unix.js
+      - src/unix/**
       - test/fuzz/**
     branches:
       - main

--- a/.github/workflows/checks-windows.yml
+++ b/.github/workflows/checks-windows.yml
@@ -4,13 +4,13 @@ on:
     paths:
       - .github/workflows/checks-windows.yml
       - .github/workflows/reusable-fuzz.yml
-      - src/win.js
+      - src/win/**
       - test/fuzz/**
   push:
     paths:
       - .github/workflows/checks-windows.yml
       - .github/workflows/reusable-fuzz.yml
-      - src/win.js
+      - src/win/**
       - test/fuzz/**
     branches:
       - main


### PR DESCRIPTION
Relates to #870, #919

## Summary

Following internal refactoring of platform specific code - including changes to files - update the path filters for Unix and Windows continuous integration workflows.