### PR TITLE
Update escaping for PowerShell with `{interpolation:false}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 - Add `%` escaping for CMD. ([#982])
 - Correct documented behavior of quoting functions. ([#969])
 - Expand injection strings to cover environment variables. ([#982])
+- Fix incorrect escaping of `$` and backticks for PowerShell. ([#984])
 
 ## [1.7.0] - 2023-06-12
 
@@ -263,6 +264,7 @@ Versioning].
 [#936]: https://github.com/ericcornelissen/shescape/pull/936
 [#969]: https://github.com/ericcornelissen/shescape/pull/969
 [#982]: https://github.com/ericcornelissen/shescape/pull/982
+[#984]: https://github.com/ericcornelissen/shescape/pull/984
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -29,10 +29,7 @@ function escapeArgForInterpolation(arg) {
  * @returns {string} The escaped argument.
  */
 function escapeArgForNoInterpolation(arg) {
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/`/gu, "``")
-    .replace(/\r(?!\n)/gu, "");
+  return arg.replace(/[\0\u0008\u001B\u009B]/gu, "").replace(/\r(?!\n)/gu, "");
 }
 
 /**

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -32,7 +32,6 @@ function escapeArgForNoInterpolation(arg) {
   return arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/`/gu, "``")
-    .replace(/\$/gu, "`$$")
     .replace(/\r(?!\n)/gu, "");
 }
 

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -2003,11 +2003,11 @@ export const escape = {
     "dollar signs ('$')": [
       {
         input: "a$b",
-        expected: { interpolation: "a`$b", noInterpolation: "a`$b" },
+        expected: { interpolation: "a`$b", noInterpolation: "a$b" },
       },
       {
         input: "a$b$c",
-        expected: { interpolation: "a`$b`$c", noInterpolation: "a`$b`$c" },
+        expected: { interpolation: "a`$b`$c", noInterpolation: "a$b$c" },
       },
     ],
     "ampersands ('&')": [

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -1927,11 +1927,11 @@ export const escape = {
     "backticks ('`')": [
       {
         input: "a`b",
-        expected: { interpolation: "a``b", noInterpolation: "a``b" },
+        expected: { interpolation: "a``b", noInterpolation: "a`b" },
       },
       {
         input: "a`b`c",
-        expected: { interpolation: "a``b``c", noInterpolation: "a``b``c" },
+        expected: { interpolation: "a``b``c", noInterpolation: "a`b`c" },
       },
     ],
     "at signs ('@')": [


### PR DESCRIPTION
Relates to #983

## Summary

The escape logic for PowerShell with `{interpolation:false}` (not quote) would escape "$" as "{backtick}$" and "{backtick}" as "{backtick}{backtick}". Both of these escapings are unnecessary for legitimate use cases and would lead to the exact value "{backtick}$" resp. "{backtick}{backtick}" being received by the invoked program.