### PR TITLE
Configure initial update groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       time: "05:00"
     labels:
       - dependencies
+    groups:
+      stryker:
+        patterns:
+          - "@stryker-mutator/*"
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

Configure one update group per the ["Grouped version updates for Dependabot public beta" blogpost](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) to streamline dependency updates by Dependabot.

This first group is aimed at the Stryker dependencies because those dependencies are always released together.