### PR TITLE
Extract option parsing into a module

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,9 @@
 import os from "os";
 import process from "process";
 
-import { resolveExecutable } from "./src/executables.js";
+import { parseOptions } from "./src/options.js";
 import { getHelpersByPlatform } from "./src/platforms.js";
-import {
-  checkedToString,
-  isString,
-  toArrayIfNecessary,
-} from "./src/reflection.js";
+import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
 
 /**
  * Get the helper functions for the current platform.
@@ -28,34 +24,6 @@ function getPlatformHelpers() {
   const platform = os.platform();
   const helpers = getHelpersByPlatform({ env: process.env, platform });
   return helpers;
-}
-
-/**
- * Parses options provided to shescape.
- *
- * @param {object} args The arguments for this function.
- * @param {object} args.options The options for escaping.
- * @param {boolean} [args.options.flagProtection] Is flag protection enabled.
- * @param {boolean} [args.options.interpolation] Is interpolation enabled.
- * @param {boolean | string} [args.options.shell] The shell to escape for.
- * @param {object} args.process The `process` values.
- * @param {object} args.process.env The environment variables.
- * @param {object} deps The dependencies for this function.
- * @param {Function} deps.getDefaultShell Function to get the default shell.
- * @param {Function} deps.getShellName Function to get the name of a shell.
- * @returns {object} The parsed arguments.
- */
-function parseOptions(
-  { options: { flagProtection, interpolation, shell }, process: { env } },
-  { getDefaultShell, getShellName }
-) {
-  flagProtection = flagProtection ? true : false;
-  interpolation = interpolation ? true : false;
-  // Stryker disable next-line ObjectLiteral: env is only needed on some systems
-  shell = isString(shell) ? shell : getDefaultShell({ env });
-
-  const shellName = getShellName({ shell }, { resolveExecutable });
-  return { flagProtection, interpolation, shellName };
 }
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,34 @@
+/**
+ * @overview Provides functionality for parsing shescape options.
+ * @license MPL-2.0
+ */
+
+import { resolveExecutable } from "./executables.js";
+import { isString } from "./reflection.js";
+
+/**
+ * Parses options provided to shescape.
+ *
+ * @param {object} args The arguments for this function.
+ * @param {object} args.options The options for escaping.
+ * @param {boolean} [args.options.flagProtection] Is flag protection enabled.
+ * @param {boolean} [args.options.interpolation] Is interpolation enabled.
+ * @param {boolean | string} [args.options.shell] The shell to escape for.
+ * @param {object} args.process The `process` values.
+ * @param {object} args.process.env The environment variables.
+ * @param {object} deps The dependencies for this function.
+ * @param {Function} deps.getDefaultShell Function to get the default shell.
+ * @param {Function} deps.getShellName Function to get the name of a shell.
+ * @returns {object} The parsed arguments.
+ */
+export function parseOptions(
+  { options: { flagProtection, interpolation, shell }, process: { env } },
+  { getDefaultShell, getShellName }
+) {
+  flagProtection = flagProtection ? true : false;
+  interpolation = interpolation ? true : false;
+  shell = isString(shell) ? shell : getDefaultShell({ env });
+
+  const shellName = getShellName({ shell }, { resolveExecutable });
+  return { flagProtection, interpolation, shellName };
+}

--- a/test/unit/options/_.js
+++ b/test/unit/options/_.js
@@ -1,0 +1,8 @@
+/**
+ * @overview Provides testing utilities.
+ * @license MIT
+ */
+
+import * as arbitrary from "../../_arbitraries.js";
+
+export { arbitrary };

--- a/test/unit/options/parse-options.test.js
+++ b/test/unit/options/parse-options.test.js
@@ -1,0 +1,124 @@
+/**
+ * @overview Contains unit tests for the functionality to parse options.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+import test from "ava";
+import * as fc from "fast-check";
+import sinon from "sinon";
+
+import { arbitrary } from "./_.js";
+
+import { resolveExecutable } from "../../../src/executables.js";
+import { parseOptions } from "../../../src/options.js";
+
+const arbitraryInput = () =>
+  fc
+    .tuple(arbitrary.shescapeOptions(), arbitrary.env())
+    .map(([options, env]) => {
+      options = options || {};
+      return { options, process: { env } };
+    });
+
+test.beforeEach((t) => {
+  const getDefaultShell = sinon.stub();
+  const getShellName = sinon.stub();
+
+  t.context.deps = { getDefaultShell, getShellName };
+});
+
+testProp("flag protection not specified", [arbitraryInput()], (t, args) => {
+  delete args.options.flagProtection;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.flagProtection, false);
+});
+
+testProp("flag protection set to true", [arbitraryInput()], (t, args) => {
+  args.options.flagProtection = true;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.flagProtection, true);
+});
+
+testProp("flag protection set to false", [arbitraryInput()], (t, args) => {
+  args.options.flagProtection = false;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.flagProtection, false);
+});
+
+testProp("interpolation not specified", [arbitraryInput()], (t, args) => {
+  delete args.options.interpolation;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.interpolation, false);
+});
+
+testProp("interpolation set to true", [arbitraryInput()], (t, args) => {
+  args.options.interpolation = true;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.interpolation, true);
+});
+
+testProp("interpolation set to false", [arbitraryInput()], (t, args) => {
+  args.options.interpolation = false;
+
+  const result = parseOptions(args, t.context.deps);
+  t.is(result.interpolation, false);
+});
+
+testProp(
+  "shell is not specified",
+  [
+    arbitraryInput(),
+    fc.constantFrom(undefined, true, false),
+    fc.string(),
+    fc.string(),
+  ],
+  (t, args, providedShell, defaultShell, shellName) => {
+    t.context.deps.getDefaultShell.resetHistory();
+    t.context.deps.getDefaultShell.returns(defaultShell);
+    t.context.deps.getShellName.resetHistory();
+    t.context.deps.getShellName.returns(shellName);
+
+    const env = args.process.env;
+    args.options.shell = providedShell;
+
+    const result = parseOptions(args, t.context.deps);
+    t.is(t.context.deps.getDefaultShell.callCount, 1);
+    t.true(t.context.deps.getDefaultShell.calledWithExactly({ env }));
+    t.is(t.context.deps.getShellName.callCount, 1);
+    t.true(
+      t.context.deps.getShellName.calledWithExactly(
+        { shell: defaultShell },
+        { resolveExecutable }
+      )
+    );
+    t.is(result.shellName, shellName);
+  }
+);
+
+testProp(
+  "shell is specified",
+  [arbitraryInput(), fc.string(), fc.string()],
+  (t, args, providedShell, shellName) => {
+    t.context.deps.getShellName.resetHistory();
+    t.context.deps.getShellName.returns(shellName);
+
+    args.options.shell = providedShell;
+
+    const result = parseOptions(args, t.context.deps);
+    t.is(t.context.deps.getDefaultShell.callCount, 0);
+    t.is(t.context.deps.getShellName.callCount, 1);
+    t.true(
+      t.context.deps.getShellName.calledWithExactly(
+        { shell: providedShell },
+        { resolveExecutable }
+      )
+    );
+    t.is(result.shellName, shellName);
+  }
+);


### PR DESCRIPTION
Relates to #971

## Summary

Refactor the source code to move the options parsing logic out of `index.js` and into a new module. This allows for unit test coverage of the logic, increasing confidence in correctness.