### PR TITLE
Make CR escaping consistent across all shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Change escaping of carriage return characters for CMD and Csh. ([#1094])
 - Fix TypeScript type declarations for `"shescape/testing"`. ([#1083])
 - Fix TypeScript type exports for CommonJS use. ([#1082])
 
@@ -285,6 +286,7 @@ Versioning].
 [#1023]: https://github.com/ericcornelissen/shescape/pull/1023
 [#1082]: https://github.com/ericcornelissen/shescape/pull/1082
 [#1083]: https://github.com/ericcornelissen/shescape/pull/1083
+[#1094]: https://github.com/ericcornelissen/shescape/pull/1094
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/unix/csh.js
+++ b/src/unix/csh.js
@@ -14,8 +14,8 @@ import { TextEncoder } from "util";
 function escapeArgForInterpolation(arg) {
   const textEncoder = new TextEncoder();
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/\\/gu, "\\\\")
     .replace(/(?<=^|\s)(~)/gu, "\\$1")
     .replace(/!(?!$)/gu, "\\!")
@@ -42,8 +42,8 @@ function escapeArgForInterpolation(arg) {
  */
 function escapeArgForNoInterpolation(arg) {
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/\\!$/gu, "\\\\!")
     .replace(/!(?!$)/gu, "\\!");
 }
@@ -71,8 +71,8 @@ export function getEscapeFunction(options) {
  */
 function escapeArgForQuoted(arg) {
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/'/gu, "'\\''")
     .replace(/\\!$/gu, "\\\\!")
     .replace(/!(?!$)/gu, "\\!");

--- a/src/win/cmd.js
+++ b/src/win/cmd.js
@@ -12,8 +12,8 @@
 function escapeArgForInterpolation(arg) {
   let shouldEscapeSpecialChar = true;
   return arg
-    .replace(/[\0\u0008\u001B\u009B]/gu, "")
-    .replace(/\r?\n|\r/gu, " ")
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
     .split("")
     .map(
@@ -43,7 +43,7 @@ function escapeArgForInterpolation(arg) {
  * @returns {string} The escaped argument.
  */
 function escapeArgForNoInterpolation(arg) {
-  return arg.replace(/[\0\u0008\u001B\u009B]/gu, "").replace(/\r?\n|\r/gu, " ");
+  return arg.replace(/[\0\u0008\r\u001B\u009B]/gu, "").replace(/\n/gu, " ");
 }
 
 /**

--- a/test/_runners.cjs
+++ b/test/_runners.cjs
@@ -59,7 +59,7 @@ function getExpectedOutput({ arg, shell }, normalizeWhitespace) {
 
   // Replace newline characters, like Shescape
   if (isShellCmd(shell) || isShellCsh(shell)) {
-    arg = arg.replace(/\r?\n|\r/gu, " ");
+    arg = arg.replace(/\r/gu, "").replace(/\n/gu, " ");
   } else {
     arg = arg.replace(/\r(?!\n)/gu, "");
   }

--- a/test/fixtures/unix.js
+++ b/test/fixtures/unix.js
@@ -6271,11 +6271,11 @@ export const quote = {
         expected: "'a b c'",
       },
       {
-        input: "a ",
+        input: "a\r\n",
         expected: "'a '",
       },
       {
-        input: " a",
+        input: "\r\na",
         expected: "' a'",
       },
     ],

--- a/test/fixtures/unix.js
+++ b/test/fixtures/unix.js
@@ -1633,19 +1633,19 @@ export const escape = {
     "<carriage return> (\\r)": [
       {
         input: "a\rb",
-        expected: { interpolation: "a\\ b", noInterpolation: "a b" },
+        expected: { interpolation: "ab", noInterpolation: "ab" },
       },
       {
         input: "a\rb\rc",
-        expected: { interpolation: "a\\ b\\ c", noInterpolation: "a b c" },
+        expected: { interpolation: "abc", noInterpolation: "abc" },
       },
       {
         input: "\ra",
-        expected: { interpolation: "\\ a", noInterpolation: " a" },
+        expected: { interpolation: "a", noInterpolation: "a" },
       },
       {
         input: "a\r",
-        expected: { interpolation: "a\\ ", noInterpolation: "a " },
+        expected: { interpolation: "a", noInterpolation: "a" },
       },
     ],
     "<carriage return> (\\r) + <end of line> (\\n)": [
@@ -2790,8 +2790,8 @@ export const escape = {
       {
         input: "a{\u000Db,c}d",
         expected: {
-          interpolation: "a\\{\\ b,c}d",
-          noInterpolation: "a{ b,c}d",
+          interpolation: "a\\{b,c}d",
+          noInterpolation: "a{b,c}d",
         },
       },
       {
@@ -2811,8 +2811,8 @@ export const escape = {
       {
         input: "a{b,c\u000D}d",
         expected: {
-          interpolation: "a\\{b,c\\ }d",
-          noInterpolation: "a{b,c }d",
+          interpolation: "a\\{b,c}d",
+          noInterpolation: "a{b,c}d",
         },
       },
       {
@@ -2849,8 +2849,8 @@ export const escape = {
       {
         input: "a{\u000D0..2}b",
         expected: {
-          interpolation: "a\\{\\ 0..2}b",
-          noInterpolation: "a{ 0..2}b",
+          interpolation: "a\\{0..2}b",
+          noInterpolation: "a{0..2}b",
         },
       },
       {
@@ -2870,8 +2870,8 @@ export const escape = {
       {
         input: "a{0..2\u000D}b",
         expected: {
-          interpolation: "a\\{0..2\\ }b",
-          noInterpolation: "a{0..2 }b",
+          interpolation: "a\\{0..2}b",
+          noInterpolation: "a{0..2}b",
         },
       },
       {
@@ -6246,19 +6246,19 @@ export const quote = {
     "<carriage return> (\\r)": [
       {
         input: "a\rb",
-        expected: "'a b'",
+        expected: "'ab'",
       },
       {
         input: "a\rb\rc",
-        expected: "'a b c'",
+        expected: "'abc'",
       },
       {
         input: "\ra",
-        expected: "' a'",
+        expected: "'a'",
       },
       {
         input: "a\r",
-        expected: "'a '",
+        expected: "'a'",
       },
     ],
     "<carriage return> (\\r) + <end of line> (\\n)": [
@@ -6271,11 +6271,11 @@ export const quote = {
         expected: "'a b c'",
       },
       {
-        input: "a\r\n",
+        input: "a ",
         expected: "'a '",
       },
       {
-        input: "\r\na",
+        input: " a",
         expected: "' a'",
       },
     ],

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -124,19 +124,19 @@ export const escape = {
     "<carriage return> (\\r)": [
       {
         input: "a\rb",
-        expected: { interpolation: "a b", noInterpolation: "a b" },
+        expected: { interpolation: "ab", noInterpolation: "ab" },
       },
       {
         input: "a\rb\rc",
-        expected: { interpolation: "a b c", noInterpolation: "a b c" },
+        expected: { interpolation: "abc", noInterpolation: "abc" },
       },
       {
         input: "\ra",
-        expected: { interpolation: " a", noInterpolation: " a" },
+        expected: { interpolation: "a", noInterpolation: "a" },
       },
       {
         input: "a\r",
-        expected: { interpolation: "a ", noInterpolation: "a " },
+        expected: { interpolation: "a", noInterpolation: "a" },
       },
     ],
     "<carriage return> (\\r) + <end of line> (\\n)": [
@@ -3687,19 +3687,19 @@ export const quote = {
     "<carriage return> (\\r)": [
       {
         input: "a\rb",
-        expected: 'a" "b',
+        expected: "ab",
       },
       {
         input: "a\rb\rc",
-        expected: 'a" "b" "c',
+        expected: "abc",
       },
       {
         input: "\ra",
-        expected: '" "a',
+        expected: "a",
       },
       {
         input: "a\r",
-        expected: 'a" "',
+        expected: "a",
       },
     ],
     "<carriage return> (\\r) + <end of line> (\\n)": [


### PR DESCRIPTION
Relates to #1092

## Summary

Update escaping for Csh and CMD to escape CR by removing it (instead of replacing by ` `) when necessary. This aligns the behavior for Csh and CMD with that of all other supported shells.