### PR TITLE
Separate `node:child_process` options from other options 

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -58,11 +58,8 @@ const execOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: execOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `exec`. DO NOT set
-  // any keys from the child_process API here.
-  ...execOptions,
 });
 
 /* 2. Collect user input */
@@ -127,11 +124,8 @@ const execOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: execOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `execSync`. DO NOT
-  // set any keys from the child_process API here.
-  ...execOptions,
 });
 
 /* 2. Collect user input */
@@ -243,11 +237,8 @@ const execFileOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: execFileOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `execFile`. DO NOT
-  // set any keys from the child_process API here.
-  ...execFileOptions,
 });
 
 /* 2. Collect user input */
@@ -326,11 +317,8 @@ const execFileOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: execFileOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `execFileSync`. DO
-  // NOT set any keys from the child_process API here.
-  ...execFileOptions,
 });
 
 /* 2. Collect user input */
@@ -411,11 +399,8 @@ if (argv[2] === "Hello") {
   };
 
   const shescape = new Shescape({
+    childProcess: forkOptions,
     interpolation: false,
-
-    // Set options for Shescape first, then add the options for `fork`. DO NOT set
-    // any keys from the child_process API here.
-    ...forkOptions,
   });
 
   /* 2. Collect user input */
@@ -482,11 +467,8 @@ const spawnOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: spawnOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `spawn`. DO NOT
-  // set any keys from the child_process API here.
-  ...spawnOptions,
 });
 
 /* 2. Collect user input */
@@ -557,11 +539,8 @@ const spawnOptions = {
 };
 
 const shescape = new Shescape({
+  childProcess: spawnOptions,
   interpolation: false,
-
-  // Set options for Shescape first, then add the options for `spawnSync`. DO
-  // NOT set any keys from the child_process API here.
-  ...spawnOptions,
 });
 
 /* 2. Collect user input */

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,11 +4,37 @@
  */
 
 /**
+ * Options for functions from the `node:child_process` module.
+ *
+ * @since 2.0.0
+ */
+interface ChildProcessOptions {
+  /**
+   * The shell to escape for. `false` and `undefined` mean no shell. `true`
+   * means the default system shell, and any non-empty string configures a
+   * particular shell.
+   *
+   * @default undefined
+   * @since 2.0.0
+   */
+  readonly shell?: boolean | string;
+}
+
+/**
  * Options for {@link Shescape}.
  *
  * @since 2.0.0
  */
 interface ShescapeOptions {
+  /**
+   * The options object that will be provided to a function from the
+   * `node:child_process` module.
+   *
+   * @default {}
+   * @since 2.0.0
+   */
+  readonly childProcess: ChildProcessOptions;
+
   /**
    * Whether or not to protect against flag and option (such as `--verbose`)
    * injection
@@ -25,16 +51,6 @@ interface ShescapeOptions {
    * @since 2.0.0
    */
   readonly interpolation?: boolean;
-
-  /**
-   * The shell to escape for. `false` and `undefined` mean no shell. `true`
-   * means the default system shell, and any non-empty string configures a
-   * particular shell.
-   *
-   * @default undefined
-   * @since 2.0.0
-   */
-  readonly shell?: boolean | string;
 }
 
 /**
@@ -60,7 +76,7 @@ interface ShescapeOptions {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ ...spawnOptions });
+ * const shescape = Shescape({ childProcess: spawnOptions });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput)],
@@ -69,7 +85,7 @@ interface ShescapeOptions {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ ...spawnOptions });
+ * const shescape = Shescape({ childProcess: spawnOptions });
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput]),

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ ...spawnOptions });
+ * const shescape = Shescape({ childProcess: spawnOptions });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput)],
@@ -47,7 +47,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ ...spawnOptions });
+ * const shescape = Shescape({ childProcess: spawnOptions });
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput]),


### PR DESCRIPTION
Merges into #963

## Summary

Update the Shescape options object to accept an object of `node:child_process` options in order to create a clear separation between "Shescape options" and "`child_process` options".