### PR TITLE
Update Codecov configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -24,20 +24,24 @@ flags:
     paths:
       - src/*.js
       - index.js
+      - testing.js
   integration-Ubuntu:
     carryforward: true
     paths:
       - src/*.js
       - index.js
+      - testing.js
   integration-Windows:
     carryforward: true
     paths:
       - src/*.js
       - index.js
+      - testing.js
   unit:
     carryforward: true
     paths:
       - src/*.js
+      - testing.js
 
 ignore:
   - script/**/*

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -24,22 +24,16 @@ flags:
     paths:
       - src/*.js
       - index.js
-      - index.cjs
-      - testing.cjs
   integration-Ubuntu:
     carryforward: true
     paths:
       - src/*.js
       - index.js
-      - index.cjs
-      - testing.cjs
   integration-Windows:
     carryforward: true
     paths:
       - src/*.js
       - index.js
-      - index.cjs
-      - testing.cjs
   unit:
     carryforward: true
     paths:


### PR DESCRIPTION
Relates to #766, #841

## Summary

Following 22356528fd252f0d9fa7acd849fc6f40517a0915 this removes the transpiled module files from the Codecov flag configuration for integration tests as such generated files are ignored by Codecov.

Also include `testing.js` file in Codecov configuration
