### PR TITLE
Refactor argument replacement chains

### DIFF
--- a/src/unix/bash.js
+++ b/src/unix/bash.js
@@ -11,10 +11,9 @@
  */
 function escapeArgForInterpolation(arg) {
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/\\/gu, "\\\\")
-    .replace(/\r?\n/gu, " ")
     .replace(/(?<=^|\s)([#~])/gu, "\\$1")
     .replace(/(["$&'()*;<>?`{|])/gu, "\\$1")
     .replace(/(?<=[:=])(~)(?=[\s+\-/0:=]|$)/gu, "\\$1")

--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -18,6 +18,7 @@ function escapeArgForInterpolation(arg) {
     .replace(/\r?\n|\r/gu, " ")
     .replace(/\\/gu, "\\\\")
     .replace(/(?<=^|\s)(~)/gu, "\\$1")
+    .replace(/!(?!$)/gu, "\\!")
     .replace(/(["#$&'()*;<>?[`{|])/gu, "\\$1")
     .replace(/([\t ])/gu, "\\$1")
     .split("")
@@ -29,8 +30,7 @@ function escapeArgForInterpolation(arg) {
       // ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995013
       (char) => (textEncoder.encode(char).includes(160) ? `'${char}'` : char),
     )
-    .join("")
-    .replace(/!(?!$)/gu, "\\!");
+    .join("");
 }
 
 /**
@@ -73,8 +73,8 @@ function escapeArgForQuoted(arg) {
   return arg
     .replace(/[\0\u0008\u001B\u009B]/gu, "")
     .replace(/\r?\n|\r/gu, " ")
-    .replace(/\\!$/gu, "\\\\!")
     .replace(/'/gu, "'\\''")
+    .replace(/\\!$/gu, "\\\\!")
     .replace(/!(?!$)/gu, "\\!");
 }
 

--- a/src/unix/dash.js
+++ b/src/unix/dash.js
@@ -17,7 +17,7 @@ function escapeArgForInterpolation(arg) {
     .replace(/\r?\n/gu, " ")
     .replace(/(?<=^|\s)([#~])/gu, "\\$1")
     .replace(/(["$&'()*;<>?`|])/gu, "\\$1")
-    .replace(/([\t\n ])/gu, "\\$1");
+    .replace(/([\t ])/gu, "\\$1");
 }
 
 /**

--- a/src/unix/dash.js
+++ b/src/unix/dash.js
@@ -11,10 +11,9 @@
  */
 function escapeArgForInterpolation(arg) {
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/\\/gu, "\\\\")
-    .replace(/\r?\n/gu, " ")
     .replace(/(?<=^|\s)([#~])/gu, "\\$1")
     .replace(/(["$&'()*;<>?`|])/gu, "\\$1")
     .replace(/([\t ])/gu, "\\$1");

--- a/src/unix/zsh.js
+++ b/src/unix/zsh.js
@@ -11,10 +11,9 @@
  */
 function escapeArgForInterpolation(arg) {
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r(?!\n)/gu, "")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/\\/gu, "\\\\")
-    .replace(/\r?\n/gu, " ")
     .replace(/(?<=^|\s)([#=~])/gu, "\\$1")
     .replace(/(["$&'()*;<>?[\]`{|}])/gu, "\\$1")
     .replace(/([\t ])/gu, "\\$1");

--- a/src/win/powershell.js
+++ b/src/win/powershell.js
@@ -11,10 +11,9 @@
  */
 function escapeArgForInterpolation(arg) {
   arg = arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/`/gu, "``")
-    .replace(/\r(?!\n)/gu, "")
-    .replace(/\r?\n/gu, " ")
     .replace(/(?<=^|[\s\u0085])([*1-6]?)(>)/gu, "$1`$2")
     .replace(/(?<=^|[\s\u0085])([#\-:<@\]])/gu, "`$1")
     .replace(/([$&'(),;{|}‘’‚‛“”„])/gu, "`$1");


### PR DESCRIPTION
Relates to #913

## Summary

Remove unnecessary character escape from dash. The character "\n" does not need to be escaped because it's replaced by a " " three lines prior.