### PR TITLE
Update expected exit code when fuzzing in CI

### DIFF
--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           npm run fuzz -- '${{ matrix.target }}' '--fuzzTime=${{ inputs.duration }}'
           export EXIT_CODE=$?
-          if [[ ($EXIT_CODE == 124) ]]; then
+          if [[ ($EXIT_CODE == 0) ]]; then
             echo 'fuzz-error=false' >> $GITHUB_OUTPUT
             echo 'script-error=false' >> $GITHUB_OUTPUT
           elif [[ ($EXIT_CODE == 1) ]]; then


### PR DESCRIPTION
Followup to #1004

## Summary

With the switch from using `timeout` to using `--fuzzTime` the expected exit code for fuzzing (i.e. when there's no crash or other failure) changed to `0`.