### PR TITLE
Improve tests through refactoring

### DIFF
--- a/test/_runners.cjs
+++ b/test/_runners.cjs
@@ -7,7 +7,7 @@
 const assert = require("node:assert");
 const cp = require("node:child_process");
 
-const constants = require("../_constants.cjs");
+const constants = require("./_constants.cjs");
 
 const shescape = require("shescape");
 

--- a/test/e2e/_macros.js
+++ b/test/e2e/_macros.js
@@ -8,7 +8,7 @@ import * as cp from "node:child_process";
 
 import test from "ava";
 
-import * as runners from "./_runners.cjs";
+import * as runners from "../_runners.cjs";
 
 /**
  * The exec macro tests Shescape usage with {@link cp.exec} for the provided

--- a/test/fuzz/_.cjs
+++ b/test/fuzz/_.cjs
@@ -1,0 +1,12 @@
+/**
+ * @overview Provides fuzzing utilities.
+ * @license MIT
+ */
+
+const common = require("./_common.cjs");
+const runners = require("../_runners.cjs");
+
+module.exports = {
+  common,
+  runners,
+};

--- a/test/fuzz/exec-file.test.cjs
+++ b/test/fuzz/exec-file.test.cjs
@@ -4,8 +4,7 @@
  * @license MIT
  */
 
-const common = require("./_common.cjs");
-const runners = require("../e2e/_runners.cjs");
+const { common, runners } = require("./_.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();

--- a/test/fuzz/exec.test.cjs
+++ b/test/fuzz/exec.test.cjs
@@ -4,8 +4,7 @@
  * @license MIT
  */
 
-const common = require("./_common.cjs");
-const runners = require("../e2e/_runners.cjs");
+const { common, runners } = require("./_.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();

--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-const runners = require("../e2e/_runners.cjs");
+const { runners } = require("./_.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();

--- a/test/fuzz/spawn.test.cjs
+++ b/test/fuzz/spawn.test.cjs
@@ -4,8 +4,7 @@
  * @license MIT
  */
 
-const common = require("./_common.cjs");
-const runners = require("../e2e/_runners.cjs");
+const { common, runners } = require("./_.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();

--- a/test/integration/escape-all.test.js
+++ b/test/integration/escape-all.test.js
@@ -9,7 +9,7 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { escape, escapeAll } from "../../index.js";
+import { escape, escapeAll } from "shescape";
 import { escapeAll as escapeAllCjs } from "../../index.cjs";
 
 test("inputs are escaped", (t) => {

--- a/test/integration/escape.test.js
+++ b/test/integration/escape.test.js
@@ -8,7 +8,7 @@ import test from "ava";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { escape as escape } from "../../index.js";
+import { escape as escape } from "shescape";
 import { escape as escapeCjs } from "../../index.cjs";
 
 test("input is escaped", (t) => {

--- a/test/integration/quote-all.test.js
+++ b/test/integration/quote-all.test.js
@@ -9,7 +9,7 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { quote, quoteAll as quoteAll } from "../../index.js";
+import { quote, quoteAll as quoteAll } from "shescape";
 import { quoteAll as quoteAllCjs } from "../../index.cjs";
 
 test("inputs are quoted", (t) => {

--- a/test/integration/quote.test.js
+++ b/test/integration/quote.test.js
@@ -8,7 +8,7 @@ import test from "ava";
 
 import { arbitrary, constants, generate, macros } from "./_.js";
 
-import { quote as quote } from "../../index.js";
+import { quote as quote } from "shescape";
 import { quote as quoteCjs } from "../../index.cjs";
 
 test("input is quoted", (t) => {

--- a/test/integration/testing.test.js
+++ b/test/integration/testing.test.js
@@ -9,8 +9,8 @@ import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";
 
-import * as shescape from "../../index.js";
-import { shescape as stubscape } from "../../testing.js";
+import * as shescape from "shescape";
+import { shescape as stubscape } from "shescape/testing";
 import { shescape as stubscapeCjs } from "../../testing.cjs";
 
 testProp(

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -18,66 +18,33 @@ import * as dash from "../../../src/unix/dash.js";
 import * as unix from "../../../src/unix.js";
 import * as zsh from "../../../src/unix/zsh.js";
 
+const shells = [
+  { module: bash, shellName: constants.binBash },
+  { module: csh, shellName: constants.binCsh },
+  { module: dash, shellName: constants.binDash },
+  { module: zsh, shellName: constants.binZsh },
+];
+
 test("the default shell", (t) => {
   const result = unix.getDefaultShell();
   t.is(result, "/bin/sh");
 });
 
-test("escape function for bash", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    unix.getEscapeFunction(constants.binBash, options),
-    bash.getEscapeFunction(options),
-  );
+for (const { module, shellName } of shells) {
+  test(`escape function for ${shellName}`, (t) => {
+    let options = { interpolation: false };
+    t.is(
+      unix.getEscapeFunction(shellName, options),
+      module.getEscapeFunction(options),
+    );
 
-  options = { interpolation: true };
-  t.is(
-    unix.getEscapeFunction(constants.binBash, options),
-    bash.getEscapeFunction(options),
-  );
-});
-
-test("escape function for csh", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    unix.getEscapeFunction(constants.binCsh, options),
-    csh.getEscapeFunction(options),
-  );
-
-  options = { interpolation: true };
-  t.is(
-    unix.getEscapeFunction(constants.binCsh, options),
-    csh.getEscapeFunction(options),
-  );
-});
-
-test("escape function for dash", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    unix.getEscapeFunction(constants.binDash, options),
-    dash.getEscapeFunction(options),
-  );
-
-  options = { interpolation: true };
-  t.is(
-    unix.getEscapeFunction(constants.binDash, options),
-    dash.getEscapeFunction(options),
-  );
-});
-
-test("escape function for zsh", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    unix.getEscapeFunction(constants.binZsh, options),
-    zsh.getEscapeFunction(options),
-  );
-
-  options = { interpolation: true };
-  t.is(
-    unix.getEscapeFunction(constants.binZsh, options),
-    zsh.getEscapeFunction(options),
-  );
-});
+    options = { interpolation: true };
+    t.is(
+      unix.getEscapeFunction(shellName, options),
+      module.getEscapeFunction(options),
+    );
+  });
+}
 
 testProp(
   "escape function for unsupported shell",
@@ -88,29 +55,13 @@ testProp(
   },
 );
 
-test("quote function for bash", (t) => {
-  const actual = unix.getQuoteFunction(constants.binBash);
-  const expected = bash.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
-
-test("quote function for csh", (t) => {
-  const actual = unix.getQuoteFunction(constants.binCsh);
-  const expected = csh.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
-
-test("quote function for dash", (t) => {
-  const actual = unix.getQuoteFunction(constants.binDash);
-  const expected = dash.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
-
-test("quote function for zsh", (t) => {
-  const actual = unix.getQuoteFunction(constants.binZsh);
-  const expected = zsh.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
+for (const { module, shellName } of shells) {
+  test(`quote function for ${shellName}`, (t) => {
+    const actual = unix.getQuoteFunction(shellName);
+    const expected = module.getQuoteFunction();
+    t.deepEqual(actual, expected);
+  });
+}
 
 testProp(
   "quote function for unsupported shell",
@@ -166,29 +117,13 @@ testProp(
   },
 );
 
-test("flag protection function for bash", (t) => {
-  const actual = unix.getFlagProtectionFunction(constants.binBash);
-  const expected = bash.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
-
-test("flag protection function for csh", (t) => {
-  const actual = unix.getFlagProtectionFunction(constants.binCsh);
-  const expected = csh.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
-
-test("flag protection function for dash", (t) => {
-  const actual = unix.getFlagProtectionFunction(constants.binDash);
-  const expected = dash.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
-
-test("flag protection function for zsh", (t) => {
-  const actual = unix.getFlagProtectionFunction(constants.binZsh);
-  const expected = zsh.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
+for (const { module, shellName } of shells) {
+  test(`flag protection function for ${shellName}`, (t) => {
+    const actual = unix.getFlagProtectionFunction(shellName);
+    const expected = module.getFlagProtectionFunction();
+    t.is(actual, expected);
+  });
+}
 
 testProp(
   "flag protection function for unsupported shell",

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -16,6 +16,11 @@ import * as cmd from "../../../src/win/cmd.js";
 import * as win from "../../../src/win.js";
 import * as powershell from "../../../src/win/powershell.js";
 
+const shells = [
+  { module: cmd, shellName: constants.binCmd },
+  { module: powershell, shellName: constants.binPowerShell },
+];
+
 testProp(
   "the default shell when %COMSPEC% is defined",
   [arbitrary.env(), arbitrary.windowsPath()],
@@ -46,33 +51,21 @@ testProp(
   },
 );
 
-test("escape function for CMD", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    win.getEscapeFunction(constants.binCmd, options),
-    cmd.getEscapeFunction(options),
-  );
+for (const { module, shellName } of shells) {
+  test(`escape function for ${shellName}`, (t) => {
+    let options = { interpolation: false };
+    t.is(
+      win.getEscapeFunction(shellName, options),
+      module.getEscapeFunction(options),
+    );
 
-  options = { interpolation: true };
-  t.is(
-    win.getEscapeFunction(constants.binCmd, options),
-    cmd.getEscapeFunction(options),
-  );
-});
-
-test("escape function for PowerShell", (t) => {
-  let options = { interpolation: false };
-  t.is(
-    win.getEscapeFunction(constants.binPowerShell, options),
-    powershell.getEscapeFunction(options),
-  );
-
-  options = { interpolation: true };
-  t.is(
-    win.getEscapeFunction(constants.binPowerShell, options),
-    powershell.getEscapeFunction(options),
-  );
-});
+    options = { interpolation: true };
+    t.is(
+      win.getEscapeFunction(shellName, options),
+      module.getEscapeFunction(options),
+    );
+  });
+}
 
 testProp(
   "escape function for unsupported shell",
@@ -83,17 +76,13 @@ testProp(
   },
 );
 
-test("quote function for CMD", (t) => {
-  const actual = win.getQuoteFunction(constants.binCmd);
-  const expected = cmd.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
-
-test("quote function for PowerShell", (t) => {
-  const actual = win.getQuoteFunction(constants.binPowerShell);
-  const expected = powershell.getQuoteFunction();
-  t.deepEqual(actual, expected);
-});
+for (const { module, shellName } of shells) {
+  test(`quote function for ${shellName}`, (t) => {
+    const actual = win.getQuoteFunction(shellName);
+    const expected = module.getQuoteFunction();
+    t.deepEqual(actual, expected);
+  });
+}
 
 testProp(
   "quote function for unsupported shell",
@@ -153,17 +142,13 @@ testProp(
   },
 );
 
-test("flag protection function for CMD", (t) => {
-  const actual = win.getFlagProtectionFunction(constants.binCmd);
-  const expected = cmd.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
-
-test("flag protection function for PowerShell", (t) => {
-  const actual = win.getFlagProtectionFunction(constants.binPowerShell);
-  const expected = powershell.getFlagProtectionFunction();
-  t.is(actual, expected);
-});
+for (const { module, shellName } of shells) {
+  test(`flag protection function for ${shellName}`, (t) => {
+    const actual = win.getFlagProtectionFunction(shellName);
+    const expected = module.getFlagProtectionFunction();
+    t.is(actual, expected);
+  });
+}
 
 testProp(
   "flag protection for unsupported shell",


### PR DESCRIPTION
Relates to #1060, #1065

## Summary

Improve various aspects of this project's tests by refactoring them.

- Update tests that import at the package level (i.e. they want to import `index.js` or `testing.js`) to import using the package name - i.e. like how end-users would import.
- Parameterize some tests for `src/{unix,win}.js`.
- Reorganize `_runners.cjs`.
- Reorganize imports in fuzz targets.