### PR TITLE
Improve fuzz time support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,6 +332,23 @@ FUZZ_SHELL=/bin/sh
 FUZZ_SHELL=powershell.exe
 ```
 
+By default, fuzzing goes on forever - until a problem is found. You can change
+this by using the `--fuzzTime` CLI option or `FUZZ_TIME` environment variable.
+In either case the time must be specified as an integer representing seconds. In
+case of the CLI option, you must use `--` to split the fuzz option from the npm
+CLI options. For example, to fuzz 10 seconds:
+
+```shell
+npm run fuzz -- exec --fuzzTime=10
+```
+
+Alternatively, you can use a `.env` file to specify the fuzz time. Note that the
+CLI provided value takes precedence. For example, to fuzz 10 seconds by default:
+
+```ini
+FUZZ_TIME=10
+```
+
 Upon completion, a fuzz coverage report is generated at `_reports/fuzz/`. If it
 is missing you can use `npm run fuzz:coverage` to generate it on demand. Note
 that this will fail if you did not first run a fuzz session.

--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -21,10 +21,11 @@ const testCasesDir = "./test/fuzz/corpus";
 main(process.argv.slice(2));
 
 function main(argv) {
+  const fuzzShell = getFuzzShell();
   const fuzzTarget = getFuzzTarget(argv);
   const fuzzTime = getFuzzTime(argv);
   prepareCorpus();
-  logShellToFuzz();
+  logFuzzDetails(fuzzShell, fuzzTarget, fuzzTime);
   startFuzzing(fuzzTarget, fuzzTime);
 }
 
@@ -87,11 +88,16 @@ function getFuzzTime(argv) {
   return timeInSeconds;
 }
 
-function logShellToFuzz() {
+function logFuzzDetails(shell, target, time) {
   console.log(
-    `Fuzzing will use ${getFuzzShell() || "[default shell]"} as shell`,
+    "Will fuzz",
+    time ? `for ${time} second(s)` : "forever",
+    "using",
+    shell || "[default shell]",
+    "as shell targeting",
+    target,
+    "\n",
   );
-  console.log("\n");
 }
 
 function prepareCorpus() {

--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -4,6 +4,8 @@
  * @license MIT
  */
 
+import "dotenv/config";
+
 import cp from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -63,11 +65,18 @@ function getFuzzTarget(argv) {
 
 function getFuzzTime(argv) {
   const fuzzTimeArg = argv.find((arg) => arg.startsWith("--fuzzTime"));
-  if (fuzzTimeArg === undefined) {
+  const fuzzTimeEnv = process.env.FUZZ_TIME;
+  if (fuzzTimeArg === undefined && fuzzTimeEnv === undefined) {
     return 0;
   }
 
-  const [, timeInSeconds] = fuzzTimeArg.split("=");
+  let timeInSeconds;
+  if (fuzzTimeArg) {
+    [, timeInSeconds] = fuzzTimeArg.split("=");
+  } else {
+    timeInSeconds = fuzzTimeEnv;
+  }
+
   if (isNaN(parseInt(timeInSeconds))) {
     console.log("The --fuzzTime should be a numeric value (number of seconds)");
     console.log(`Got '${timeInSeconds}' instead`);


### PR DESCRIPTION
Relates to #1039

## Summary

Update the `fuzz.js` script to consider the `FUZZ_TIME` environment variable as a secondary source for the fuzz duration in seconds. Use the static `dotenv/config` import to make sure a `FUZZ_TIME` value set in `.env` will be used.

Also document the availability of fuzz time options in the Contributing Guidelines (missing before).