### PR TITLE
Split config workflow into multiple workflows

### DIFF
--- a/.github/workflows/config-codecov.yml
+++ b/.github/workflows/config-codecov.yml
@@ -1,0 +1,34 @@
+name: Config Codecov
+on:
+  pull_request:
+    paths:
+      - .github/workflows/config-codecov.yml
+      - .github/codecov.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/config-codecov.yml
+      - .github/codecov.yml
+
+permissions: read-all
+
+jobs:
+  codecov:
+    name: Codecov
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
+            api.github.com:443
+            codecov.io:443
+            github.com:443
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Validate Codecov configuration
+        uses: ericcornelissen/codecov-config-validator-action@bbb3f8ef45de6f6ce57ea8d566940bdd78b4814a # v1.0.2

--- a/.github/workflows/config-npm.yml
+++ b/.github/workflows/config-npm.yml
@@ -1,40 +1,20 @@
-name: Config
+name: Config npm
 on:
   pull_request:
     paths:
-      - .github/workflows/configs.yml
-      - .github/codecov.yml
+      - .github/workflows/config-npm.yml
       - package.json
   push:
     branches:
       - main
     paths:
-      - .github/workflows/configs.yml
-      - .github/codecov.yml
+      - .github/workflows/config-npm.yml
       - package.json
 
 permissions: read-all
 
 jobs:
-  codecov:
-    name: Codecov
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            codecov.io:443
-            github.com:443
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Validate Codecov configuration
-        uses: ericcornelissen/codecov-config-validator-action@bbb3f8ef45de6f6ce57ea8d566940bdd78b4814a # v1.0.2
-  npm:
+  package-json:
     name: package.json
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Relates to #295, #673

## Summary

Remove the general config validation CI workflow and replace it with more specific workflows. The aim is to trigger these workflows only when necessary and not, say, validate the Codecov configuration when `package.json` changed.