### PR TITLE
Remove `shell: true` from `script/fuzz.js`

### DIFF
--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -91,7 +91,6 @@ function prepareCorpus() {
 function startFuzzing(target, time) {
   const fuzz = cp.spawn("jsfuzz", [target, corpusDir, `--fuzzTime=${time}`], {
     stdio: ["inherit", "inherit", "inherit"],
-    shell: true,
   });
 
   fuzz.on("close", (code) => process.exit(code));


### PR DESCRIPTION
## Summary

Update `script/fuzz.js` by omitting the unnecessary `shell: true` option.