### PR TITLE
Use `node:` protocol imports in library code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -246,7 +246,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14.17.0
+          - 14.18.0
           - 16.13.0
           - 18.0.0
           - 19.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 ## [Unreleased]
 
 - BREAKING CHANGE: Drop support for Node.js `^10.13.0`, `^12`, `14.0.0` through
-  `14.17.0`, and `16.0.0` through `16.13.0`. ([#963])
+  `14.18.0`, and `16.0.0` through `16.13.0`. ([#963])
 - Bump dependency `which` from v2 to v3. ([#963])
 
 ## [1.7.0] - 2023-06-12

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@
  * @license MPL-2.0
  */
 
-import os from "os";
-import process from "process";
+import os from "node:os";
+import process from "node:process";
 
 import { escapeShellArg, quoteShellArg } from "./src/main.js";
 import { getHelpersByPlatform } from "./src/platforms.js";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "typings": "index.d.ts",
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || ^18 || ^19 || ^20"
+    "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20"
   },
   "repository": {
     "type": "git",
@@ -106,7 +106,7 @@
     "lint:yml": "npm run _eslint -- --ext .yml",
     "test": "npm run test:unit",
     "test:compat": "mocha test/compat/**/*.test.cjs",
-    "test:compat-all": "nve 14.17.0,16.13.0,18.0.0,19.0.0,20.0.0 mocha test/compat/**/*.test.cjs",
+    "test:compat-all": "nve 14.18.0,16.13.0,18.0.0,19.0.0,20.0.0 mocha test/compat/**/*.test.cjs",
     "test:e2e": "ava test/e2e/**/*.test.js --timeout 1m",
     "test:integration": "ava test/integration/**/*.test.js --timeout 1m",
     "test:mutation": "stryker run stryker.config.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,13 @@
 // Check out rollup.js at: https://rollupjs.org/guide/en/
 
-const external = ["fs", "os", "path", "process", "util", "which"];
+const external = [
+  "node:fs",
+  "node:os",
+  "node:path",
+  "node:process",
+  "node:util",
+  "which",
+];
 
 export default [
   {

--- a/src/unix.js
+++ b/src/unix.js
@@ -3,8 +3,8 @@
  * @license MPL-2.0
  */
 
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 import which from "which";
 

--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -3,7 +3,7 @@
  * @license MPL-2.0
  */
 
-import { TextEncoder } from "util";
+import { TextEncoder } from "node:util";
 
 /**
  * Escape an argument for use in csh when interpolation is active.

--- a/src/win.js
+++ b/src/win.js
@@ -3,8 +3,8 @@
  * @license MPL-2.0
  */
 
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 import which from "which";
 


### PR DESCRIPTION
Merges into #963
Relates to #237

## Summary

Update all imports of built-in modules in the library code to use `node:` protocol imports.

~~Currently on hold because it requires a higher minimum version than #963. Whether or not it makes sense to go with a slightly higher minimum version (`v14.17.0 -> v14.18.0`) _just_ for `node:` protocol imports is TBD. Perhaps the version has to be raised for a different reason, in which case this can be merged without further consideration.~~

I've decided to include this change in the v2.0.0 release because:
1. I'm pretty sure anyone using v14.17.0 could also be using v14.18.0 or higher. Even if non-trivial, I think anyone on a legacy version of Node.js should be prepared to make such adjustments.
2. If point 1 turns out to be wrong, this change can always be reverted and the minimum supported Node.js version of Shescape updated.