### PR TITLE
Add unit tests covering reflection functionality directly

### DIFF
--- a/test/unit/reflection/_.js
+++ b/test/unit/reflection/_.js
@@ -1,0 +1,9 @@
+/**
+ * @overview Provides testing utilities.
+ * @license MIT
+ */
+
+import * as arbitrary from "../../_arbitraries.js";
+import * as constants from "../../_constants.cjs";
+
+export { arbitrary, constants };

--- a/test/unit/reflection/checked-to-string.test.js
+++ b/test/unit/reflection/checked-to-string.test.js
@@ -1,0 +1,42 @@
+/**
+ * @overview Contains unit tests for the `checkedToString` function.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+import test from "ava";
+import * as fc from "fast-check";
+
+import { arbitrary, constants } from "./_.js";
+
+import { checkedToString } from "../../../src/reflection.js";
+
+testProp("strings", [fc.string()], (t, value) => {
+  const result = checkedToString(value);
+  t.is(result, value);
+});
+
+test("string.prototype.toString does not return a string", (t) => {
+  const stringToStringBackup = String.prototype.toString;
+  String.prototype.toString = () => null;
+
+  const result = checkedToString("");
+  t.is(result, "");
+
+  String.prototype.toString = stringToStringBackup;
+});
+
+testProp("stringable values", [arbitrary.shescapeArg()], (t, value) => {
+  const result = checkedToString(value);
+  t.is(result, value.toString());
+});
+
+for (const { description, value } of constants.illegalArguments) {
+  test(description, (t) => {
+    t.throws(() => checkedToString(value), {
+      instanceOf: TypeError,
+      message:
+        "Shescape requires strings or values that can be converted into a string using .toString()",
+    });
+  });
+}

--- a/test/unit/reflection/is-string.test.js
+++ b/test/unit/reflection/is-string.test.js
@@ -1,0 +1,23 @@
+/**
+ * @overview Contains unit tests for the `isString` function.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+import * as fc from "fast-check";
+
+import { isString } from "../../../src/reflection.js";
+
+testProp("strings", [fc.string()], (t, value) => {
+  const result = isString(value);
+  t.true(result);
+});
+
+testProp(
+  "non-strings",
+  [fc.anything().filter((value) => typeof value !== "string")],
+  (t, value) => {
+    const result = isString(value);
+    t.false(result);
+  }
+);

--- a/test/unit/reflection/to-array-if-necessary.test.js
+++ b/test/unit/reflection/to-array-if-necessary.test.js
@@ -1,0 +1,23 @@
+/**
+ * @overview Contains unit tests for the `toArrayIfNecessary` function.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+import * as fc from "fast-check";
+
+import { toArrayIfNecessary } from "../../../src/reflection.js";
+
+testProp("arrays", [fc.array(fc.anything())], (t, value) => {
+  const result = toArrayIfNecessary(value);
+  t.is(result, value);
+});
+
+testProp(
+  "non-arrays",
+  [fc.anything().filter((value) => !Array.isArray(value))],
+  (t, value) => {
+    const result = toArrayIfNecessary(value);
+    t.deepEqual(result, [value]);
+  }
+);


### PR DESCRIPTION
Relates to #710

## Summary

Add a new suite of unit tests targeting [`src/reflection.js`](https://github.com/ericcornelissen/shescape/blob/74ed727a4b1b39525807f8b502c895b6bd6e4f10/src/reflection.js) directly. Previously, this code was covered by unit tests almost entirely by the [suite for `main.js`](https://github.com/ericcornelissen/shescape/tree/74ed727a4b1b39525807f8b502c895b6bd6e4f10/test/unit/main).