### PR TITLE
Drop the barrel files and move back to `src/{unix,win}.js`

### DIFF
--- a/.github/workflows/checks-unix.yml
+++ b/.github/workflows/checks-unix.yml
@@ -4,12 +4,14 @@ on:
     paths:
       - .github/workflows/checks-unix.yml
       - .github/workflows/reusable-fuzz.yml
+      - src/unix.js
       - src/unix/**
       - test/fuzz/**
   push:
     paths:
       - .github/workflows/checks-unix.yml
       - .github/workflows/reusable-fuzz.yml
+      - src/unix.js
       - src/unix/**
       - test/fuzz/**
     branches:

--- a/.github/workflows/checks-windows.yml
+++ b/.github/workflows/checks-windows.yml
@@ -4,12 +4,14 @@ on:
     paths:
       - .github/workflows/checks-windows.yml
       - .github/workflows/reusable-fuzz.yml
+      - src/win.js
       - src/win/**
       - test/fuzz/**
   push:
     paths:
       - .github/workflows/checks-windows.yml
       - .github/workflows/reusable-fuzz.yml
+      - src/win.js
       - src/win/**
       - test/fuzz/**
     branches:

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -14,8 +14,8 @@ import {
   binZsh,
 } from "../test/_constants.cjs";
 
-import * as unix from "../src/unix/index.js";
-import * as win from "../src/win/index.js";
+import * as unix from "../src/unix.js";
+import * as win from "../src/win.js";
 
 const sampleArg = "foobar";
 

--- a/bench/unix.js
+++ b/bench/unix.js
@@ -7,7 +7,7 @@ import Benchmark from "benchmark";
 
 import { binBash, binCsh, binDash, binZsh } from "../test/_constants.cjs";
 
-import * as unix from "../src/unix/index.js";
+import * as unix from "../src/unix.js";
 
 const targetArg = "foobar";
 const targetShell = binZsh;

--- a/bench/win.js
+++ b/bench/win.js
@@ -7,7 +7,7 @@ import Benchmark from "benchmark";
 
 import { binCmd, binPowerShell } from "../test/_constants.cjs";
 
-import * as win from "../src/win/index.js";
+import * as win from "../src/win.js";
 
 const targetArg = "foobar";
 const targetShell = binCmd;

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -4,8 +4,8 @@
  * @license MPL-2.0
  */
 
-import * as unix from "./unix/index.js";
-import * as win from "./win/index.js";
+import * as unix from "./unix.js";
+import * as win from "./win.js";
 
 /**
  * The string identifying the OS type Cygwin.

--- a/src/unix.js
+++ b/src/unix.js
@@ -8,10 +8,10 @@ import * as path from "path";
 
 import which from "which";
 
-import * as bash from "./bash.js";
-import * as csh from "./csh.js";
-import * as dash from "./dash.js";
-import * as zsh from "./zsh.js";
+import * as bash from "./unix/bash.js";
+import * as csh from "./unix/csh.js";
+import * as dash from "./unix/dash.js";
+import * as zsh from "./unix/zsh.js";
 
 /**
  * The name of the Bourne-again shell (Bash) binary.

--- a/src/win.js
+++ b/src/win.js
@@ -8,8 +8,8 @@ import * as path from "path";
 
 import which from "which";
 
-import * as cmd from "./cmd.js";
-import * as powershell from "./powershell.js";
+import * as cmd from "./win/cmd.js";
+import * as powershell from "./win/powershell.js";
 
 /**
  * The name of the Windows Command Prompt binary.

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -9,8 +9,8 @@ import { testProp } from "@fast-check/ava";
 import { arbitrary, constants } from "./_.js";
 
 import { getHelpersByPlatform } from "../../../src/platforms.js";
-import * as unix from "../../../src/unix/index.js";
-import * as win from "../../../src/win/index.js";
+import * as unix from "../../../src/unix.js";
+import * as win from "../../../src/win.js";
 
 for (const platform of [
   constants.osAix,

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -15,7 +15,7 @@ import { arbitrary, constants } from "./_.js";
 import * as bash from "../../../src/unix/bash.js";
 import * as csh from "../../../src/unix/csh.js";
 import * as dash from "../../../src/unix/dash.js";
-import * as unix from "../../../src/unix/index.js";
+import * as unix from "../../../src/unix.js";
 import * as zsh from "../../../src/unix/zsh.js";
 
 test("the default shell", (t) => {

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -13,7 +13,7 @@ import sinon from "sinon";
 import { arbitrary, constants } from "./_.js";
 
 import * as cmd from "../../../src/win/cmd.js";
-import * as win from "../../../src/win/index.js";
+import * as win from "../../../src/win.js";
 import * as powershell from "../../../src/win/powershell.js";
 
 testProp(


### PR DESCRIPTION
Relates to #870,  #919

## Summary

Remove the `src/{unix,win}/index.js` (barrel) files in favor of (the re-introduction of) `src/{unix,win}.js`.