### PR TITLE
Improve integration tests

### DIFF
--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -3,8 +3,6 @@
  * @license MIT
  */
 
-import os from "node:os";
-
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
 import common from "../_constants.cjs";
@@ -15,12 +13,10 @@ import common from "../_constants.cjs";
  * @returns {string[]} Supported shells for the current platform.
  */
 function getPlatformShells() {
-  const platform = os.platform();
-  switch (platform) {
-    case "win32":
-      return common.shellsWindows;
-    default:
-      return common.shellsUnix;
+  if (common.isWindows) {
+    return common.shellsWindows;
+  } else {
+    return common.shellsUnix;
   }
 }
 
@@ -30,12 +26,10 @@ function getPlatformShells() {
  * @returns {object} All test fixtures for the current platform.
  */
 function getPlatformFixtures() {
-  const platform = os.platform();
-  switch (platform) {
-    case "win32":
-      return fixturesWindows;
-    default:
-      return fixturesUnix;
+  if (common.isWindows) {
+    return fixturesWindows;
+  } else {
+    return fixturesUnix;
   }
 }
 

--- a/test/integration/testing.test.js
+++ b/test/integration/testing.test.js
@@ -17,7 +17,7 @@ testProp(
   "escape (stubscape ~ shescape)",
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
-    let result, stubResult, errored;
+    let result, stubResult, errored, stubErrored;
 
     try {
       result = shescape.escape(arg, options);
@@ -28,9 +28,10 @@ testProp(
     try {
       stubResult = stubscape.escape(arg, options);
     } catch (_) {
-      t.true(errored);
+      stubErrored = true;
     }
 
+    t.is(errored, stubErrored);
     t.is(typeof result, typeof stubResult);
   },
 );
@@ -39,7 +40,7 @@ testProp(
   "escapeAll (stubscape ~ shescape)",
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, args, options) => {
-    let result, stubResult, errored;
+    let result, stubResult, errored, stubErrored;
 
     try {
       result = shescape.escapeAll(args, options);
@@ -50,9 +51,10 @@ testProp(
     try {
       stubResult = stubscape.escapeAll(args, options);
     } catch (_) {
-      t.true(errored);
+      stubErrored = true;
     }
 
+    t.is(errored, stubErrored);
     t.is(typeof result, typeof stubResult);
   },
 );
@@ -61,7 +63,7 @@ testProp(
   "quote (stubscape ~ shescape)",
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
-    let result, stubResult, errored;
+    let result, stubResult, errored, stubErrored;
 
     try {
       result = shescape.quote(arg, options);
@@ -72,9 +74,10 @@ testProp(
     try {
       stubResult = stubscape.quote(arg, options);
     } catch (_) {
-      t.true(errored);
+      stubErrored = true;
     }
 
+    t.is(errored, stubErrored);
     t.is(typeof result, typeof stubResult);
   },
 );
@@ -83,7 +86,7 @@ testProp(
   "quoteAll (stubscape ~ shescape)",
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, args, options) => {
-    let result, stubResult, errored;
+    let result, stubResult, errored, stubErrored;
 
     try {
       result = shescape.quoteAll(args, options);
@@ -94,9 +97,10 @@ testProp(
     try {
       stubResult = stubscape.quoteAll(args, options);
     } catch (_) {
-      t.true(errored);
+      stubErrored = true;
     }
 
+    t.is(errored, stubErrored);
     t.is(typeof result, typeof stubResult);
   },
 );


### PR DESCRIPTION
## Summary

- `testing.test.js`: Assert errored also when stubscape didn't error to avoid potential false positives if it also returns `undefined` values.
- `_generators.js`: Use common Windows detection logic instead of custom/local Windows detection logic.