### PR TITLE
Re-introduce explicit import for `TextEncoder`

### DIFF
--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -3,6 +3,8 @@
  * @license MPL-2.0
  */
 
+import { TextEncoder } from "util";
+
 /**
  * Escape an argument for use in csh when interpolation is active.
  *


### PR DESCRIPTION
Relates to #659, #870

## Summary

Explicit imports are preferred over using globals as it makes it explicit what is being used, improving understandability by reducing the need to guess.