### PR TITLE
Disable verbose logging when linting in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Check formatting
-        run: npm run format:check -- --loglevel debug
+        run: npm run format:check
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04
@@ -170,13 +170,13 @@ jobs:
         run: npm clean-install
       - name: Lint CI
         if: ${{ failure() || success() }}
-        run: npm run lint:ci -- -verbose
+        run: npm run lint:ci
       - name: Lint JavaScript
         if: ${{ failure() || success() }}
-        run: npm run lint:js -- --debug
+        run: npm run lint:js
       - name: Lint JSON
         if: ${{ failure() || success() }}
-        run: npm run lint:json -- --debug
+        run: npm run lint:json
       - name: Lint MarkDown
         if: ${{ failure() || success() }}
         run: npm run lint:md
@@ -185,7 +185,7 @@ jobs:
         run: npm run lint:sh
       - name: Lint YAML
         if: ${{ failure() || success() }}
-        run: npm run lint:yml -- --debug
+        run: npm run lint:yml
   njsscan:
     name: njsscan
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Reverts #646
Relates to  #1025

## Summary

Removes the use of "verbose" logging from CI invocations of npm scripts.

First the approach can lead to undetected unexpected changes, creating corresponding overhead. Second, and relatedly, it creates an unnecessary discrepancy between local development and CI. Lastly, I've simply not found the more verbose logs helpful.