### PR TITLE
Use a `Symbol` to represent 'no shell'

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -7,6 +7,14 @@ import { resolveExecutable } from "./executables.js";
 import { isString } from "./reflection.js";
 
 /**
+ * The identifier for 'no shell' or the absence of a shell.
+ *
+ * @constant
+ * @type {symbol}
+ */
+export const noShellId = Symbol("no shell");
+
+/**
  * Parses options provided to shescape.
  *
  * @param {object} args The arguments for this function.
@@ -26,7 +34,7 @@ export function parseOptions(
 ) {
   flagProtection = flagProtection ? true : false;
 
-  let shellName = null;
+  let shellName = noShellId;
   if (shell !== false) {
     if (!isString(shell)) {
       shell = getDefaultShell({ env });

--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@ import { isString } from "./reflection.js";
  * @constant
  * @type {symbol}
  */
-export const noShellId = Symbol("no shell");
+export const noShell = Symbol();
 
 /**
  * Parses options provided to shescape.
@@ -34,7 +34,7 @@ export function parseOptions(
 ) {
   flagProtection = flagProtection ? true : false;
 
-  let shellName = noShellId;
+  let shellName = noShell;
   if (shell !== false) {
     if (!isString(shell)) {
       shell = getDefaultShell({ env });

--- a/src/unix.js
+++ b/src/unix.js
@@ -13,6 +13,7 @@ import * as csh from "./unix/csh.js";
 import * as dash from "./unix/dash.js";
 import * as noShell from "./unix/no-shell.js";
 import * as zsh from "./unix/zsh.js";
+import { noShellId } from "./options.js";
 
 /**
  * The name of the Bourne-again shell (Bash) binary.
@@ -61,12 +62,12 @@ export function getDefaultShell() {
 /**
  * Returns a function to escape arguments for use in a particular shell.
  *
- * @param {string | null} shellName The name of a Unix shell.
+ * @param {string | symbol} shellName The name of a Unix shell.
  * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getEscapeFunction();
     case binBash:
       return bash.getEscapeFunction();
@@ -83,12 +84,12 @@ export function getEscapeFunction(shellName) {
  * Returns a pair of functions to escape and quote arguments for use in a
  * particular shell.
  *
- * @param {string | null} shellName The name of a Unix shell.
+ * @param {string | symbol} shellName The name of a Unix shell.
  * @returns {Function[] | undefined} A function pair to escape & quote arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getQuoteFunction();
     case binBash:
       return bash.getQuoteFunction();
@@ -104,12 +105,12 @@ export function getQuoteFunction(shellName) {
 /**
  * Returns a function to protect against flag injection.
  *
- * @param {string | null} shellName The name of a Unix shell.
+ * @param {string | symbol} shellName The name of a Unix shell.
  * @returns {Function | undefined} A function to protect against flag injection.
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getFlagProtectionFunction();
     case binBash:
       return bash.getFlagProtectionFunction();

--- a/src/unix.js
+++ b/src/unix.js
@@ -11,9 +11,9 @@ import which from "which";
 import * as bash from "./unix/bash.js";
 import * as csh from "./unix/csh.js";
 import * as dash from "./unix/dash.js";
-import * as noShell from "./unix/no-shell.js";
+import * as nosh from "./unix/no-shell.js";
 import * as zsh from "./unix/zsh.js";
-import { noShellId } from "./options.js";
+import { noShell } from "./options.js";
 
 /**
  * The name of the Bourne-again shell (Bash) binary.
@@ -67,8 +67,8 @@ export function getDefaultShell() {
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getEscapeFunction();
+    case noShell:
+      return nosh.getEscapeFunction();
     case binBash:
       return bash.getEscapeFunction();
     case binCsh:
@@ -89,8 +89,8 @@ export function getEscapeFunction(shellName) {
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getQuoteFunction();
+    case noShell:
+      return nosh.getQuoteFunction();
     case binBash:
       return bash.getQuoteFunction();
     case binCsh:
@@ -110,8 +110,8 @@ export function getQuoteFunction(shellName) {
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getFlagProtectionFunction();
+    case noShell:
+      return nosh.getFlagProtectionFunction();
     case binBash:
       return bash.getFlagProtectionFunction();
     case binCsh:

--- a/src/win.js
+++ b/src/win.js
@@ -11,6 +11,7 @@ import which from "which";
 import * as cmd from "./win/cmd.js";
 import * as noShell from "./win/no-shell.js";
 import * as powershell from "./win/powershell.js";
+import { noShellId } from "./options.js";
 
 /**
  * The name of the Windows Command Prompt binary.
@@ -50,12 +51,12 @@ export function getDefaultShell({ env: { ComSpec } }) {
 /**
  * Returns a function to escape arguments for use in a particular shell.
  *
- * @param {string | null} shellName The name of a Windows shell.
+ * @param {string | symbol} shellName The name of a Windows shell.
  * @returns {Function | undefined} A function to escape arguments.
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getEscapeFunction();
     case binCmd:
       return cmd.getEscapeFunction();
@@ -68,12 +69,12 @@ export function getEscapeFunction(shellName) {
  * Returns a pair of functions to escape and quote arguments for use in a
  * particular shell.
  *
- * @param {string | null} shellName The name of a Windows shell.
+ * @param {string | symbol} shellName The name of a Windows shell.
  * @returns {Function[] | undefined} A function pair to escape & quote arguments.
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getQuoteFunction();
     case binCmd:
       return cmd.getQuoteFunction();
@@ -85,12 +86,12 @@ export function getQuoteFunction(shellName) {
 /**
  * Returns a function to protect against flag injection.
  *
- * @param {string | null} shellName The name of a Windows shell.
+ * @param {string | symbol} shellName The name of a Windows shell.
  * @returns {Function | undefined} A function to protect against flag injection.
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
-    case null:
+    case noShellId:
       return noShell.getFlagProtectionFunction();
     case binCmd:
       return cmd.getFlagProtectionFunction();

--- a/src/win.js
+++ b/src/win.js
@@ -9,9 +9,9 @@ import * as path from "node:path";
 import which from "which";
 
 import * as cmd from "./win/cmd.js";
-import * as noShell from "./win/no-shell.js";
+import * as nosh from "./win/no-shell.js";
 import * as powershell from "./win/powershell.js";
-import { noShellId } from "./options.js";
+import { noShell } from "./options.js";
 
 /**
  * The name of the Windows Command Prompt binary.
@@ -56,8 +56,8 @@ export function getDefaultShell({ env: { ComSpec } }) {
  */
 export function getEscapeFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getEscapeFunction();
+    case noShell:
+      return nosh.getEscapeFunction();
     case binCmd:
       return cmd.getEscapeFunction();
     case binPowerShell:
@@ -74,8 +74,8 @@ export function getEscapeFunction(shellName) {
  */
 export function getQuoteFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getQuoteFunction();
+    case noShell:
+      return nosh.getQuoteFunction();
     case binCmd:
       return cmd.getQuoteFunction();
     case binPowerShell:
@@ -91,8 +91,8 @@ export function getQuoteFunction(shellName) {
  */
 export function getFlagProtectionFunction(shellName) {
   switch (shellName) {
-    case noShellId:
-      return noShell.getFlagProtectionFunction();
+    case noShell:
+      return nosh.getFlagProtectionFunction();
     case binCmd:
       return cmd.getFlagProtectionFunction();
     case binPowerShell:

--- a/test/unit/options/parse-options.test.js
+++ b/test/unit/options/parse-options.test.js
@@ -11,7 +11,7 @@ import sinon from "sinon";
 import { arbitrary } from "./_.js";
 
 import { resolveExecutable } from "../../../src/executables.js";
-import { parseOptions } from "../../../src/options.js";
+import { noShell, parseOptions } from "../../../src/options.js";
 
 const arbitraryInput = () =>
   fc
@@ -58,7 +58,7 @@ testProp(
     const result = parseOptions(args, t.context.deps);
     t.is(t.context.deps.getDefaultShell.callCount, 0);
     t.is(t.context.deps.getShellName.callCount, 0);
-    t.is(result.shellName, null);
+    t.is(result.shellName, noShell);
   },
 );
 

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -16,8 +16,9 @@ import * as unix from "../../../src/unix.js";
 import * as bash from "../../../src/unix/bash.js";
 import * as csh from "../../../src/unix/csh.js";
 import * as dash from "../../../src/unix/dash.js";
-import * as noShell from "../../../src/unix/no-shell.js";
+import * as nosh from "../../../src/unix/no-shell.js";
 import * as zsh from "../../../src/unix/zsh.js";
+import { noShell } from "../../../src/options.js";
 
 const shells = [
   { module: bash, shellName: constants.binBash },
@@ -32,8 +33,8 @@ test("the default shell", (t) => {
 });
 
 test("escape function for no shell", (t) => {
-  const actual = unix.getEscapeFunction(null);
-  const expected = noShell.getEscapeFunction();
+  const actual = unix.getEscapeFunction(noShell);
+  const expected = nosh.getEscapeFunction();
   t.deepEqual(actual, expected);
 });
 
@@ -55,8 +56,8 @@ testProp(
 );
 
 test("quote function for no shell", (t) => {
-  const actual = unix.getQuoteFunction(null);
-  const expected = noShell.getQuoteFunction();
+  const actual = unix.getQuoteFunction(noShell);
+  const expected = nosh.getQuoteFunction();
   t.deepEqual(actual, expected);
 });
 
@@ -123,8 +124,8 @@ testProp(
 );
 
 test("flag protection function for no shell", (t) => {
-  const actual = unix.getFlagProtectionFunction(null);
-  const expected = noShell.getFlagProtectionFunction();
+  const actual = unix.getFlagProtectionFunction(noShell);
+  const expected = nosh.getFlagProtectionFunction();
   t.is(actual, expected);
 });
 
@@ -146,7 +147,7 @@ testProp(
 );
 
 test(`is shell supported, no shell`, (t) => {
-  const actual = unix.isShellSupported(null);
+  const actual = unix.isShellSupported(noShell);
   t.true(actual);
 });
 

--- a/test/unit/unix/no-shell.test.js
+++ b/test/unit/unix/no-shell.test.js
@@ -7,14 +7,14 @@
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
-import * as noShell from "../../../src/unix/no-shell.js";
+import * as nosh from "../../../src/unix/no-shell.js";
 
 testProp("quote function", [fc.string()], (t, arg) => {
   const expected = {
     message: "Quoting is not supported when no shell is used",
   };
 
-  const [escapeFn, quoteFn] = noShell.getQuoteFunction();
+  const [escapeFn, quoteFn] = nosh.getQuoteFunction();
   t.throws(() => escapeFn(arg), expected);
   t.throws(() => quoteFn(arg), expected);
 });

--- a/test/unit/unix/shells.test.js
+++ b/test/unit/unix/shells.test.js
@@ -12,11 +12,11 @@ import { constants, fixtures, macros } from "./_.js";
 import * as bash from "../../../src/unix/bash.js";
 import * as csh from "../../../src/unix/csh.js";
 import * as dash from "../../../src/unix/dash.js";
-import * as noShell from "../../../src/unix/no-shell.js";
+import * as nosh from "../../../src/unix/no-shell.js";
 import * as zsh from "../../../src/unix/zsh.js";
 
 const shells = {
-  [null]: noShell,
+  [null]: nosh,
   [constants.binBash]: bash,
   [constants.binCsh]: csh,
   [constants.binDash]: dash,
@@ -63,7 +63,7 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     },
   );
 
-  if (shellExports !== noShell) {
+  if (shellExports !== nosh) {
     quoteFixtures.forEach(({ input, expected }) => {
       test(macros.quote, {
         expected,

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -14,8 +14,9 @@ import { arbitrary, constants } from "./_.js";
 
 import * as win from "../../../src/win.js";
 import * as cmd from "../../../src/win/cmd.js";
-import * as noShell from "../../../src/win/no-shell.js";
+import * as nosh from "../../../src/win/no-shell.js";
 import * as powershell from "../../../src/win/powershell.js";
+import { noShell } from "../../../src/options.js";
 
 const shells = [
   { module: cmd, shellName: constants.binCmd },
@@ -53,8 +54,8 @@ testProp(
 );
 
 test("escape function for no shell", (t) => {
-  const actual = win.getEscapeFunction(null);
-  const expected = noShell.getEscapeFunction();
+  const actual = win.getEscapeFunction(noShell);
+  const expected = nosh.getEscapeFunction();
   t.is(actual, expected);
 });
 
@@ -76,8 +77,8 @@ testProp(
 );
 
 test("quote function for no shell", (t) => {
-  const actual = win.getQuoteFunction(null);
-  const expected = noShell.getQuoteFunction();
+  const actual = win.getQuoteFunction(noShell);
+  const expected = nosh.getQuoteFunction();
   t.deepEqual(actual, expected);
 });
 
@@ -148,8 +149,8 @@ testProp(
 );
 
 test("flag protection function for no shell", (t) => {
-  const actual = win.getFlagProtectionFunction(null);
-  const expected = noShell.getFlagProtectionFunction();
+  const actual = win.getFlagProtectionFunction(noShell);
+  const expected = nosh.getFlagProtectionFunction();
   t.is(actual, expected);
 });
 
@@ -171,7 +172,7 @@ testProp(
 );
 
 test(`is shell supported, no shell`, (t) => {
-  const actual = win.isShellSupported(null);
+  const actual = win.isShellSupported(noShell);
   t.true(actual);
 });
 

--- a/test/unit/win/no-shell.test.js
+++ b/test/unit/win/no-shell.test.js
@@ -7,14 +7,14 @@
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 
-import * as noShell from "../../../src/win/no-shell.js";
+import * as nosh from "../../../src/win/no-shell.js";
 
 testProp("quote function", [fc.string()], (t, arg) => {
   const expected = {
     message: "Quoting is not supported when no shell is used",
   };
 
-  const [escapeFn, quoteFn] = noShell.getQuoteFunction();
+  const [escapeFn, quoteFn] = nosh.getQuoteFunction();
   t.throws(() => escapeFn(arg), expected);
   t.throws(() => quoteFn(arg), expected);
 });

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -10,11 +10,11 @@ import * as fc from "fast-check";
 import { constants, fixtures, macros } from "./_.js";
 
 import * as cmd from "../../../src/win/cmd.js";
-import * as noShell from "../../../src/win/no-shell.js";
+import * as nosh from "../../../src/win/no-shell.js";
 import * as powershell from "../../../src/win/powershell.js";
 
 const shells = {
-  [null]: noShell,
+  [null]: nosh,
   [constants.binCmd]: cmd,
   [constants.binPowerShell]: powershell,
 };
@@ -58,7 +58,7 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     },
   );
 
-  if (shellExports !== noShell) {
+  if (shellExports !== nosh) {
     quoteFixtures.forEach(({ input, expected }) => {
       test(macros.quote, {
         expected,


### PR DESCRIPTION
Merges into #963
Relates to #1067

## Summary

Improve the inner workings of Shescape by avoiding the use of `null` to represent a meaningful value - the selection of 'no shell' - by a `Symbol`. A `Symbol` was chosen because it is unique, impossible to intersect with a real shell name (as opposed to a string), and meaningful (as opposed to `null`).