### PR TITLE
Make Shescape reject unsupported platforms

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,7 @@ interface Shescape {
    * @param {boolean} [options.flagProtection=true] Is flag protection enabled.
    * @param {boolean} [options.interpolation=true] Is interpolation enabled.
    * @param {boolean | string} [options.shell] The shell to escape for.
+   * @throws {Error} The current platform isn't officially supported.
    * @since 2.0.0
    */
   new (options: ShescapeOptions): Shescape;

--- a/index.js
+++ b/index.js
@@ -12,8 +12,18 @@ import os from "node:os";
 import process from "node:process";
 
 import { parseOptions } from "./src/options.js";
-import { getHelpersByPlatform } from "./src/platforms.js";
+import { getHelpersByPlatform, isPlatformSupported } from "./src/platforms.js";
 import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
+
+/**
+ * Build error messages for unsupported platforms.
+ *
+ * @param {string} platform The name of a platform.
+ * @returns {string} The unsupported platform error message.
+ */
+function platformErrorMessage(platform) {
+  return `Shescape does not support the platform ${platform}`;
+}
 
 /**
  * A class to escape user-controlled inputs to shell commands to prevent shell
@@ -62,12 +72,16 @@ export class Shescape {
    * @param {boolean} [options.flagProtection=true] Is flag protection enabled.
    * @param {boolean} [options.interpolation=true] Is interpolation enabled.
    * @param {boolean | string} [options.shell] The shell to escape for.
+   * @throws {Error} The current platform isn't officially supported.
    * @since 2.0.0
    */
   constructor(options = {}) {
     const platform = os.platform();
-    const helpers = getHelpersByPlatform({ env: process.env, platform });
+    if (!isPlatformSupported({ env: process.env, platform })) {
+      throw new Error(platformErrorMessage(platform));
+    }
 
+    const helpers = getHelpersByPlatform({ env: process.env, platform });
     const { flagProtection, interpolation, shellName } = parseOptions(
       { options, process },
       helpers,

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -16,6 +16,22 @@ import * as win from "./win.js";
 const cygwin = "cygwin";
 
 /**
+ * The string identifying macOS platforms.
+ *
+ * @constant
+ * @type {string}
+ */
+const darwin = "darwin";
+
+/**
+ * The string identifying Linux platforms.
+ *
+ * @constant
+ * @type {string}
+ */
+const linux = "linux";
+
+/**
  * The string identifying the OS type MSYS.
  *
  * @constant
@@ -57,4 +73,20 @@ export function getHelpersByPlatform({ env, platform }) {
   }
 
   return unix;
+}
+
+/**
+ * Returns whether or not the current platform is officially supported.
+ *
+ * @param {object} args The arguments for this function.
+ * @param {Object<string, string>} args.env The environment variables.
+ * @param {string} args.platform The `os.platform()` value.
+ * @returns {boolean} Is the current platform supported.
+ */
+export function isPlatformSupported({ env, platform }) {
+  if (isWindow({ env, platform })) {
+    return true;
+  } else {
+    return platform === darwin || platform === linux;
+  }
 }

--- a/test/unit/platforms/is-supported.test.js
+++ b/test/unit/platforms/is-supported.test.js
@@ -1,0 +1,71 @@
+/**
+ * @overview Contains unit tests for the functionality to get helpers functions
+ * for a given platform.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+
+import { arbitrary, constants } from "./_.js";
+
+import { isPlatformSupported } from "../../../src/platforms.js";
+
+for (const platform of [
+  constants.osDarwin,
+  constants.osLinux,
+  constants.osWin32,
+]) {
+  testProp(
+    `platform ${platform} is officially supported`,
+    [arbitrary.env()],
+    (t, env) => {
+      delete env.OSTYPE;
+
+      const result = isPlatformSupported({
+        env,
+        platform,
+      });
+
+      t.true(result);
+    },
+  );
+}
+
+for (const osType of [constants.ostypeCygwin, constants.ostypeMsys]) {
+  testProp(
+    `platform with OS type ${osType} is officially supported`,
+    [arbitrary.env(), arbitrary.platform()],
+    (t, env, platform) => {
+      env.OSTYPE = osType;
+
+      const result = isPlatformSupported({
+        env,
+        platform,
+      });
+
+      t.true(result);
+    },
+  );
+}
+
+for (const platform of [
+  constants.osAix,
+  constants.osFreebsd,
+  constants.osOpenbsd,
+  constants.osSunos,
+]) {
+  testProp(
+    `platform ${platform} is NOT officially supported`,
+    [arbitrary.env()],
+    (t, env) => {
+      delete env.OSTYPE;
+
+      const result = isPlatformSupported({
+        env,
+        platform,
+      });
+
+      t.false(result);
+    },
+  );
+}


### PR DESCRIPTION
Merges into #963
Relates to #200

## Summary

Update the Shescape API and implementation to reject unsupported platforms.