### PR TITLE
Clean up the list of externals in Rollup configuration

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 // Check out rollup.js at: https://rollupjs.org/guide/en/
 
-const external = ["fs", "os", "path", "path/win32", "process", "util", "which"];
+const external = ["fs", "os", "path", "process", "which"];
 
 export default [
   {


### PR DESCRIPTION
Relates to #161, #199, #308, #659, #965

## Summary

Update the Rollup configuration by cleaning up the list of external modules to exclude unused modules.