### PR TITLE
Align escaping for interpolation with escaping for quoting for CMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Fix incorrect escaping of `"` when escaping for CMD. ([#1022])
 - Fix incorrect escaping of `%` when quoting for CMD. ([#986], [#998])
 
 ## [1.7.1] - 2023-06-21
@@ -273,6 +274,7 @@ Versioning].
 [#984]: https://github.com/ericcornelissen/shescape/pull/984
 [#986]: https://github.com/ericcornelissen/shescape/pull/986
 [#998]: https://github.com/ericcornelissen/shescape/pull/998
+[#1022]: https://github.com/ericcornelissen/shescape/pull/1022
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -10,11 +10,29 @@
  * @returns {string} The escaped argument.
  */
 function escapeArgForInterpolation(arg) {
+  let shouldEscapeSpecialChar = true;
   return arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/\r?\n|\r/gu, " ")
-    .replace(/\^/gu, "^^")
-    .replace(/(["%&<>|])/gu, "^$1");
+    .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
+    .split("")
+    .map(
+      // Due to the way CMD determines if it is inside a quoted section, and the
+      // way we escape double quotes, whether or not special character need to
+      // be escaped depends on the number of double quotes that proceed it. So,
+      // we flip a flag for every double quote we encounter and escape special
+      // characters conditionally on that flag.
+      (char) => {
+        if (char === '"') {
+          shouldEscapeSpecialChar = !shouldEscapeSpecialChar;
+        } else if (shouldEscapeSpecialChar && /[%&<>^|]/u.test(char)) {
+          return `^${char}`;
+        }
+
+        return char;
+      }
+    )
+    .join("");
 }
 
 /**

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -68,30 +68,10 @@ export function getEscapeFunction(options) {
  * @returns {string} The escaped argument.
  */
 function escapeArgForQuoted(arg) {
-  let shouldEscapeSpecialChar = true;
-  return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
-    .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2")
-    .split("")
-    .map(
-      // Due to the way CMD determines if it is inside a quoted section, and the
-      // way we escape double quotes, whether or not special character need to
-      // be escaped depends on the number of double quotes that proceed it. So,
-      // we flip a flag for every double quote we encounter and escape special
-      // characters conditionally on that flag.
-      (char) => {
-        if (char === '"') {
-          shouldEscapeSpecialChar = !shouldEscapeSpecialChar;
-        } else if (shouldEscapeSpecialChar && /[%&<>^|]/u.test(char)) {
-          return `^${char}`;
-        }
-
-        return char;
-      }
-    )
-    .join("");
+  return escapeArgForInterpolation(arg).replace(
+    /(?<!\\)(\\*)([\t ])/gu,
+    "$1$1$2"
+  );
 }
 
 /**

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -806,28 +806,28 @@ export const escape = {
       {
         input: 'a"b',
         expected: {
-          interpolation: 'a^"b',
+          interpolation: 'a\\"b',
           noInterpolation: 'a"b',
         },
       },
       {
         input: 'a"b"c',
         expected: {
-          interpolation: 'a^"b^"c',
+          interpolation: 'a\\"b\\"c',
           noInterpolation: 'a"b"c',
         },
       },
       {
         input: 'a"',
         expected: {
-          interpolation: 'a^"',
+          interpolation: 'a\\"',
           noInterpolation: 'a"',
         },
       },
       {
         input: '"a',
         expected: {
-          interpolation: '^"a',
+          interpolation: '\\"a',
           noInterpolation: '"a',
         },
       },
@@ -904,6 +904,20 @@ export const escape = {
         expected: { interpolation: "^^a", noInterpolation: "^a" },
       },
     ],
+    "carets ('^') + double quotes ('\"')": [
+      {
+        input: 'a"b^c',
+        expected: { interpolation: 'a\\"b^c', noInterpolation: 'a"b^c' },
+      },
+      {
+        input: 'a"b"c^d',
+        expected: { interpolation: 'a\\"b\\"c^^d', noInterpolation: 'a"b"c^d' },
+      },
+      {
+        input: 'a^b"c',
+        expected: { interpolation: 'a^^b\\"c', noInterpolation: 'a^b"c' },
+      },
+    ],
     "dollar signs ('$')": [
       {
         input: "a$b",
@@ -940,6 +954,20 @@ export const escape = {
         expected: { interpolation: "^%a", noInterpolation: "%a" },
       },
     ],
+    "percentage signs ('%') + double quotes ('\"')": [
+      {
+        input: 'a"b%c',
+        expected: { interpolation: 'a\\"b%c', noInterpolation: 'a"b%c' },
+      },
+      {
+        input: 'a"b"c%d',
+        expected: { interpolation: 'a\\"b\\"c^%d', noInterpolation: 'a"b"c%d' },
+      },
+      {
+        input: 'a%b"c',
+        expected: { interpolation: 'a^%b\\"c', noInterpolation: 'a%b"c' },
+      },
+    ],
     "ampersands ('&')": [
       {
         input: "a&b",
@@ -956,6 +984,20 @@ export const escape = {
       {
         input: "&a",
         expected: { interpolation: "^&a", noInterpolation: "&a" },
+      },
+    ],
+    "ampersands ('&') + double quotes ('\"')": [
+      {
+        input: 'a"b&c',
+        expected: { interpolation: 'a\\"b&c', noInterpolation: 'a"b&c' },
+      },
+      {
+        input: 'a"b"c&d',
+        expected: { interpolation: 'a\\"b\\"c^&d', noInterpolation: 'a"b"c&d' },
+      },
+      {
+        input: 'a&b"c',
+        expected: { interpolation: 'a^&b\\"c', noInterpolation: 'a&b"c' },
       },
     ],
     "hyphens ('-')": [
@@ -1046,6 +1088,20 @@ export const escape = {
       {
         input: "|a",
         expected: { interpolation: "^|a", noInterpolation: "|a" },
+      },
+    ],
+    "pipes ('|') + double quotes ('\"')": [
+      {
+        input: 'a"b|c',
+        expected: { interpolation: 'a\\"b|c', noInterpolation: 'a"b|c' },
+      },
+      {
+        input: 'a"b"c|d',
+        expected: { interpolation: 'a\\"b\\"c^|d', noInterpolation: 'a"b"c|d' },
+      },
+      {
+        input: 'a|b"c',
+        expected: { interpolation: 'a^|b\\"c', noInterpolation: 'a|b"c' },
       },
     ],
     "comma (',')": [
@@ -1216,6 +1272,32 @@ export const escape = {
       {
         input: "a<b>c",
         expected: { interpolation: "a^<b^>c", noInterpolation: "a<b>c" },
+      },
+    ],
+    "angle brackets ('<', '>') + double quotes ('\"')": [
+      {
+        input: 'a"b>c',
+        expected: { interpolation: 'a\\"b>c', noInterpolation: 'a"b>c' },
+      },
+      {
+        input: 'a"b<c',
+        expected: { interpolation: 'a\\"b<c', noInterpolation: 'a"b<c' },
+      },
+      {
+        input: 'a"b"c>d',
+        expected: { interpolation: 'a\\"b\\"c^>d', noInterpolation: 'a"b"c>d' },
+      },
+      {
+        input: 'a"b"c<d',
+        expected: { interpolation: 'a\\"b\\"c^<d', noInterpolation: 'a"b"c<d' },
+      },
+      {
+        input: 'a>b"c',
+        expected: { interpolation: 'a^>b\\"c', noInterpolation: 'a>b"c' },
+      },
+      {
+        input: 'a<b"c',
+        expected: { interpolation: 'a^<b\\"c', noInterpolation: 'a<b"c' },
       },
     ],
     "left double quotation mark ('“')": [
@@ -3731,6 +3813,10 @@ export const quote = {
         input: 'a"b"c^d',
         expected: 'a\\"b\\"c^^d',
       },
+      {
+        input: 'a^b"c',
+        expected: 'a^^b\\"c',
+      },
     ],
     "dollar signs ('$')": [
       {
@@ -3777,6 +3863,10 @@ export const quote = {
         input: 'a"b"c%d',
         expected: 'a\\"b\\"c^%d',
       },
+      {
+        input: 'a%b"c',
+        expected: 'a^%b\\"c',
+      },
     ],
     "ampersands ('&')": [
       {
@@ -3804,6 +3894,10 @@ export const quote = {
       {
         input: 'a"b"c&d',
         expected: 'a\\"b\\"c^&d',
+      },
+      {
+        input: 'a&b"c',
+        expected: 'a^&b\\"c',
       },
     ],
     "hyphens ('-')": [
@@ -3869,6 +3963,10 @@ export const quote = {
         input: 'a"b"c|d',
         expected: 'a\\"b\\"c^|d',
       },
+      {
+        input: 'a|b"c',
+        expected: 'a^|b\\"c',
+      },
     ],
     "angle brackets ('<', '>')": [
       {
@@ -3924,6 +4022,14 @@ export const quote = {
       {
         input: 'a"b"c<d',
         expected: 'a\\"b\\"c^<d',
+      },
+      {
+        input: 'a>b"c',
+        expected: 'a^>b\\"c',
+      },
+      {
+        input: 'a<b"c',
+        expected: 'a^<b\\"c',
       },
     ],
     "left double quotation mark ('“')": [

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -109,19 +109,7 @@ function getFuzzShell() {
 function prepareArg({ arg, quoted, shell }, disableExtraWindowsPreparations) {
   if (constants.isWindows && !disableExtraWindowsPreparations) {
     // Node on Windows ...
-    if (isShellCmd(shell)) {
-      // ... in CMD, depending on if the argument is quoted ...
-      if (!quoted) {
-        // ... interprets arguments with `\"` as `"` so we escape the `\` ...
-        arg = arg.replace(
-          /(?<!\\)((?:\\[\0\u0008\u001B\u009B]*)+)(?=")/gu,
-          "$1$1"
-        );
-
-        // ... interprets arguments with `"` as `` so we escape it with `\`.
-        arg = arg.replace(/"/gu, '\\"');
-      }
-    } else if (isShellPowerShell(shell)) {
+    if (isShellPowerShell(shell)) {
       // ... in PowerShell, depending on if there's whitespace in the
       // argument ...
       if (


### PR DESCRIPTION
Relates to #998

## Summary

Update CMD escaping for `{ interpolation: true }` to work similar to escaping for quoting. This change is motivated by 1) the fact that it is used when quoting, and 2) that it removes the need for argument preparation when running e2e tests or fuzzing.