### PR TITLE
Test coverage for environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Versioning].
 
 ## [Unreleased]
 
+- Add `%` escaping for CMD. ([#982])
 - Correct documented behavior of quoting functions. ([#969])
+- Expand injection strings to cover environment variables. ([#982])
 
 ## [1.7.0] - 2023-06-12
 
@@ -260,6 +262,7 @@ Versioning].
 [#909]: https://github.com/ericcornelissen/shescape/pull/909
 [#936]: https://github.com/ericcornelissen/shescape/pull/936
 [#969]: https://github.com/ericcornelissen/shescape/pull/969
+[#982]: https://github.com/ericcornelissen/shescape/pull/982
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -14,7 +14,7 @@ function escapeArgForInterpolation(arg) {
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/\r?\n|\r/gu, " ")
     .replace(/\^/gu, "^^")
-    .replace(/(["&<>|])/gu, "^$1");
+    .replace(/(["%&<>|])/gu, "^$1");
 }
 
 /**
@@ -53,6 +53,7 @@ function escapeArgForQuoted(arg) {
   return arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/\r?\n|\r/gu, " ")
+    .replace(/%/gu, "^%")
     .replace(/"/gu, `""`);
 }
 

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -854,6 +854,16 @@ export const escape = {
         expected: { interpolation: "a$b$c", noInterpolation: "a$b$c" },
       },
     ],
+    "percentage signs ('%')": [
+      {
+        input: "a%b",
+        expected: { interpolation: "a^%b", noInterpolation: "a%b" },
+      },
+      {
+        input: "a%b%c",
+        expected: { interpolation: "a^%b^%c", noInterpolation: "a%b%c" },
+      },
+    ],
     "ampersands ('&')": [
       {
         input: "a&b",
@@ -2010,6 +2020,16 @@ export const escape = {
         expected: { interpolation: "a`$b`$c", noInterpolation: "a`$b`$c" },
       },
     ],
+    "percentage signs ('%')": [
+      {
+        input: "a%b",
+        expected: { interpolation: "a%b", noInterpolation: "a%b" },
+      },
+      {
+        input: "a%b%c",
+        expected: { interpolation: "a%b%c", noInterpolation: "a%b%c" },
+      },
+    ],
     "ampersands ('&')": [
       {
         input: "a&b",
@@ -2949,6 +2969,16 @@ export const quote = {
         expected: '"a$b$c"',
       },
     ],
+    "percentage signs ('%')": [
+      {
+        input: "a%b",
+        expected: '"a^%b"',
+      },
+      {
+        input: "a%b%c",
+        expected: '"a^%b^%c"',
+      },
+    ],
     "left double quotation mark ('“')": [
       {
         input: "a“b",
@@ -3145,6 +3175,16 @@ export const quote = {
       {
         input: "a$b$c",
         expected: '"a`$b`$c"',
+      },
+    ],
+    "percentage signs ('%')": [
+      {
+        input: "a%b",
+        expected: '"a%b"',
+      },
+      {
+        input: "a%b%c",
+        expected: '"a%b%c"',
       },
     ],
     "left double quotation mark ('“')": [

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -49,11 +49,12 @@ function isShellPowerShell(shell) {
  *
  * @param {object} args The function arguments.
  * @param {string} args.arg The input argument that was echoed.
+ * @param {boolean} args.quoted Was `arg` quoted prior to echoing.
  * @param {string} args.shell The shell used for echoing.
  * @param {boolean} normalizeWhitespace Whether whitespace should be normalized.
  * @returns {string} The expected echoed value.
  */
-function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
+function getExpectedOutput({ arg, quoted, shell }, normalizeWhitespace) {
   // Remove control characters, like Shescape
   arg = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
 
@@ -62,6 +63,11 @@ function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
     arg = arg.replace(/\r?\n|\r/gu, " ");
   } else {
     arg = arg.replace(/\r(?!\n)/gu, "");
+  }
+
+  // Adjust % for shell when quoted
+  if (isShellCmd(shell) && quoted) {
+    arg = arg.replace(/%/gu, "^%");
   }
 
   if (normalizeWhitespace) {

--- a/testing.js
+++ b/testing.js
@@ -15,7 +15,15 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  *   assert.equal(result, "no injection");
  * }
  */
-export const injectionStrings = ["\x00world", "&& ls", "'; ls #", '"; ls #'];
+export const injectionStrings = [
+  "\x00world",
+  "&& ls",
+  "'; ls #",
+  '"; ls #',
+  "$PATH",
+  "$Env:PATH",
+  "%PATH%",
+];
 
 /**
  * A test stub of shescape that has the same input-output profile as the real


### PR DESCRIPTION
Relates to #976

## Summary

Improve testing w.r.t. protection against injection of environment variables. Fix a bug uncovered by these new tests in escaping for CMD, which did not cover escaping for environment variables before this Pull Request.

As of this Pull Request the escaping of environment variables when using `quote(All)` is not perfect in that it adds unexpected characters to the string received by the target program. A solution for this was not found in time, but pushing out any solution for the environment variables bug is seen as more important.