### PR TITLE
Improve use of fuzz coverage data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,9 +332,9 @@ FUZZ_SHELL=/bin/sh
 FUZZ_SHELL=powershell.exe
 ```
 
-After fuzzing has completed you can use `npm run fuzz:coverage` to generate a
-fuzz coverage report at `_reports/fuzz/`. This command will fail if you did not
-first run a fuzz session to completion.
+Upon completion, a fuzz coverage report is generated at `_reports/fuzz/`. If it
+is missing you can use `npm run fuzz:coverage` to generate it on demand. Note
+that this will fail if you did not first run a fuzz session.
 
 When you discover a bug by fuzzing please keep the crash file. If you do not
 plan to fix the bug, either follow the [security policy] or file a [bug report]

--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -4,10 +4,10 @@
  * @license MIT
  */
 
-import * as cp from "node:child_process";
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as process from "node:process";
+import cp from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import process from "node:process";
 
 import { getFuzzShell } from "../test/fuzz/_common.cjs";
 
@@ -117,5 +117,9 @@ function startFuzzing(target, time) {
     fs.rmSync(defaultCoverageFile);
 
     process.exit(code);
+  });
+
+  process.on("SIGINT", () => {
+    fuzz.kill("SIGINT");
   });
 }


### PR DESCRIPTION
Relates to #1039

## Summary

Update the fuzz script to, on completion, rename the generated coverage file so that it's unique to the target and shell that was fuzzed. This results in maintaining coverage data from previous runs. In turn, using nyc to generate a HTML coverage report will combine all coverage files into one report, giving a more holistic view of fuzz coverage.

One _limitation_ here is that the implementation distinguishes between fuzzing `cp.fork` using different shells, even though the shell is irrelevant when fuzzing `fork` (since it doesn't have a `shell` option).