### PR TITLE
Remove input validation from `resolveExecutable`

### DIFF
--- a/src/executables.js
+++ b/src/executables.js
@@ -21,10 +21,6 @@
  * @throws {Error} If the `deps` aren't provided.
  */
 export function resolveExecutable({ executable }, { exists, readlink, which }) {
-  if (readlink === undefined || which === undefined) {
-    throw new Error();
-  }
-
   try {
     executable = which(executable);
   } catch (_) {

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -95,28 +95,3 @@ test("the executable exists and is a (sym)link", (t) => {
   t.is(t.context.deps.which.callCount, 1);
   t.is(t.context.deps.exists.callCount, 1);
 });
-
-test("input validation", (t) => {
-  const args = { executable: "a" };
-
-  t.throws(() =>
-    resolveExecutable(args, {
-      exists: t.context.deps.exists,
-      readlink: t.context.deps.readlink,
-    }),
-  );
-
-  t.throws(() =>
-    resolveExecutable(args, {
-      exists: t.context.deps.exists,
-      which: t.context.deps.which,
-    }),
-  );
-
-  t.throws(() =>
-    resolveExecutable(args, {
-      readlink: t.context.deps.readlink,
-      which: t.context.deps.which,
-    }),
-  );
-});


### PR DESCRIPTION
Relates to #159

## Summary

Remove input validation of the provided `deps` from the internal `resolveExecutable` function. This input validation isn't needed because the function is only used internally and if it isn't provided this should be caught by a test or similar, not an unhelpful runtime check which unnecessarily impacts performance.