### PR TITLE
Extract the test runners for `node:child_process`

### DIFF
--- a/test/e2e/_macros.js
+++ b/test/e2e/_macros.js
@@ -8,12 +8,7 @@ import * as cp from "node:child_process";
 
 import test from "ava";
 
-/* eslint-disable ava/no-import-test-files */
-import * as execFileTest from "../fuzz/exec-file.test.cjs";
-import * as execTest from "../fuzz/exec.test.cjs";
-import * as forkTest from "../fuzz/fork.test.cjs";
-import * as spawnTest from "../fuzz/spawn.test.cjs";
-/* eslint-enable ava/no-import-test-files */
+import * as runners from "./_runners.cjs";
 
 /**
  * The exec macro tests Shescape usage with {@link cp.exec} for the provided
@@ -25,13 +20,13 @@ import * as spawnTest from "../fuzz/spawn.test.cjs";
  */
 export const exec = test.macro({
   async exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    await t.notThrowsAsync(() => execTest.check({ arg, shell }));
-    await t.notThrowsAsync(() =>
-      execTest.checkUsingInterpolation({ arg, shell }),
-    );
+    await t.notThrowsAsync(() => runners.exec(scenario));
+    await t.notThrowsAsync(() => runners.execUsingInterpolation(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');
@@ -50,11 +45,13 @@ export const exec = test.macro({
  */
 export const execSync = test.macro({
   exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    t.notThrows(() => execTest.checkSync({ arg, shell }));
-    t.notThrows(() => execTest.checkUsingInterpolationSync({ arg, shell }));
+    t.notThrows(() => runners.execSync(scenario));
+    t.notThrows(() => runners.execSyncUsingInterpolation(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');
@@ -73,10 +70,12 @@ export const execSync = test.macro({
  */
 export const execFile = test.macro({
   async exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    await t.notThrowsAsync(() => execFileTest.check({ arg, shell }));
+    await t.notThrowsAsync(() => runners.execFile(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');
@@ -95,10 +94,12 @@ export const execFile = test.macro({
  */
 export const execFileSync = test.macro({
   exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    t.notThrows(() => execFileTest.checkSync({ arg, shell }));
+    t.notThrows(() => runners.execFileSync(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');
@@ -120,7 +121,7 @@ export const fork = test.macro({
   async exec(t, args) {
     const arg = args.arg;
 
-    await t.notThrowsAsync(() => forkTest.check(arg));
+    await t.notThrowsAsync(() => runners.fork(arg));
   },
   title(_, args) {
     const arg = args.arg;
@@ -138,10 +139,12 @@ export const fork = test.macro({
  */
 export const spawn = test.macro({
   async exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    await t.notThrowsAsync(() => spawnTest.check({ arg, shell }));
+    await t.notThrowsAsync(() => runners.spawn(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');
@@ -160,10 +163,12 @@ export const spawn = test.macro({
  */
 export const spawnSync = test.macro({
   exec(t, args) {
-    const arg = args.arg;
-    const shell = args.shell;
+    const scenario = {
+      arg: args.arg,
+      shell: args.shell,
+    };
 
-    t.notThrows(() => spawnTest.checkSync({ arg, shell }));
+    t.notThrows(() => runners.spawnSync(scenario));
   },
   title(_, args) {
     const arg = args.arg.replace(/"/gu, '\\"');

--- a/test/e2e/_runners.cjs
+++ b/test/e2e/_runners.cjs
@@ -1,0 +1,323 @@
+/**
+ * @overview Provides functions for running a sample command with arguments
+ * escaped by shescape against the `node:child_process` API.
+ * @license MIT
+ */
+
+const assert = require("node:assert");
+const cp = require("node:child_process");
+
+const constants = require("../_constants.cjs");
+
+const shescape = require("shescape");
+
+/**
+ * Checks if the fuzz shell is CMD.
+ *
+ * @param {string} shell The configured shell.
+ * @returns {boolean} `true` if `shell` is CMD, `false` otherwise.
+ */
+function isShellCmd(shell) {
+  return (
+    (constants.isWindows && [undefined, true, false].includes(shell)) ||
+    /cmd\.exe$/u.test(shell)
+  );
+}
+
+/**
+ * Checks if the fuzz shell is the C shell.
+ *
+ * @param {string} shell The configured shell.
+ * @returns {boolean} `true` if `shell` is csh, `false` otherwise.
+ */
+function isShellCsh(shell) {
+  return /csh$/u.test(shell);
+}
+
+/**
+ * Checks if the fuzz shell is PowerShell.
+ *
+ * @param {string} shell The configured shell.
+ * @returns {boolean} `true` if `shell` is PowerShell, `false` otherwise.
+ */
+function isShellPowerShell(shell) {
+  return /powershell\.exe$/u.test(shell);
+}
+
+/**
+ * Produces the expected echoed output.
+ *
+ * @param {object} args The function arguments.
+ * @param {string} args.arg The input argument that was echoed.
+ * @param {string} args.shell The shell used for echoing.
+ * @param {boolean} normalizeWhitespace Whether whitespace should be normalized.
+ * @returns {string} The expected echoed value.
+ */
+function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
+  // Remove control characters, like Shescape
+  arg = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
+
+  // Replace newline characters, like Shescape
+  if (isShellCmd(shell) || isShellCsh(shell)) {
+    arg = arg.replace(/\r?\n|\r/gu, " ");
+  } else {
+    arg = arg.replace(/\r(?!\n)/gu, "");
+  }
+
+  if (normalizeWhitespace) {
+    // Replace newline characters, like Shescape
+    if (!isShellCmd(shell)) {
+      arg = arg.replace(/\r?\n/gu, " ");
+    }
+
+    // Convert whitespace between arguments, like the shell
+    if (isShellCmd(shell)) {
+      arg = arg.replace(/[\t ]+/gu, " ");
+    }
+
+    // Trim the string, like the shell
+    if (isShellPowerShell(shell)) {
+      arg = arg.replace(/^[\s\u0085]+/gu, "");
+    } else if (isShellCmd(shell)) {
+      arg = arg.replace(/^[\t\n\r ]+|(?<![\t\n\r ])[\t\n\r ]+$/gu, "");
+    }
+  }
+
+  arg = `${arg}\n`; // Append a newline, like the echo script
+  return arg;
+}
+
+module.exports.exec = function ({ arg, shell }) {
+  const execOptions = { encoding: "utf8", shell };
+
+  const quotedArg = shescape.quote(arg, {
+    shell: execOptions.shell,
+  });
+
+  return new Promise((resolve, reject) => {
+    cp.exec(
+      `node ${constants.echoScript} ${quotedArg}`,
+      execOptions,
+      (error, stdout) => {
+        if (error) {
+          reject(`an unexpected error occurred: ${error}`);
+        } else {
+          const result = stdout;
+          const expected = getExpectedOutput({ arg, shell });
+          try {
+            assert.strictEqual(result, expected);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      },
+    );
+  });
+};
+
+module.exports.execSync = function ({ arg, shell }) {
+  const execOptions = { encoding: "utf8", shell };
+
+  const quotedArg = shescape.quote(arg, {
+    shell: execOptions.shell,
+  });
+
+  let stdout;
+  try {
+    stdout = cp.execSync(
+      `node ${constants.echoScript} ${quotedArg}`,
+      execOptions,
+    );
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
+
+  const result = stdout;
+  const expected = getExpectedOutput({ arg, shell });
+  assert.strictEqual(result, expected);
+};
+
+module.exports.execUsingInterpolation = function ({ arg, shell }) {
+  const execOptions = { encoding: "utf8", shell };
+
+  const escapedArg = shescape.escape(arg, {
+    shell: execOptions.shell,
+    interpolation: true,
+  });
+
+  return new Promise((resolve, reject) => {
+    cp.exec(
+      `node ${constants.echoScript} ${escapedArg}`,
+      execOptions,
+      (error, stdout) => {
+        if (error) {
+          reject(`an unexpected error occurred: ${error}`);
+        } else {
+          const result = stdout;
+          const expected = getExpectedOutput({ arg, shell }, true);
+          try {
+            assert.strictEqual(result, expected);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      },
+    );
+  });
+};
+
+module.exports.execSyncUsingInterpolation = function ({ arg, shell }) {
+  const execOptions = { encoding: "utf8", shell };
+
+  const escapedArg = shescape.escape(arg, {
+    shell: execOptions.shell,
+    interpolation: true,
+  });
+
+  let stdout;
+  try {
+    stdout = cp.execSync(
+      `node ${constants.echoScript} ${escapedArg}`,
+      execOptions,
+    );
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
+
+  const result = stdout;
+  const expected = getExpectedOutput({ arg, shell }, true);
+  assert.strictEqual(result, expected);
+};
+
+module.exports.execFile = function ({ arg, shell }) {
+  const execFileOptions = { encoding: "utf8", shell };
+
+  const safeArg = execFileOptions.shell
+    ? shescape.quote(arg, execFileOptions)
+    : shescape.escape(arg, execFileOptions);
+
+  return new Promise((resolve, reject) => {
+    cp.execFile(
+      "node",
+      [constants.echoScript, safeArg],
+      execFileOptions,
+      (error, stdout) => {
+        if (error) {
+          reject(`an unexpected error occurred: ${error}`);
+        } else {
+          const result = stdout;
+          const expected = getExpectedOutput({ arg, shell });
+          try {
+            assert.strictEqual(result, expected);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        }
+      },
+    );
+  });
+};
+
+module.exports.execFileSync = function ({ arg, shell }) {
+  const execFileOptions = { encoding: "utf8", shell };
+
+  const safeArg = execFileOptions.shell
+    ? shescape.quote(arg, execFileOptions)
+    : shescape.escape(arg, execFileOptions);
+
+  let stdout;
+  try {
+    stdout = cp.execFileSync(
+      "node",
+      [constants.echoScript, safeArg],
+      execFileOptions,
+    );
+  } catch (error) {
+    assert.fail(`an unexpected error occurred: ${error}`);
+  }
+
+  const result = stdout;
+  const expected = getExpectedOutput({ arg, shell });
+  assert.strictEqual(result, expected);
+};
+
+module.exports.fork = function (arg) {
+  const forkOptions = { silent: true };
+
+  const safeArg = shescape.escape(arg);
+
+  return new Promise((resolve, reject) => {
+    const echo = cp.fork(constants.echoScript, [safeArg], forkOptions);
+
+    echo.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
+
+    echo.stdout.on("data", (data) => {
+      const result = data.toString();
+      const expected = getExpectedOutput({ arg });
+      try {
+        assert.strictEqual(result, expected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+};
+
+module.exports.spawn = function ({ arg, shell }) {
+  const spawnOptions = { encoding: "utf8", shell };
+
+  const safeArg = spawnOptions.shell
+    ? shescape.quote(arg, spawnOptions)
+    : shescape.escape(arg, spawnOptions);
+
+  return new Promise((resolve, reject) => {
+    const child = cp.spawn(
+      "node",
+      [constants.echoScript, safeArg],
+      spawnOptions,
+    );
+
+    child.on("error", (error) => {
+      reject(`an unexpected error occurred: ${error}`);
+    });
+
+    child.stdout.on("data", (data) => {
+      const result = data.toString();
+      const expected = getExpectedOutput({ arg, shell });
+      try {
+        assert.strictEqual(result, expected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+};
+
+module.exports.spawnSync = function ({ arg, shell }) {
+  const spawnOptions = { encoding: "utf8", shell };
+
+  const safeArg = spawnOptions.shell
+    ? shescape.quote(arg, spawnOptions)
+    : shescape.escape(arg, spawnOptions);
+
+  const child = cp.spawnSync(
+    "node",
+    [constants.echoScript, safeArg],
+    spawnOptions,
+  );
+
+  if (child.error) {
+    assert.fail(`an unexpected error occurred: ${child.error}`);
+  } else {
+    const result = child.stdout;
+    const expected = getExpectedOutput({ arg, shell });
+    assert.strictEqual(result, expected);
+  }
+};

--- a/test/fuzz/_common.cjs
+++ b/test/fuzz/_common.cjs
@@ -7,86 +7,6 @@ const process = require("node:process");
 
 require("dotenv").config();
 
-const constants = require("../_constants.cjs");
-
-const ECHO_SCRIPT = constants.echoScript;
-
-/**
- * Checks if the fuzz shell is CMD.
- *
- * @param {string} shell The configured shell.
- * @returns {boolean} `true` if `shell` is CMD, `false` otherwise.
- */
-function isShellCmd(shell) {
-  return (
-    (constants.isWindows && [undefined, true, false].includes(shell)) ||
-    /cmd\.exe$/u.test(shell)
-  );
-}
-
-/**
- * Checks if the fuzz shell is the C shell.
- *
- * @param {string} shell The configured shell.
- * @returns {boolean} `true` if `shell` is csh, `false` otherwise.
- */
-function isShellCsh(shell) {
-  return /csh$/u.test(shell);
-}
-
-/**
- * Checks if the fuzz shell is PowerShell.
- *
- * @param {string} shell The configured shell.
- * @returns {boolean} `true` if `shell` is PowerShell, `false` otherwise.
- */
-function isShellPowerShell(shell) {
-  return /powershell\.exe$/u.test(shell);
-}
-
-/**
- * Produces the expected echoed output.
- *
- * @param {object} args The function arguments.
- * @param {string} args.arg The input argument that was echoed.
- * @param {string} args.shell The shell used for echoing.
- * @param {boolean} normalizeWhitespace Whether whitespace should be normalized.
- * @returns {string} The expected echoed value.
- */
-function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
-  // Remove control characters, like Shescape
-  arg = arg.replace(/[\0\u0008\u001B\u009B]/gu, "");
-
-  // Replace newline characters, like Shescape
-  if (isShellCmd(shell) || isShellCsh(shell)) {
-    arg = arg.replace(/\r?\n|\r/gu, " ");
-  } else {
-    arg = arg.replace(/\r(?!\n)/gu, "");
-  }
-
-  if (normalizeWhitespace) {
-    // Replace newline characters, like Shescape
-    if (!isShellCmd(shell)) {
-      arg = arg.replace(/\r?\n/gu, " ");
-    }
-
-    // Convert whitespace between arguments, like the shell
-    if (isShellCmd(shell)) {
-      arg = arg.replace(/[\t ]+/gu, " ");
-    }
-
-    // Trim the string, like the shell
-    if (isShellPowerShell(shell)) {
-      arg = arg.replace(/^[\s\u0085]+/gu, "");
-    } else if (isShellCmd(shell)) {
-      arg = arg.replace(/^[\t\n\r ]+|(?<![\t\n\r ])[\t\n\r ]+$/gu, "");
-    }
-  }
-
-  arg = `${arg}\n`; // Append a newline, like the echo script
-  return arg;
-}
-
 /**
  * Returns the shell configured to be used for fuzzing.
  *
@@ -97,8 +17,5 @@ function getFuzzShell() {
 }
 
 module.exports = {
-  ECHO_SCRIPT,
-  isShellPowerShell,
-  getExpectedOutput,
   getFuzzShell,
 };

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -4,80 +4,21 @@
  * @license MIT
  */
 
-const assert = require("node:assert");
-const { execFile, execFileSync } = require("node:child_process");
-
 const common = require("./_common.cjs");
-
-const shescape = require("../../index.cjs");
-
-function check({ arg, shell }) {
-  const execFileOptions = { encoding: "utf8", shell };
-
-  const safeArg = execFileOptions.shell
-    ? shescape.quote(arg, execFileOptions)
-    : shescape.escape(arg, execFileOptions);
-
-  return new Promise((resolve, reject) => {
-    execFile(
-      "node",
-      [common.ECHO_SCRIPT, safeArg],
-      execFileOptions,
-      (error, stdout) => {
-        if (error) {
-          reject(`an unexpected error occurred: ${error}`);
-        } else {
-          const result = stdout;
-          const expected = common.getExpectedOutput({ arg, shell });
-          try {
-            assert.strictEqual(result, expected);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        }
-      },
-    );
-  });
-}
-
-function checkSync({ arg, shell }) {
-  const execFileOptions = { encoding: "utf8", shell };
-
-  const safeArg = execFileOptions.shell
-    ? shescape.quote(arg, execFileOptions)
-    : shescape.escape(arg, execFileOptions);
-
-  let stdout;
-  try {
-    stdout = execFileSync(
-      "node",
-      [common.ECHO_SCRIPT, safeArg],
-      execFileOptions,
-    );
-  } catch (error) {
-    assert.fail(`an unexpected error occurred: ${error}`);
-  }
-
-  const result = stdout;
-  const expected = common.getExpectedOutput({ arg, shell });
-  assert.strictEqual(result, expected);
-}
+const runners = require("../e2e/_runners.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();
   const shell = common.getFuzzShell();
 
   try {
-    await check({ arg, shell });
-    checkSync({ arg, shell });
+    await runners.execFile({ arg, shell });
+    runners.execFileSync({ arg, shell });
   } catch (e) {
     throw e;
   }
 }
 
 module.exports = {
-  check,
-  checkSync,
   fuzz,
 };

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -4,129 +4,23 @@
  * @license MIT
  */
 
-const assert = require("node:assert");
-const { exec, execSync } = require("node:child_process");
-
 const common = require("./_common.cjs");
-
-const shescape = require("../../index.cjs");
-
-function check({ arg, shell }) {
-  const execOptions = { encoding: "utf8", shell };
-
-  const quotedArg = shescape.quote(arg, {
-    shell: execOptions.shell,
-  });
-
-  return new Promise((resolve, reject) => {
-    exec(
-      `node ${common.ECHO_SCRIPT} ${quotedArg}`,
-      execOptions,
-      (error, stdout) => {
-        if (error) {
-          reject(`an unexpected error occurred: ${error}`);
-        } else {
-          const result = stdout;
-          const expected = common.getExpectedOutput({ arg, shell });
-          try {
-            assert.strictEqual(result, expected);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        }
-      },
-    );
-  });
-}
-
-function checkSync({ arg, shell }) {
-  const execOptions = { encoding: "utf8", shell };
-
-  const quotedArg = shescape.quote(arg, {
-    shell: execOptions.shell,
-  });
-
-  let stdout;
-  try {
-    stdout = execSync(`node ${common.ECHO_SCRIPT} ${quotedArg}`, execOptions);
-  } catch (error) {
-    assert.fail(`an unexpected error occurred: ${error}`);
-  }
-
-  const result = stdout;
-  const expected = common.getExpectedOutput({ arg, shell });
-  assert.strictEqual(result, expected);
-}
-
-function checkUsingInterpolation({ arg, shell }) {
-  const execOptions = { encoding: "utf8", shell };
-
-  const escapedArg = shescape.escape(arg, {
-    shell: execOptions.shell,
-    interpolation: true,
-  });
-
-  return new Promise((resolve, reject) => {
-    exec(
-      `node ${common.ECHO_SCRIPT} ${escapedArg}`,
-      execOptions,
-      (error, stdout) => {
-        if (error) {
-          reject(`an unexpected error occurred: ${error}`);
-        } else {
-          const result = stdout;
-          const expected = common.getExpectedOutput({ arg, shell }, true);
-          try {
-            assert.strictEqual(result, expected);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        }
-      },
-    );
-  });
-}
-
-function checkUsingInterpolationSync({ arg, shell }) {
-  const execOptions = { encoding: "utf8", shell };
-
-  const escapedArg = shescape.escape(arg, {
-    shell: execOptions.shell,
-    interpolation: true,
-  });
-
-  let stdout;
-  try {
-    stdout = execSync(`node ${common.ECHO_SCRIPT} ${escapedArg}`, execOptions);
-  } catch (error) {
-    assert.fail(`an unexpected error occurred: ${error}`);
-  }
-
-  const result = stdout;
-  const expected = common.getExpectedOutput({ arg, shell }, true);
-  assert.strictEqual(result, expected);
-}
+const runners = require("../e2e/_runners.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();
   const shell = common.getFuzzShell();
 
   try {
-    await check({ arg, shell });
-    await checkUsingInterpolation({ arg, shell });
-    checkSync({ arg, shell });
-    checkUsingInterpolationSync({ arg, shell });
+    await runners.exec({ arg, shell });
+    await runners.execUsingInterpolation({ arg, shell });
+    runners.execSync({ arg, shell });
+    runners.execSyncUsingInterpolation({ arg, shell });
   } catch (e) {
     throw e;
   }
 }
 
 module.exports = {
-  check,
-  checkSync,
-  checkUsingInterpolation,
-  checkUsingInterpolationSync,
   fuzz,
 };

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -4,49 +4,18 @@
  * @license MIT
  */
 
-const assert = require("node:assert");
-const { fork } = require("node:child_process");
-
-const common = require("./_common.cjs");
-
-const shescape = require("../../index.cjs");
-
-function check(arg) {
-  const forkOptions = { silent: true };
-
-  const safeArg = shescape.escape(arg);
-
-  return new Promise((resolve, reject) => {
-    const echo = fork(common.ECHO_SCRIPT, [safeArg], forkOptions);
-
-    echo.on("error", (error) => {
-      reject(`an unexpected error occurred: ${error}`);
-    });
-
-    echo.stdout.on("data", (data) => {
-      const result = data.toString();
-      const expected = common.getExpectedOutput({ arg });
-      try {
-        assert.strictEqual(result, expected);
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
-}
+const runners = require("../e2e/_runners.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();
 
   try {
-    await check(arg);
+    await runners.fork(arg);
   } catch (e) {
     throw e;
   }
 }
 
 module.exports = {
-  check,
   fuzz,
 };

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -4,72 +4,21 @@
  * @license MIT
  */
 
-const assert = require("node:assert");
-const { spawn, spawnSync } = require("node:child_process");
-
 const common = require("./_common.cjs");
-
-const shescape = require("../../index.cjs");
-
-function check({ arg, shell }) {
-  const spawnOptions = { encoding: "utf8", shell };
-
-  const safeArg = spawnOptions.shell
-    ? shescape.quote(arg, spawnOptions)
-    : shescape.escape(arg, spawnOptions);
-
-  return new Promise((resolve, reject) => {
-    const child = spawn("node", [common.ECHO_SCRIPT, safeArg], spawnOptions);
-
-    child.on("error", (error) => {
-      reject(`an unexpected error occurred: ${error}`);
-    });
-
-    child.stdout.on("data", (data) => {
-      const result = data.toString();
-      const expected = common.getExpectedOutput({ arg, shell });
-      try {
-        assert.strictEqual(result, expected);
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
-}
-
-function checkSync({ arg, shell }) {
-  const spawnOptions = { encoding: "utf8", shell };
-
-  const safeArg = spawnOptions.shell
-    ? shescape.quote(arg, spawnOptions)
-    : shescape.escape(arg, spawnOptions);
-
-  const child = spawnSync("node", [common.ECHO_SCRIPT, safeArg], spawnOptions);
-
-  if (child.error) {
-    assert.fail(`an unexpected error occurred: ${child.error}`);
-  } else {
-    const result = child.stdout;
-    const expected = common.getExpectedOutput({ arg, shell });
-    assert.strictEqual(result, expected);
-  }
-}
+const runners = require("../e2e/_runners.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();
   const shell = common.getFuzzShell();
 
   try {
-    await check({ arg, shell });
-    checkSync({ arg, shell });
+    await runners.spawn({ arg, shell });
+    runners.spawnSync({ arg, shell });
   } catch (e) {
     throw e;
   }
 }
 
 module.exports = {
-  check,
-  checkSync,
   fuzz,
 };


### PR DESCRIPTION
## Summary

Extract the function that "run a test" against functions from the `node:child_process` API from the `test/fuzz` folder into a separate module that is more clearly intended for sharing (between e2e tests and fuzzing).