### PR TITLE
Correction to the documentation for quoting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Correct documented behavior of quoting functions. ([#969])
 
 ## [1.7.0] - 2023-06-12
 
@@ -259,6 +259,7 @@ Versioning].
 [#908]: https://github.com/ericcornelissen/shescape/pull/908
 [#909]: https://github.com/ericcornelissen/shescape/pull/909
 [#936]: https://github.com/ericcornelissen/shescape/pull/936
+[#969]: https://github.com/ericcornelissen/shescape/pull/969
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ export function escape(arg: string, options?: EscapeOptions): string;
 export function escapeAll(args: string[], options?: EscapeOptions): string[];
 
 /**
- * Take a single value, the argument, put OS-specific quotes around it and
+ * Take a single value, the argument, put shell-specific quotes around it and
  * escape any dangerous characters.
  *
  * Non-string inputs will be converted to strings using a `toString()` method.
@@ -144,8 +144,8 @@ export function escapeAll(args: string[], options?: EscapeOptions): string[];
 export function quote(arg: string, options?: QuoteOptions): string;
 
 /**
- * Take an array of values, the arguments, put OS-specific quotes around every
- * argument and escape any dangerous characters in every argument.
+ * Take an array of values, the arguments, put shell-specific quotes around
+ * every argument and escape any dangerous characters in every argument.
  *
  * Non-array inputs will be converted to one-value arrays and non-string values
  * will be converted to strings using a `toString()` method.

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ export function escapeAll(args, options = {}) {
 }
 
 /**
- * Take a single value, the argument, put OS-specific quotes around it and
+ * Take a single value, the argument, put shell-specific quotes around it and
  * escape any dangerous characters.
  *
  * Non-string inputs will be converted to strings using a `toString()` method.
@@ -120,8 +120,8 @@ export function quote(arg, options = {}) {
 }
 
 /**
- * Take an array of values, the arguments, put OS-specific quotes around every
- * argument and escape any dangerous characters in every argument.
+ * Take an array of values, the arguments, put shell-specific quotes around
+ * every argument and escape any dangerous characters in every argument.
  *
  * Non-array inputs will be converted to one-value arrays and non-string values
  * will be converted to strings using a `toString()` method.


### PR DESCRIPTION
## Summary

Quotes are shell specific, not necessarily the same for all shells for a given OS.