### PR TITLE
Reward providing arguments as strings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@
  */
 
 import { resolveExecutable } from "./executables.js";
-import { isString, checkedToString } from "./reflection.js";
+import { checkedToString, isString } from "./reflection.js";
 
 /**
  * Parses options provided to {@link escapeShellArg} or {@link quoteShellArg}.

--- a/src/reflection.js
+++ b/src/reflection.js
@@ -40,12 +40,12 @@ export function checkedToString(value) {
     return value;
   }
 
-  const [str, ok] = isStringable(value);
-  if (!ok) {
+  const maybeStr = isStringable(value);
+  if (maybeStr === null) {
     throw new TypeError(typeError);
   }
 
-  return str;
+  return maybeStr;
 }
 
 /**
@@ -71,15 +71,19 @@ export function isString(value) {
  */
 function isStringable(value) {
   if (value === undefined || value === null) {
-    return [null, false];
+    return null;
   }
 
   if (typeof value.toString !== typeofFunction) {
-    return [null, false];
+    return null;
   }
 
   const maybeStr = value.toString();
-  return [maybeStr, isString(maybeStr)];
+  if (isString(maybeStr)) {
+    return maybeStr;
+  } else {
+    return null;
+  }
 }
 
 /**

--- a/src/reflection.js
+++ b/src/reflection.js
@@ -36,12 +36,16 @@ const typeofString = "string";
  * @throws {TypeError} The `value` is not stringable.
  */
 export function checkedToString(value) {
-  if (!isStringable(value)) {
+  if (isString(value)) {
+    return value;
+  }
+
+  const [str, ok] = isStringable(value);
+  if (!ok) {
     throw new TypeError(typeError);
   }
 
-  const valueAsString = value.toString();
-  return valueAsString;
+  return str;
 }
 
 /**
@@ -55,22 +59,27 @@ export function isString(value) {
 }
 
 /**
- * Checks if a value can be converted into a string.
+ * Checks if a value can be converted into a string and converts it if possible.
+ *
+ * Returns either:
+ * - `[_, false]`: if the provided value isn't stringable.
+ * - `[str, true]`: if the provided value is stringable, where `str` is the
+ * string representation of the provided value.
  *
  * @param {any} value The value of interest.
- * @returns {boolean} `true` if `value` is stringable, `false` otherwise.
+ * @returns {string|boolean[]} A pair `[str, ok]`.
  */
 function isStringable(value) {
   if (value === undefined || value === null) {
-    return false;
+    return [null, false];
   }
 
   if (typeof value.toString !== typeofFunction) {
-    return false;
+    return [null, false];
   }
 
-  const str = value.toString();
-  return isString(str);
+  const maybeStr = value.toString();
+  return [maybeStr, isString(maybeStr)];
 }
 
 /**

--- a/src/reflection.js
+++ b/src/reflection.js
@@ -29,6 +29,29 @@ const typeofFunction = "function";
 const typeofString = "string";
 
 /**
+ * Checks if a value can be converted into a string and converts it if possible.
+ *
+ * @param {any} value The value of interest.
+ * @returns {string|null} The `.toString()` if it's a string, otherwise `null`.
+ */
+function maybeToString(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value.toString !== typeofFunction) {
+    return null;
+  }
+
+  const maybeStr = value.toString();
+  if (isString(maybeStr)) {
+    return maybeStr;
+  } else {
+    return null;
+  }
+}
+
+/**
  * Convert a value into a string if that is possible.
  *
  * @param {any} value The value to convert into a string.
@@ -40,7 +63,7 @@ export function checkedToString(value) {
     return value;
   }
 
-  const maybeStr = isStringable(value);
+  const maybeStr = maybeToString(value);
   if (maybeStr === null) {
     throw new TypeError(typeError);
   }
@@ -56,34 +79,6 @@ export function checkedToString(value) {
  */
 export function isString(value) {
   return typeof value === typeofString;
-}
-
-/**
- * Checks if a value can be converted into a string and converts it if possible.
- *
- * Returns either:
- * - `[_, false]`: if the provided value isn't stringable.
- * - `[str, true]`: if the provided value is stringable, where `str` is the
- * string representation of the provided value.
- *
- * @param {any} value The value of interest.
- * @returns {string|boolean[]} A pair `[str, ok]`.
- */
-function isStringable(value) {
-  if (value === undefined || value === null) {
-    return null;
-  }
-
-  if (typeof value.toString !== typeofFunction) {
-    return null;
-  }
-
-  const maybeStr = value.toString();
-  if (isString(maybeStr)) {
-    return maybeStr;
-  } else {
-    return null;
-  }
 }
 
 /**

--- a/test/_constants.cjs
+++ b/test/_constants.cjs
@@ -14,6 +14,7 @@ module.exports.illegalArguments = [
   { description: "undefined", value: undefined },
   { description: "toString is missing", value: { toString: null } },
   { description: "toString returns null", value: { toString: () => null } },
+  { description: "toString returns a number", value: { toString: () => 42 } },
 ];
 
 /* OS platforms (based on https://nodejs.org/api/os.html#osplatform) */

--- a/test/unit/main/escape.test.js
+++ b/test/unit/main/escape.test.js
@@ -224,6 +224,17 @@ for (const { description, value } of constants.illegalArguments) {
   });
 }
 
+test("''.toString() does not return a string", (t) => {
+  const stringToStringBackup = String.prototype.toString;
+  String.prototype.toString = () => null;
+
+  t.notThrows(() => {
+    escapeShellArg(t.context.args, t.context.deps);
+  });
+
+  String.prototype.toString = stringToStringBackup;
+});
+
 test(macros.prototypePollution, (t, payload) => {
   t.context.args.options = payload;
   escapeShellArg(t.context.args, t.context.deps);

--- a/test/unit/main/quote.test.js
+++ b/test/unit/main/quote.test.js
@@ -188,6 +188,17 @@ for (const { description, value } of constants.illegalArguments) {
   });
 }
 
+test("''.toString() does not return a string", (t) => {
+  const stringToStringBackup = String.prototype.toString;
+  String.prototype.toString = () => null;
+
+  t.notThrows(() => {
+    quoteShellArg(t.context.args, t.context.deps);
+  });
+
+  String.prototype.toString = stringToStringBackup;
+});
+
 test(macros.prototypePollution, (t, payload) => {
   t.context.args.options = payload;
   quoteShellArg(t.context.args, t.context.deps);


### PR DESCRIPTION
Relates to #856, #948

## Summary

In most cases provided arguments should be strings. So, reward providing strings with slightly better performance in the form of fewer conditions - at the cost of more conditions for non-string values.