### PR TITLE
Replace homegrown tooling updates by dedicated action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,40 +43,14 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
       - name: Create automation token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         id: automation-token
         with:
           app_id: ${{ secrets.AUTOMATION_APP_ID }}
           private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-      - name: Get latest version
-        id: version
-        run: |
-          LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
-          echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-      - name: Install new version
-        run: |
-          asdf install '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
-      - name: Apply latest version to .tool-versions
-        run: |
-          asdf local '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action@9c487be028e21aac02daeec168ea23844006cdf1 # v0.1.0
         with:
+          max: 1
           token: ${{ steps.automation-token.outputs.token }}
-          title: Update ${{ matrix.tool }} to v${{ steps.version.outputs.latest }}
-          body: |
-            _This Pull Request was created automatically_
-
-            ---
-
-            Bump ${{ matrix.tool }} to v${{ steps.version.outputs.latest }}
-          branch: asdf-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
-          labels: dependencies
-          commit-message: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
-          add-paths: |
-            .tool-versions


### PR DESCRIPTION
Relates to #613, #622, #669, #839

## Summary

Update the nightly schedule to create Pull Requests to update tools defined in the `.tool-versions` file to use [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action) instead.