### PR TITLE
Move CI auditing into separate workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,13 @@
+name: Audit
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  audit:
+    name: Audit
+    uses: ericcornelissen/shescape/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,9 +8,6 @@ on:
 permissions: read-all
 
 jobs:
-  audit:
-    name: Audit
-    uses: ericcornelissen/shescape/.github/workflows/reusable-audit.yml@main
   benchmark:
     name: Benchmark
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Separate the continuous audit job from the general checks workflow. The motivation for this is that checks should always pass (similar to `npm run verify`), but audit may not always be passing and this is not always a problem.

One place where this has an immediate impact is the build status badge in the README, which will no longer show as failing when the audit job is failing.