### PR TITLE
Fix flaky PowerShell unit test

### DIFF
--- a/test/unit/win/_expressions.js
+++ b/test/unit/win/_expressions.js
@@ -12,6 +12,6 @@ export const flag = {
   },
   [binPowerShell]: {
     flag: /^(?:`?-+|\/+)$/u,
-    nonFlag: /^[^-/]/u,
+    nonFlag: /^([^-/`]|[^-/][^-])/u,
   },
 };


### PR DESCRIPTION
Relates to #908

## Summary

Update the expression for generating test strings that shouldn't be considered flags by the PowerShell flag protection logic to avoid generating strings starting with "`-".