### PR TITLE
Resolve CVE-2023-26115

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,5 +2,9 @@
   "GHSA-c2qf-rxjj-qqgw": {
     "active": true,
     "notes": "ReDoS in various devDependency trees with limited impact. Updates should come in over time."
+  },
+  "GHSA-j8xg-fqg3-53r7": {
+    "active": true,
+    "notes": "ReDoS in the jsfuzz devDependency tree with limited impact. Updates should come in over time."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,15 @@
         "node": "^10.13.0 || ^12 || ^14 || ^16 || ^18 || ^19 || ^20"
       }
     },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -9752,17 +9761,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"


### PR DESCRIPTION
## Summary

Upgrade the transitive dependency `optionator` coming in through ESLint to the latest available version in order to resolve a transitive dependency on the word-wrap package following CVE-2023-26115. Also ignore CVE-2023-26115 because it's still in the dependency tree through jsfuzz (see [jsfuzz Merge Request 19](https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/merge_requests/19) for more that), which isn't really a problem for this vulnerability.