### PR TITLE
Add labeler rules for `fuzz` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,11 @@ dependencies:
 documentation:
   - docs/*
 
+fuzz:
+  - script/fuzz.js
+  - test/fuzz/*
+  - test/fuzz/**/*
+
 meta:
   - .github/ISSUE_TEMPLATE/*
   - .github/dependabot.yml
@@ -32,6 +37,8 @@ meta:
 test:
   - test/**
   - test/**/*
+  - "!test/fuzz/*"
+  - "!test/fuzz/**/*"
   - stryker.*.config.js
 
 security:


### PR DESCRIPTION
Relates to #798, #1006

## Summary

Update [actions/labeler](https://github.com/actions/labeler) rules to:
1. Label Pull Requests touching fuzzing related files with the (new) [`fuzz` label](https://github.com/ericcornelissen/shescape/issues?q=label%3Afuzz), and
2. Not label fuzz tests using the [`test` label](https://github.com/ericcornelissen/shescape/issues?q=label%3Atest).