### PR TITLE
Use single quotes when quoting for PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 - Correct documented behavior of quoting functions. ([#969])
 - Expand injection strings to cover environment variables. ([#982])
 - Fix incorrect escaping of `$` and backticks for PowerShell. ([#984])
+- Improve quoting functionality for PowerShell. ([#983])
 
 ## [1.7.0] - 2023-06-12
 
@@ -264,6 +265,7 @@ Versioning].
 [#936]: https://github.com/ericcornelissen/shescape/pull/936
 [#969]: https://github.com/ericcornelissen/shescape/pull/969
 [#982]: https://github.com/ericcornelissen/shescape/pull/982
+[#983]: https://github.com/ericcornelissen/shescape/pull/983
 [#984]: https://github.com/ericcornelissen/shescape/pull/984
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -61,10 +61,8 @@ export function getEscapeFunction(options) {
 function escapeArgForQuoted(arg) {
   return arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/`/gu, "``")
-    .replace(/\$/gu, "`$$")
     .replace(/\r(?!\n)/gu, "")
-    .replace(/(["“”„])/gu, "$1$1");
+    .replace(/(['‘’‚‛])/gu, "$1$1");
 }
 
 /**

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -74,7 +74,7 @@ function escapeArgForQuoted(arg) {
  * @returns {string} The quoted and escaped argument.
  */
 function quoteArg(arg) {
-  return `"${arg}"`;
+  return `'${arg}'`;
 }
 
 /**

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -2667,133 +2667,133 @@ export const flag = {
     "sample strings": [
       {
         input: "foobar",
-        expected: { unquoted: "foobar", quoted: '"foobar"' },
+        expected: { unquoted: "foobar", quoted: "'foobar'" },
       },
     ],
     "single hyphen (-)": [
       {
         input: "-a",
-        expected: { unquoted: "a", quoted: '"a"' },
+        expected: { unquoted: "a", quoted: "'a'" },
       },
       {
         input: "a-",
-        expected: { unquoted: "a-", quoted: '"a-"' },
+        expected: { unquoted: "a-", quoted: "'a-'" },
       },
       {
         input: "-a-",
-        expected: { unquoted: "a-", quoted: '"a-"' },
+        expected: { unquoted: "a-", quoted: "'a-'" },
       },
       {
         input: "-ab",
-        expected: { unquoted: "ab", quoted: '"ab"' },
+        expected: { unquoted: "ab", quoted: "'ab'" },
       },
       {
         input: "a-b",
-        expected: { unquoted: "a-b", quoted: '"a-b"' },
+        expected: { unquoted: "a-b", quoted: "'a-b'" },
       },
       {
         input: "-a-b",
-        expected: { unquoted: "a-b", quoted: '"a-b"' },
+        expected: { unquoted: "a-b", quoted: "'a-b'" },
       },
       {
         input: "-a=b",
-        expected: { unquoted: "a=b", quoted: '"a=b"' },
+        expected: { unquoted: "a=b", quoted: "'a=b'" },
       },
     ],
     "double hyphen (--)": [
       {
         input: "--a",
-        expected: { unquoted: "a", quoted: '"a"' },
+        expected: { unquoted: "a", quoted: "'a'" },
       },
       {
         input: "a--",
-        expected: { unquoted: "a--", quoted: '"a--"' },
+        expected: { unquoted: "a--", quoted: "'a--'" },
       },
       {
         input: "--a--",
-        expected: { unquoted: "a--", quoted: '"a--"' },
+        expected: { unquoted: "a--", quoted: "'a--'" },
       },
       {
         input: "--ab",
-        expected: { unquoted: "ab", quoted: '"ab"' },
+        expected: { unquoted: "ab", quoted: "'ab'" },
       },
       {
         input: "a--b",
-        expected: { unquoted: "a--b", quoted: '"a--b"' },
+        expected: { unquoted: "a--b", quoted: "'a--b'" },
       },
       {
         input: "--a--b",
-        expected: { unquoted: "a--b", quoted: '"a--b"' },
+        expected: { unquoted: "a--b", quoted: "'a--b'" },
       },
       {
         input: "--a=b",
-        expected: { unquoted: "a=b", quoted: '"a=b"' },
+        expected: { unquoted: "a=b", quoted: "'a=b'" },
       },
     ],
     "many hyphens (/-{3,}/)": [
       {
         input: "---a",
-        expected: { unquoted: "a", quoted: '"a"' },
+        expected: { unquoted: "a", quoted: "'a'" },
       },
       {
         input: "---ab",
-        expected: { unquoted: "ab", quoted: '"ab"' },
+        expected: { unquoted: "ab", quoted: "'ab'" },
       },
       {
         input: "---a=b",
-        expected: { unquoted: "a=b", quoted: '"a=b"' },
+        expected: { unquoted: "a=b", quoted: "'a=b'" },
       },
     ],
     "forward slash (/)": [
       {
         input: "/a",
-        expected: { unquoted: "a", quoted: '"a"' },
+        expected: { unquoted: "a", quoted: "'a'" },
       },
       {
         input: "a/",
-        expected: { unquoted: "a/", quoted: '"a/"' },
+        expected: { unquoted: "a/", quoted: "'a/'" },
       },
       {
         input: "/a/",
-        expected: { unquoted: "a/", quoted: '"a/"' },
+        expected: { unquoted: "a/", quoted: "'a/'" },
       },
       {
         input: "/ab",
-        expected: { unquoted: "ab", quoted: '"ab"' },
+        expected: { unquoted: "ab", quoted: "'ab'" },
       },
       {
         input: "a/b",
-        expected: { unquoted: "a/b", quoted: '"a/b"' },
+        expected: { unquoted: "a/b", quoted: "'a/b'" },
       },
       {
         input: "/a/b",
-        expected: { unquoted: "a/b", quoted: '"a/b"' },
+        expected: { unquoted: "a/b", quoted: "'a/b'" },
       },
     ],
     "multiple forward slashes (//{2,}/)": [
       {
         input: "//a",
-        expected: { unquoted: "a", quoted: '"a"' },
+        expected: { unquoted: "a", quoted: "'a'" },
       },
       {
         input: "a//",
-        expected: { unquoted: "a//", quoted: '"a//"' },
+        expected: { unquoted: "a//", quoted: "'a//'" },
       },
       {
         input: "//a//",
-        expected: { unquoted: "a//", quoted: '"a//"' },
+        expected: { unquoted: "a//", quoted: "'a//'" },
       },
       {
         input: "//ab",
-        expected: { unquoted: "ab", quoted: '"ab"' },
+        expected: { unquoted: "ab", quoted: "'ab'" },
       },
       {
         input: "a//b",
-        expected: { unquoted: "a//b", quoted: '"a//b"' },
+        expected: { unquoted: "a//b", quoted: "'a//b'" },
       },
       {
         input: "//a//b",
-        expected: { unquoted: "a//b", quoted: '"a//b"' },
+        expected: { unquoted: "a//b", quoted: "'a//b'" },
       },
     ],
   },
@@ -3002,209 +3002,209 @@ export const quote = {
     "sample strings": [
       {
         input: "a",
-        expected: '"a"',
+        expected: "'a'",
       },
     ],
     "<null> (\\0)": [
       {
         input: "a\x00b",
-        expected: '"ab"',
+        expected: "'ab'",
       },
       {
         input: "a\x00b\x00c",
-        expected: '"abc"',
+        expected: "'abc'",
       },
       {
         input: "a\x00",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "\x00a",
-        expected: '"a"',
+        expected: "'a'",
       },
     ],
     "<backspace> (\\b)": [
       {
         input: "a\bb",
-        expected: '"ab"',
+        expected: "'ab'",
       },
       {
         input: "a\bb\bc",
-        expected: '"abc"',
+        expected: "'abc'",
       },
       {
         input: "a\b",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "\ba",
-        expected: '"a"',
+        expected: "'a'",
       },
     ],
     "<end of line> ('\\n')": [
       {
         input: "a\nb",
-        expected: '"a\nb"',
+        expected: "'a\nb'",
       },
       {
         input: "a\nb\nc",
-        expected: '"a\nb\nc"',
+        expected: "'a\nb\nc'",
       },
       {
         input: "a\n",
-        expected: '"a\n"',
+        expected: "'a\n'",
       },
       {
         input: "\na",
-        expected: '"\na"',
+        expected: "'\na'",
       },
     ],
     "<carriage return> ('\\r')": [
       {
         input: "a\rb",
-        expected: '"ab"',
+        expected: "'ab'",
       },
       {
         input: "a\rb\rc",
-        expected: '"abc"',
+        expected: "'abc'",
       },
       {
         input: "\ra",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "a\r",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "a\r\nb",
-        expected: '"a\r\nb"',
+        expected: "'a\r\nb'",
       },
     ],
     "<escape> ('\\u001B')": [
       {
         input: "a\u001Bb",
-        expected: '"ab"',
+        expected: "'ab'",
       },
       {
         input: "a\u001Bb\u001Bc",
-        expected: '"abc"',
+        expected: "'abc'",
       },
       {
         input: "a\u001B",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "\u001Ba",
-        expected: '"a"',
+        expected: "'a'",
       },
     ],
     "<control sequence introducer> ('\\u009B')": [
       {
         input: "a\u009Bb",
-        expected: '"ab"',
+        expected: "'ab'",
       },
       {
         input: "a\u009Bb\u009Bc",
-        expected: '"abc"',
+        expected: "'abc'",
       },
       {
         input: "a\u009B",
-        expected: '"a"',
+        expected: "'a'",
       },
       {
         input: "\u009Ba",
-        expected: '"a"',
+        expected: "'a'",
       },
     ],
     "double quotes ('\"')": [
       {
         input: 'a"b',
-        expected: '"a""b"',
+        expected: "'a\"\"b'",
       },
       {
         input: 'a"b"c',
-        expected: '"a""b""c"',
+        expected: '\'a""b""c\'',
       },
     ],
     "backticks ('`')": [
       {
         input: "a`b",
-        expected: '"a``b"',
+        expected: "'a``b'",
       },
       {
         input: "a`b`c",
-        expected: '"a``b``c"',
+        expected: "'a``b``c'",
       },
     ],
     "dollar signs ('$')": [
       {
         input: "a$b",
-        expected: '"a`$b"',
+        expected: "'a`$b'",
       },
       {
         input: "a$b$c",
-        expected: '"a`$b`$c"',
+        expected: "'a`$b`$c'",
       },
     ],
     "left double quotation mark ('“')": [
       {
         input: "a“b",
-        expected: '"a““b"',
+        expected: "'a““b'",
       },
       {
         input: "a“b“c",
-        expected: '"a““b““c"',
+        expected: "'a““b““c'",
       },
     ],
     "right double quotation mark ('”')": [
       {
         input: "a”b",
-        expected: '"a””b"',
+        expected: "'a””b'",
       },
       {
         input: "a”b”c",
-        expected: '"a””b””c"',
+        expected: "'a””b””c'",
       },
     ],
     "double low-9 quotation mark ('„')": [
       {
         input: "a„b",
-        expected: '"a„„b"',
+        expected: "'a„„b'",
       },
       {
         input: "a„b„c",
-        expected: '"a„„b„„c"',
+        expected: "'a„„b„„c'",
       },
     ],
     "hyphens ('-')": [
       {
         input: "-a",
-        expected: '"-a"',
+        expected: "'-a'",
       },
       {
         input: "-a-b",
-        expected: '"-a-b"',
+        expected: "'-a-b'",
       },
       {
         input: "a-b",
-        expected: '"a-b"',
+        expected: "'a-b'",
       },
       {
         input: "a-b-c",
-        expected: '"a-b-c"',
+        expected: "'a-b-c'",
       },
       {
         input: "a -b",
-        expected: '"a -b"',
+        expected: "'a -b'",
       },
       {
         input: "a\t-b",
-        expected: '"a\t-b"',
+        expected: "'a\t-b'",
       },
       {
         input: "a\u0085-b",
-        expected: '"a\u0085-b"',
+        expected: "'a\u0085-b'",
       },
     ],
   },

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -2939,6 +2939,16 @@ export const quote = {
         expected: '"a"',
       },
     ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: '"a\'b"',
+      },
+      {
+        input: "a'b'c",
+        expected: "\"a'b'c\"",
+      },
+    ],
     "double quotes ('\"')": [
       {
         input: 'a"b',
@@ -2979,6 +2989,24 @@ export const quote = {
         expected: '"a^%b^%c"',
       },
     ],
+    "hyphens ('-')": [
+      {
+        input: "-a",
+        expected: '"-a"',
+      },
+      {
+        input: "-a-b",
+        expected: '"-a-b"',
+      },
+      {
+        input: "a-b",
+        expected: '"a-b"',
+      },
+      {
+        input: "a-b-c",
+        expected: '"a-b-c"',
+      },
+    ],
     "left double quotation mark ('“')": [
       {
         input: "a“b",
@@ -3009,22 +3037,44 @@ export const quote = {
         expected: '"a„b„c"',
       },
     ],
-    "hyphens ('-')": [
+    "left single quotation mark ('‘')": [
       {
-        input: "-a",
-        expected: '"-a"',
+        input: "a‘b",
+        expected: '"a‘b"',
       },
       {
-        input: "-a-b",
-        expected: '"-a-b"',
+        input: "a‘b‘c",
+        expected: '"a‘b‘c"',
+      },
+    ],
+    "right single quotation mark ('’')": [
+      {
+        input: "a’b",
+        expected: '"a’b"',
       },
       {
-        input: "a-b",
-        expected: '"a-b"',
+        input: "a’b’c",
+        expected: '"a’b’c"',
+      },
+    ],
+    "single low-9 quotation mark ('‚')": [
+      {
+        input: "a‚b",
+        expected: '"a‚b"',
       },
       {
-        input: "a-b-c",
-        expected: '"a-b-c"',
+        input: "a‚b‚c",
+        expected: '"a‚b‚c"',
+      },
+    ],
+    "single high-reversed-9 quotation mark ('‛')": [
+      {
+        input: "a‛b",
+        expected: '"a‛b"',
+      },
+      {
+        input: "a‛b‛c",
+        expected: '"a‛b‛c"',
       },
     ],
   },
@@ -3147,74 +3197,54 @@ export const quote = {
         expected: "'a'",
       },
     ],
+    'single quotes ("\'")': [
+      {
+        input: "a'b",
+        expected: "'a''b'",
+      },
+      {
+        input: "a'b'c",
+        expected: "'a''b''c'",
+      },
+    ],
     "double quotes ('\"')": [
       {
         input: 'a"b',
-        expected: "'a\"\"b'",
+        expected: "'a\"b'",
       },
       {
         input: 'a"b"c',
-        expected: '\'a""b""c\'',
+        expected: "'a\"b\"c'",
       },
     ],
     "backticks ('`')": [
       {
         input: "a`b",
-        expected: "'a``b'",
+        expected: "'a`b'",
       },
       {
         input: "a`b`c",
-        expected: "'a``b``c'",
+        expected: "'a`b`c'",
       },
     ],
     "dollar signs ('$')": [
       {
         input: "a$b",
-        expected: "'a`$b'",
+        expected: "'a$b'",
       },
       {
         input: "a$b$c",
-        expected: "'a`$b`$c'",
+        expected: "'a$b$c'",
       },
     ],
     "percentage signs ('%')": [
       {
         input: "a%b",
-        expected: '"a%b"',
+        expected: "'a%b'",
       },
       {
         input: "a%b%c",
-        expected: '"a%b%c"',
-      },
-    ],
-    "left double quotation mark ('“')": [
-      {
-        input: "a“b",
-        expected: "'a““b'",
-      },
-      {
-        input: "a“b“c",
-        expected: "'a““b““c'",
-      },
-    ],
-    "right double quotation mark ('”')": [
-      {
-        input: "a”b",
-        expected: "'a””b'",
-      },
-      {
-        input: "a”b”c",
-        expected: "'a””b””c'",
-      },
-    ],
-    "double low-9 quotation mark ('„')": [
-      {
-        input: "a„b",
-        expected: "'a„„b'",
-      },
-      {
-        input: "a„b„c",
-        expected: "'a„„b„„c'",
+        expected: "'a%b%c'",
       },
     ],
     "hyphens ('-')": [
@@ -3245,6 +3275,76 @@ export const quote = {
       {
         input: "a\u0085-b",
         expected: "'a\u0085-b'",
+      },
+    ],
+    "left double quotation mark ('“')": [
+      {
+        input: "a“b",
+        expected: "'a“b'",
+      },
+      {
+        input: "a“b“c",
+        expected: "'a“b“c'",
+      },
+    ],
+    "right double quotation mark ('”')": [
+      {
+        input: "a”b",
+        expected: "'a”b'",
+      },
+      {
+        input: "a”b”c",
+        expected: "'a”b”c'",
+      },
+    ],
+    "double low-9 quotation mark ('„')": [
+      {
+        input: "a„b",
+        expected: "'a„b'",
+      },
+      {
+        input: "a„b„c",
+        expected: "'a„b„c'",
+      },
+    ],
+    "left single quotation mark ('‘')": [
+      {
+        input: "a‘b",
+        expected: "'a‘‘b'",
+      },
+      {
+        input: "a‘b‘c",
+        expected: "'a‘‘b‘‘c'",
+      },
+    ],
+    "right single quotation mark ('’')": [
+      {
+        input: "a’b",
+        expected: "'a’’b'",
+      },
+      {
+        input: "a’b’c",
+        expected: "'a’’b’’c'",
+      },
+    ],
+    "single low-9 quotation mark ('‚')": [
+      {
+        input: "a‚b",
+        expected: "'a‚‚b'",
+      },
+      {
+        input: "a‚b‚c",
+        expected: "'a‚‚b‚‚c'",
+      },
+    ],
+    "single high-reversed-9 quotation mark ('‛')": [
+      {
+        input: "a‛b",
+        expected: "'a‛‛b'",
+      },
+      {
+        input: "a‛b‛c",
+        expected: "'a‛‛b‛‛c'",
       },
     ],
   },


### PR DESCRIPTION
Relates to #976, #982, #984

## Summary

The quoting implementation for PowerShell incorrectly used double quotes which, like most Unix Shells, allows for string interpolation - i.e. `"$Env:PATH"` would expand the PATH environment variable whereas `'$Env:PATH'` would not. Hence, PowerShell quoting should be using single quotes to prevent interpolation. Tests have been updated accordingly.

~~The effects of this are TBD because it looks like [the escaping logic when quoting](https://github.com/ericcornelissen/shescape/blob/bfd88e7ffbfb75eee1236194ff9025be032d48d1/src/win/powershell.js#L61-L68) did account for this. The tests being added in #982 support this.~~ As far as I can tell this change does not have security or behavioral implication and does not fix any bugs. It is an improvement in two ways: 1) it should be more performant as there's less `replace`ments, and 2) it makes the library more defensive-in-depth by eliminating the possibility of interpolation when quoting entirely[^1].

[^1]: In case I missed an attack vector... In which case, please report it with a example exploit as it would most likely deserve a vulnerability identifier.