### PR TITLE
Reduce integration tests coverage of transpiled library

### DIFF
--- a/test/integration/escape-all.test.js
+++ b/test/integration/escape-all.test.js
@@ -9,90 +9,83 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { escape, escapeAll as escapeAllEsm } from "../../index.js";
+import { escape, escapeAll } from "../../index.js";
 import { escapeAll as escapeAllCjs } from "../../index.cjs";
 
-const cases = [
-  { escapeAll: escapeAllCjs, type: "cjs" },
-  { escapeAll: escapeAllEsm, type: "esm" },
-];
+test("inputs are escaped", (t) => {
+  for (const { expected, input, options } of generate.escapeExamples()) {
+    const result = escapeAll([input], options);
+    t.deepEqual(result, [expected]);
+  }
+});
 
-for (const { escapeAll, type } of cases) {
-  test(`inputs are escaped (${type})`, (t) => {
-    for (const { expected, input, options } of generate.escapeExamples()) {
-      const result = escapeAll([input], options);
-      t.deepEqual(result, [expected]);
-    }
-  });
+testProp(
+  "return values",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const result = escapeAll(args, options);
+    t.deepEqual(
+      result,
+      args.map((arg) => escape(arg, options))
+    );
+  }
+);
 
-  testProp(
-    `return values (${type})`,
-    [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
-    (t, args, options) => {
-      const result = escapeAll(args, options);
-      t.deepEqual(
-        result,
-        args.map((arg) => escape(arg, options))
-      );
-    }
-  );
+testProp(
+  "return size",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const result = escapeAll(args, options);
+    t.is(result.length, args.length);
+  }
+);
 
-  testProp(
-    `return size (${type})`,
-    [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
-    (t, args, options) => {
-      const result = escapeAll(args, options);
-      t.is(result.length, args.length);
-    }
-  );
+testProp(
+  "extra arguments",
+  [
+    fc.array(arbitrary.shescapeArg()),
+    arbitrary.shescapeArg(),
+    arbitrary.shescapeOptions(),
+  ],
+  (t, args, extraArg, options) => {
+    const r1 = escapeAll(args, options);
 
-  testProp(
-    `extra arguments (${type})`,
-    [
-      fc.array(arbitrary.shescapeArg()),
-      arbitrary.shescapeArg(),
-      arbitrary.shescapeOptions(),
-    ],
-    (t, args, extraArg, options) => {
-      const r1 = escapeAll(args, options);
+    const r2 = escapeAll([...args, extraArg], options);
+    t.deepEqual(r2, [...r1, escape(extraArg, options)]);
 
-      const r2 = escapeAll([...args, extraArg], options);
-      t.deepEqual(r2, [...r1, escape(extraArg, options)]);
+    const r3 = escapeAll([extraArg, ...args], options);
+    t.deepEqual(r3, [escape(extraArg, options), ...r1]);
+  }
+);
 
-      const r3 = escapeAll([extraArg, ...args], options);
-      t.deepEqual(r3, [escape(extraArg, options), ...r1]);
-    }
-  );
+testProp(
+  "non-array input",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const result = escapeAll(arg, options);
+    t.is(result.length, 1);
 
-  testProp(
-    `non-array input (${type})`,
-    [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
-    (t, arg, options) => {
-      const result = escapeAll(arg, options);
-      t.is(result.length, 1);
+    const entry = result[0];
+    t.is(entry, escape(arg, options));
+  }
+);
 
-      const entry = result[0];
-      t.is(entry, escape(arg, options));
-    }
-  );
+test("invalid arguments", (t) => {
+  for (const { value } of constants.illegalArguments) {
+    t.throws(() => escapeAll([value]));
+    t.throws(() => escapeAll(value));
+  }
+});
 
-  test(`invalid arguments (${type})`, (t) => {
-    for (const { value } of constants.illegalArguments) {
-      t.throws(() => escapeAll([value]));
-      t.throws(() => escapeAll(value));
-    }
-  });
-
-  test(type, macros.prototypePollution, (_, payload) => {
-    escapeAll(["a"], payload);
-  });
-}
+test(macros.prototypePollution, (_, payload) => {
+  escapeAll(["a"], payload);
+});
 
 testProp(
   "esm === cjs",
   [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
   (t, args, options) => {
-    const resultEsm = escapeAllEsm(args, options);
+    const resultEsm = escapeAll(args, options);
     const resultCjs = escapeAllCjs(args, options);
     t.deepEqual(resultEsm, resultCjs);
   }

--- a/test/integration/escape.test.js
+++ b/test/integration/escape.test.js
@@ -8,47 +8,40 @@ import test from "ava";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { escape as escapeEsm } from "../../index.js";
+import { escape as escape } from "../../index.js";
 import { escape as escapeCjs } from "../../index.cjs";
 
-const cases = [
-  { escape: escapeCjs, type: "cjs" },
-  { escape: escapeEsm, type: "esm" },
-];
+test("input is escaped", (t) => {
+  for (const { expected, input, options } of generate.escapeExamples()) {
+    const result = escape(input, options);
+    t.is(result, expected);
+  }
+});
 
-for (const { escape, type } of cases) {
-  test(`input is escaped (${type})`, (t) => {
-    for (const { expected, input, options } of generate.escapeExamples()) {
-      const result = escape(input, options);
-      t.is(result, expected);
-    }
-  });
+testProp(
+  "return values",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const result = escape(arg, options);
+    t.is(typeof result, "string");
+  }
+);
 
-  testProp(
-    `return values (${type})`,
-    [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
-    (t, arg, options) => {
-      const result = escape(arg, options);
-      t.is(typeof result, "string");
-    }
-  );
+test("invalid arguments", (t) => {
+  for (const { value } of constants.illegalArguments) {
+    t.throws(() => escape(value));
+  }
+});
 
-  test(`invalid arguments (${type})`, (t) => {
-    for (const { value } of constants.illegalArguments) {
-      t.throws(() => escape(value));
-    }
-  });
-
-  test(type, macros.prototypePollution, (_, payload) => {
-    escape("a", payload);
-  });
-}
+test(macros.prototypePollution, (_, payload) => {
+  escape("a", payload);
+});
 
 testProp(
   "esm === cjs",
   [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
-    const resultEsm = escapeEsm(arg, options);
+    const resultEsm = escape(arg, options);
     const resultCjs = escapeCjs(arg, options);
     t.is(resultEsm, resultCjs);
   }

--- a/test/integration/quote-all.test.js
+++ b/test/integration/quote-all.test.js
@@ -9,90 +9,83 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { quote, quoteAll as quoteAllEsm } from "../../index.js";
+import { quote, quoteAll as quoteAll } from "../../index.js";
 import { quoteAll as quoteAllCjs } from "../../index.cjs";
 
-const cases = [
-  { quoteAll: quoteAllCjs, type: "cjs" },
-  { quoteAll: quoteAllEsm, type: "esm" },
-];
+test("inputs are quoted", (t) => {
+  for (const { expected, input, options } of generate.quoteExamples()) {
+    const result = quoteAll([input], options);
+    t.deepEqual(result, [expected]);
+  }
+});
 
-for (const { quoteAll, type } of cases) {
-  test(`inputs are quoted (${type})`, (t) => {
-    for (const { expected, input, options } of generate.quoteExamples()) {
-      const result = quoteAll([input], options);
-      t.deepEqual(result, [expected]);
-    }
-  });
+testProp(
+  "return values",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const result = quoteAll(args, options);
+    t.deepEqual(
+      result,
+      args.map((arg) => quote(arg, options))
+    );
+  }
+);
 
-  testProp(
-    `return values (${type})`,
-    [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
-    (t, args, options) => {
-      const result = quoteAll(args, options);
-      t.deepEqual(
-        result,
-        args.map((arg) => quote(arg, options))
-      );
-    }
-  );
+testProp(
+  "return size",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const result = quoteAll(args, options);
+    t.is(result.length, args.length);
+  }
+);
 
-  testProp(
-    `return size (${type})`,
-    [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
-    (t, args, options) => {
-      const result = quoteAll(args, options);
-      t.is(result.length, args.length);
-    }
-  );
+testProp(
+  "extra arguments",
+  [
+    fc.array(arbitrary.shescapeArg()),
+    arbitrary.shescapeArg(),
+    arbitrary.shescapeOptions(),
+  ],
+  (t, args, extraArg, options) => {
+    const r1 = quoteAll(args, options);
 
-  testProp(
-    `extra arguments (${type})`,
-    [
-      fc.array(arbitrary.shescapeArg()),
-      arbitrary.shescapeArg(),
-      arbitrary.shescapeOptions(),
-    ],
-    (t, args, extraArg, options) => {
-      const r1 = quoteAll(args, options);
+    const r2 = quoteAll([...args, extraArg], options);
+    t.deepEqual(r2, [...r1, quote(extraArg, options)]);
 
-      const r2 = quoteAll([...args, extraArg], options);
-      t.deepEqual(r2, [...r1, quote(extraArg, options)]);
+    const r3 = quoteAll([extraArg, ...args], options);
+    t.deepEqual(r3, [quote(extraArg, options), ...r1]);
+  }
+);
 
-      const r3 = quoteAll([extraArg, ...args], options);
-      t.deepEqual(r3, [quote(extraArg, options), ...r1]);
-    }
-  );
+testProp(
+  "non-array input",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const result = quoteAll(arg, options);
+    t.is(result.length, 1);
 
-  testProp(
-    `non-array input (${type})`,
-    [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
-    (t, arg, options) => {
-      const result = quoteAll(arg, options);
-      t.is(result.length, 1);
+    const entry = result[0];
+    t.is(entry, quote(arg, options));
+  }
+);
 
-      const entry = result[0];
-      t.is(entry, quote(arg, options));
-    }
-  );
+test("invalid arguments", (t) => {
+  for (const { value } of constants.illegalArguments) {
+    t.throws(() => quoteAll([value]));
+    t.throws(() => quoteAll(value));
+  }
+});
 
-  test(`invalid arguments (${type})`, (t) => {
-    for (const { value } of constants.illegalArguments) {
-      t.throws(() => quoteAll([value]));
-      t.throws(() => quoteAll(value));
-    }
-  });
-
-  test(type, macros.prototypePollution, (_, payload) => {
-    quoteAll(["a"], payload);
-  });
-}
+test(macros.prototypePollution, (_, payload) => {
+  quoteAll(["a"], payload);
+});
 
 testProp(
   "esm === cjs",
   [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
   (t, args, options) => {
-    const resultEsm = quoteAllEsm(args, options);
+    const resultEsm = quoteAll(args, options);
     const resultCjs = quoteAllCjs(args, options);
     t.deepEqual(resultEsm, resultCjs);
   }

--- a/test/integration/quote.test.js
+++ b/test/integration/quote.test.js
@@ -8,47 +8,40 @@ import test from "ava";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { quote as quoteEsm } from "../../index.js";
+import { quote as quote } from "../../index.js";
 import { quote as quoteCjs } from "../../index.cjs";
 
-const cases = [
-  { quote: quoteCjs, type: "cjs" },
-  { quote: quoteEsm, type: "esm" },
-];
+test("input is quoted", (t) => {
+  for (const { expected, input, options } of generate.quoteExamples()) {
+    const result = quote(input, options);
+    t.is(result, expected);
+  }
+});
 
-for (const { quote, type } of cases) {
-  test(`input is quoted (${type})`, (t) => {
-    for (const { expected, input, options } of generate.quoteExamples()) {
-      const result = quote(input, options);
-      t.is(result, expected);
-    }
-  });
+testProp(
+  "return value",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const result = quote(arg, options);
+    t.is(typeof result, "string");
+  }
+);
 
-  testProp(
-    `return value (${type})`,
-    [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
-    (t, arg, options) => {
-      const result = quote(arg, options);
-      t.is(typeof result, "string");
-    }
-  );
+test("invalid arguments", (t) => {
+  for (const { value } of constants.illegalArguments) {
+    t.throws(() => quote(value));
+  }
+});
 
-  test(`invalid arguments (${type})`, (t) => {
-    for (const { value } of constants.illegalArguments) {
-      t.throws(() => quote(value));
-    }
-  });
-
-  test(type, macros.prototypePollution, (_, payload) => {
-    quote("a", payload);
-  });
-}
+test(macros.prototypePollution, (_, payload) => {
+  quote("a", payload);
+});
 
 testProp(
   "esm === cjs",
   [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
-    const resultEsm = quoteEsm(arg, options);
+    const resultEsm = quote(arg, options);
     const resultCjs = quoteCjs(arg, options);
     t.is(resultEsm, resultCjs);
   }


### PR DESCRIPTION
Relates to #873

## Summary

Remove the duplication of all integration tests for both the ESM and CJS version of the library in favor of testing the ESM version extensively. The motivation for this is to speed up integration tests and reduce unnecessary work.