### PR TITLE
Run all test levels in verify command

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "test:integration": "ava test/integration/**/*.test.js --timeout 1m",
     "test:unit": "ava test/unit/**/*.test.js",
     "transpile": "rollup --config rollup.config.js",
-    "verify": "npm run format:check && npm run license-check && npm run lint && npm run test:unit && npm run test:integration && npm run test:e2e && npm run vet",
+    "verify": "npm run format:check && npm run license-check && npm run lint && npm run coverage && npm run vet",
     "vet": "npm run vet:deps",
     "vet:deps": "knip --config .knip.jsonc"
   }


### PR DESCRIPTION
Relates to #1066

## Summary

1. Extend the `npm run verify` command to run all tests levels.
2. Make the `npm run verify` command run tests with coverage.