### PR TITLE
Replace `eslint-plugin-json` by `eslint-plugin-jsonc`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -553,15 +553,101 @@ overrides:
       - .unimportedrc.json
       - package-lock.json
       - package.json
-    plugins:
-      - json
+    extends:
+      - plugin:jsonc/base
     rules:
+      no-irregular-whitespace: off
       jsdoc/require-file-overview: off
 
-      # https://github.com/azeemba/eslint-plugin-json#custom-configuration
-      json/*:
+      # https://ota-meshi.github.io/eslint-plugin-jsonc/rules/
+      jsonc/array-bracket-newline: off
+      jsonc/array-bracket-spacing: off
+      jsonc/array-element-newline: off
+      jsonc/comma-dangle:
         - error
-        - allowComments: false
+        - arrays: never
+          objects: never
+      jsonc/comma-style:
+        - error
+        - last
+      jsonc/indent:
+        - error
+        - 2
+      jsonc/key-name-casing: off
+      jsonc/key-spacing:
+        - error
+        - afterColon: true
+          beforeColon: false
+          mode: strict
+      jsonc/no-bigint-literals:
+        - error
+      jsonc/no-binary-expression:
+        - error
+      jsonc/no-binary-numeric-literals:
+        - error
+      jsonc/no-comments: off
+      jsonc/no-dupe-keys:
+        - error
+      jsonc/no-escape-sequence-in-identifier:
+        - error
+      jsonc/no-floating-decimal:
+        - error
+      jsonc/no-hexadecimal-numeric-literals:
+        - error
+      jsonc/no-infinity:
+        - error
+      jsonc/no-irregular-whitespace:
+        - error
+        - skipStrings: true
+          skipComments: false
+          skipRegExps: false
+          skipTemplates: false
+      jsonc/no-multi-str:
+        - error
+      jsonc/no-nan:
+        - error
+      jsonc/no-number-props:
+        - error
+      jsonc/no-numeric-separators:
+        - error
+      jsonc/no-octal:
+        - error
+      jsonc/no-octal-escape:
+        - error
+      jsonc/no-octal-numeric-literals:
+        - error
+      jsonc/no-parenthesized:
+        - error
+      jsonc/no-plus-sign:
+        - error
+      jsonc/no-regexp-literals:
+        - error
+      jsonc/no-sparse-arrays:
+        - error
+      jsonc/no-template-literals:
+        - error
+      jsonc/no-undefined-value:
+        - error
+      jsonc/no-unicode-codepoint-escapes:
+        - error
+      jsonc/no-useless-escape:
+        - error
+      jsonc/object-curly-newline: off
+      jsonc/object-curly-spacing: off
+      jsonc/object-property-newline: off
+      jsonc/quote-props:
+        - error
+        - always
+      jsonc/quotes:
+        - error
+        - double
+        - avoidEscape: false
+      jsonc/sort-array-values: off
+      jsonc/sort-keys: off
+      jsonc/space-unary-ops:
+        - error
+      jsonc/valid-json-number:
+        - error
 
   # YAML configuration files
   - files:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "8.44.0",
         "eslint-plugin-ava": "14.0.0",
         "eslint-plugin-jsdoc": "46.4.3",
-        "eslint-plugin-json": "3.1.0",
+        "eslint-plugin-jsonc": "2.9.0",
         "eslint-plugin-regexp": "1.15.0",
         "eslint-plugin-yml": "1.8.0",
         "fast-check": "3.11.0",
@@ -4725,17 +4725,24 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/eslint-plugin-json": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
-      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.9.0.tgz",
+      "integrity": "sha512-RK+LeONVukbLwT2+t7/OY54NJRccTXh/QbnXzPuTLpFMVZhPuq1C9E07+qWenGx7rrQl0kAalAWl7EmB+RjpGA==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.21",
-        "vscode-json-languageservice": "^4.1.6"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-regexp": {
@@ -7123,6 +7130,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.3.0.tgz",
+      "integrity": "sha512-9xZPKVYp9DxnM3sd1yAsh/d59iIaswDkai8oTxbursfKYbg/ibjX0IzFt35+VZ8iEW453TVTXztnRvYUQlAfUQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/jsonc-parser": {
@@ -13002,43 +13027,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-      "dev": true
-    },
-    "node_modules/vscode-json-languageservice": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
-      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
-      "dev": true,
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-languageserver-textdocument": "^1.0.3",
-        "vscode-languageserver-types": "^3.16.0",
-        "vscode-nls": "^5.0.0",
-        "vscode-uri": "^3.0.3"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
-      "dev": true
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
-      "dev": true
-    },
-    "node_modules/vscode-nls": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
-      "dev": true
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
       "dev": true
     },
     "node_modules/walk-up-path": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "8.44.0",
     "eslint-plugin-ava": "14.0.0",
     "eslint-plugin-jsdoc": "46.4.3",
-    "eslint-plugin-json": "3.1.0",
+    "eslint-plugin-jsonc": "2.9.0",
     "eslint-plugin-regexp": "1.15.0",
     "eslint-plugin-yml": "1.8.0",
     "fast-check": "3.11.0",


### PR DESCRIPTION
Relates to #537, #1049

## Summary

Remove the dependency on [`eslint-plugin-json`] in favor of [`eslint-plugin-jsonc`]. There's a couple of motivations for this, most notably 1) it is more up-to-date (the former's last release was 2 years ago, the  latter's 1 month), and 2) it has support for `.jsonc` and `.json5`.

[`eslint-plugin-json`]: https://www.npmjs.com/package/eslint-plugin-json
[`eslint-plugin-jsonc`]: https://www.npmjs.com/package/eslint-plugin-jsonc