### PR TITLE
Make CodeQL scan `testing.js`

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -8,3 +8,4 @@ queries:
 paths:
   - src/
   - index.js
+  - testing.js


### PR DESCRIPTION
Relates to 61f25a1df0213bf44f66b51c554b2c85a958ec9d, #134, #766

## Summary

Include [`testing.js`](https://github.com/ericcornelissen/shescape/blob/d256d6d8df1fde1a91a6b5785883190f406b5910/testing.js) in the CodeQL analysis.