### PR TITLE
Explicitly handle falsy `shells`

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -27,8 +27,14 @@ export function parseOptions(
 ) {
   flagProtection = flagProtection ? true : false;
   interpolation = interpolation ? true : false;
-  shell = isString(shell) ? shell : getDefaultShell({ env });
 
-  const shellName = getShellName({ shell }, { resolveExecutable });
+  let shellName = null;
+  if (isString(shell)) {
+    shellName = getShellName({ shell }, { resolveExecutable });
+  } else if (!!shell === true) {
+    shell = getDefaultShell({ env });
+    shellName = getShellName({ shell }, { resolveExecutable });
+  }
+
   return { flagProtection, interpolation, shellName };
 }

--- a/src/unix.js
+++ b/src/unix.js
@@ -67,6 +67,8 @@ export function getDefaultShell() {
  */
 export function getEscapeFunction(shellName, options) {
   switch (shellName) {
+    case null:
+    // TODO: using `bash` when no shell is used can be confusing to the reader
     case binBash:
       return bash.getEscapeFunction(options);
     case binCsh:
@@ -87,6 +89,8 @@ export function getEscapeFunction(shellName, options) {
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
+    case null:
+    // TODO: using `bash` when no shell is used can be confusing to the reader
     case binBash:
       return bash.getQuoteFunction();
     case binCsh:
@@ -106,6 +110,8 @@ export function getQuoteFunction(shellName) {
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
+    case null:
+    // TODO: using `bash` when no shell is used can be confusing to the reader
     case binBash:
       return bash.getFlagProtectionFunction();
     case binCsh:

--- a/src/win.js
+++ b/src/win.js
@@ -56,6 +56,8 @@ export function getDefaultShell({ env: { ComSpec } }) {
  */
 export function getEscapeFunction(shellName, options) {
   switch (shellName) {
+    case null:
+    // TODO: using `cmd` when no shell is used can be confusing to the reader
     case binCmd:
       return cmd.getEscapeFunction(options);
     case binPowerShell:
@@ -72,6 +74,8 @@ export function getEscapeFunction(shellName, options) {
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
+    case null:
+    // TODO: using `cmd` when no shell is used can be confusing to the reader
     case binCmd:
       return cmd.getQuoteFunction();
     case binPowerShell:
@@ -87,6 +91,8 @@ export function getQuoteFunction(shellName) {
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
+    case null:
+    // TODO: using `cmd` when no shell is used can be confusing to the reader
     case binCmd:
       return cmd.getFlagProtectionFunction();
     case binPowerShell:

--- a/test/unit/options/parse-options.test.js
+++ b/test/unit/options/parse-options.test.js
@@ -71,13 +71,21 @@ testProp("interpolation set to false", [arbitraryInput()], (t, args) => {
 });
 
 testProp(
-  "shell is not specified",
-  [
-    arbitraryInput(),
-    fc.constantFrom(undefined, true, false),
-    fc.string(),
-    fc.string(),
-  ],
+  "shell is falsy",
+  [arbitraryInput(), fc.constantFrom(undefined, false)],
+  (t, args, providedShell) => {
+    args.options.shell = providedShell;
+
+    const result = parseOptions(args, t.context.deps);
+    t.is(t.context.deps.getDefaultShell.callCount, 0);
+    t.is(t.context.deps.getShellName.callCount, 0);
+    t.is(result.shellName, null);
+  },
+);
+
+testProp(
+  "shell is truthy",
+  [arbitraryInput(), fc.constantFrom(true), fc.string(), fc.string()],
   (t, args, providedShell, defaultShell, shellName) => {
     t.context.deps.getDefaultShell.resetHistory();
     t.context.deps.getDefaultShell.returns(defaultShell);

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -30,6 +30,14 @@ test("the default shell", (t) => {
   t.is(result, "/bin/sh");
 });
 
+test("escape function for no shell", (t) => {
+  let options = { interpolation: false };
+  t.is(unix.getEscapeFunction(null, options), bash.getEscapeFunction(options));
+
+  options = { interpolation: true };
+  t.is(unix.getEscapeFunction(null, options), bash.getEscapeFunction(options));
+});
+
 for (const { module, shellName } of shells) {
   test(`escape function for ${shellName}`, (t) => {
     let options = { interpolation: false };
@@ -54,6 +62,12 @@ testProp(
     t.is(result, undefined);
   },
 );
+
+test("quote function for no shell", (t) => {
+  const actual = unix.getQuoteFunction(null);
+  const expected = bash.getQuoteFunction();
+  t.deepEqual(actual, expected);
+});
 
 for (const { module, shellName } of shells) {
   test(`quote function for ${shellName}`, (t) => {
@@ -116,6 +130,12 @@ testProp(
     );
   },
 );
+
+test("flag protection function for no shell", (t) => {
+  const actual = unix.getFlagProtectionFunction(null);
+  const expected = bash.getFlagProtectionFunction();
+  t.is(actual, expected);
+});
 
 for (const { module, shellName } of shells) {
   test(`flag protection function for ${shellName}`, (t) => {

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -51,6 +51,14 @@ testProp(
   },
 );
 
+test("escape function for no shell", (t) => {
+  let options = { interpolation: false };
+  t.is(win.getEscapeFunction(null, options), cmd.getEscapeFunction(options));
+
+  options = { interpolation: true };
+  t.is(win.getEscapeFunction(null, options), cmd.getEscapeFunction(options));
+});
+
 for (const { module, shellName } of shells) {
   test(`escape function for ${shellName}`, (t) => {
     let options = { interpolation: false };
@@ -75,6 +83,12 @@ testProp(
     t.is(result, undefined);
   },
 );
+
+test("quote function for no shell", (t) => {
+  const actual = win.getQuoteFunction(null);
+  const expected = cmd.getQuoteFunction();
+  t.deepEqual(actual, expected);
+});
 
 for (const { module, shellName } of shells) {
   test(`quote function for ${shellName}`, (t) => {
@@ -141,6 +155,12 @@ testProp(
     );
   },
 );
+
+test("flag protection function for no shell", (t) => {
+  const actual = win.getFlagProtectionFunction(null);
+  const expected = cmd.getFlagProtectionFunction();
+  t.is(actual, expected);
+});
 
 for (const { module, shellName } of shells) {
   test(`flag protection function for ${shellName}`, (t) => {


### PR DESCRIPTION
Relates to #1067, #1072

## Summary

Update options parsing to resolve falsy shell options to a `null` shellName to make it internally explicit that we're escaping for a shell-less context (assuming correct usage of the library). Update the platform modules to handle this as an expected `shellName`.

In an ideal world, this case would be handled in a way that it only supports escaping without interpolation (so not escaping with interpolation or even quoting). However, that would be a breaking change and hence this change is externally indistinguishable to the original as the null shellName falls through to the fallback value of getShellName. Instead, this change aims to make it easier to switch to the above behavior in the next major version.

As an added benefit it improves performance when the `shell` option is falsy because it foregoes the executable lookup in favor of a truthy check.