### PR TITLE
Update knip configuration

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -3,7 +3,8 @@
 {
   "$schema": "./node_modules/knip/schema.json",
   "entry": ["index.js", "testing.js"],
-  "ignore": ["bench/unix.js", "bench/win.js", "stryker.*.config.js"],
+  "ignore": ["bench/unix.js", "bench/win.js"],
   "ignoreBinaries": ["actionlint", "shellcheck"],
-  "ignoreDependencies": ["@gitlab-org/jsfuzz", "@stryker-mutator/tap-runner"]
+  "ignoreDependencies": ["@gitlab-org/jsfuzz"],
+  "stryker": ["stryker.*.config.js"]
 }


### PR DESCRIPTION
Relates to #1049
See also [this comment on `0442cd9`](https://github.com/ericcornelissen/shescape/commit/0442cd9bfc471dae36112a69ab71b136f63b4f51#r122387796)

## Summary

Update knip configuration by configuring its Stryker plugin rather than ignoring the Stryker configuration files. This conveniently allows for unignoring the dependency on `@stryker-mutator/tap-runner`.