### PR TITLE
Update how `child_process` options should be given to Shescape

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -52,9 +52,7 @@ const execOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `exec`. DO NOT set
-  // any keys from the child_process API here.
-  ...execOptions,
+  shell: execOptions.shell,
 };
 
 /* 2. Collect user input */
@@ -113,9 +111,7 @@ const execOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `execSync`. DO NOT
-  // set any keys from the child_process API here.
-  ...execOptions,
+  shell: execOptions.shell,
 };
 
 /* 2. Collect user input */
@@ -221,9 +217,7 @@ const execFileOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `execFile`. DO NOT
-  // set any keys from the child_process API here.
-  ...execFileOptions,
+  shell: execFileOptions.shell,
 };
 
 /* 2. Collect user input */
@@ -296,9 +290,7 @@ const execFileOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `execFileSync`. DO
-  // NOT set any keys from the child_process API here.
-  ...execFileOptions,
+  shell: execFileOptions.shell,
 };
 
 /* 2. Collect user input */
@@ -373,9 +365,7 @@ if (argv[2] === "Hello") {
     detached: true,
   };
   const shescapeOptions = {
-    // Set options for Shescape first, then add the options for `fork`. DO NOT set
-    // any keys from the child_process API here.
-    ...forkOptions,
+    shell: forkOptions.shell,
   };
 
   /* 2. Collect user input */
@@ -436,9 +426,7 @@ const spawnOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `spawn`. DO NOT
-  // set any keys from the child_process API here.
-  ...spawnOptions,
+  shell: spawnOptions.shell,
 };
 
 /* 2. Collect user input */
@@ -503,9 +491,7 @@ const spawnOptions = {
   shell: "/bin/bash",
 };
 const shescapeOptions = {
-  // Set options for Shescape first, then add the options for `spawnSync`. DO
-  // NOT set any keys from the child_process API here.
-  ...spawnOptions,
+  shell: spawnOptions.shell,
 };
 
 /* 2. Collect user input */

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ export function escapeAll(args: string[], options?: EscapeOptions): string[];
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescapeOptions = { ...spawnOptions };
+ * const shescapeOptions = { shell: spawnOptions.shell };
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput, shescapeOptions)],
@@ -128,7 +128,7 @@ export function escapeAll(args: string[], options?: EscapeOptions): string[];
  * @example
  * import { exec } from "node:child_process";
  * const execOptions = null || { };
- * const shescapeOptions = { ...execOptions };
+ * const shescapeOptions = { shell: execOptions.shell };
  * exec(
  *   `echo Hello ${shescape.quote(userInput, shescapeOptions)}`,
  *   execOptions
@@ -153,7 +153,7 @@ export function quote(arg: string, options?: QuoteOptions): string;
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescapeOptions = { ...spawnOptions };
+ * const shescapeOptions = { shell: spawnOptions.shell };
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput], shescapeOptions),

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ export function escapeAll(args, options = {}) {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescapeOptions = { ...spawnOptions };
+ * const shescapeOptions = { shell: spawnOptions.shell };
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput, shescapeOptions)],
@@ -113,7 +113,7 @@ export function escapeAll(args, options = {}) {
  * @example
  * import { exec } from "node:child_process";
  * const execOptions = null || { };
- * const shescapeOptions = { ...execOptions };
+ * const shescapeOptions = { shell: execOptions.shell };
  * exec(
  *   `echo Hello ${shescape.quote(userInput, shescapeOptions)}`,
  *   execOptions
@@ -153,7 +153,7 @@ export function quote(arg, options = {}) {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescapeOptions = { ...spawnOptions };
+ * const shescapeOptions = { shell: spawnOptions.shell };
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput], shescapeOptions),

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -15,7 +15,7 @@ function check({ arg, shell }) {
   const execOptions = { encoding: "utf8", shell };
 
   const quotedArg = shescape.quote(arg, {
-    ...execOptions,
+    shell: execOptions.shell,
   });
 
   return new Promise((resolve, reject) => {
@@ -44,7 +44,7 @@ function checkSync({ arg, shell }) {
   const execOptions = { encoding: "utf8", shell };
 
   const quotedArg = shescape.quote(arg, {
-    ...execOptions,
+    shell: execOptions.shell,
   });
 
   let stdout;
@@ -63,7 +63,7 @@ function checkUsingInterpolation({ arg, shell }) {
   const execOptions = { encoding: "utf8", shell };
 
   const escapedArg = shescape.escape(arg, {
-    ...execOptions,
+    shell: execOptions.shell,
     interpolation: true,
   });
 
@@ -93,7 +93,7 @@ function checkUsingInterpolationSync({ arg, shell }) {
   const execOptions = { encoding: "utf8", shell };
 
   const escapedArg = shescape.escape(arg, {
-    ...execOptions,
+    shell: execOptions.shell,
     interpolation: true,
   });
 


### PR DESCRIPTION
Relates to #1027

## Summary

Update documentation as well as test code that relates to taking options intended for the `child_process` module and providing it to Shescape to move away from using the spread operator to assigning exactly and only what needs to be assigned.