### PR TITLE
Harden CI workflow against shell/script injection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,19 +79,25 @@ jobs:
       - name: Get release version
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: major_version
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
         with:
           result-encoding: string
           script: |
-            const version = "${{ needs.check.outputs.version }}"
+            const version = `${process.env.VERSION}`
             const major = version.replace(/\.\d\.\d$/, "")
             return major
       - name: Create release tag
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
         run: |
-          git tag '${{ needs.check.outputs.version }}'
-          git push origin '${{ needs.check.outputs.version }}'
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
       - name: Update major version branch
+        env:
+          MAJOR_VERSION: ${{ steps.major_version.outputs.result }}
         run: |
-          git push origin 'HEAD:${{ steps.major_version.outputs.result }}'
+          git push origin "HEAD:${MAJOR_VERSION}"
   github:
     name: GitHub
     runs-on: ubuntu-22.04

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -53,14 +53,18 @@ jobs:
       - name: Create identifier
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: run-id
+        env:
+          OS: ${{ inputs.os }}
+          SHELL: ${{ inputs.shell }}
+          TARGET: ${{ matrix.target }}
         with:
           result-encoding: string
           script: |
-            const path = "${{ inputs.shell }}"
+            const path = `${process.env.SHELL}`
             const fileName = path.split(/\//g).pop()
             const shellName = fileName.endsWith(".exe") ?
               fileName.slice(0, -4) : fileName
-            return `${{ inputs.os }}-${shellName}-${{ matrix.target }}`
+            return `${process.env.OS}-${shellName}-${process.env.TARGET}`
       - name: Install Node.js
         uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
         with:
@@ -85,9 +89,11 @@ jobs:
         id: fuzz
         shell: bash {0}
         env:
+          DURATION: ${{ inputs.duration }}
           FUZZ_SHELL: ${{ inputs.shell }}
+          TARGET: ${{ matrix.target }}
         run: |
-          timeout '${{ inputs.duration }}s' npm run fuzz '${{ matrix.target }}'
+          timeout "${DURATION}s" npm run fuzz "${TARGET}"
           export EXIT_CODE=$?
           if [[ ($EXIT_CODE == 124) ]]; then
             echo 'fuzz-error=false' >> $GITHUB_OUTPUT
@@ -102,8 +108,10 @@ jobs:
           fi
       - name: Check for unexpected error
         if: ${{ steps.fuzz.outputs.script-error == 'true' }}
+        env:
+          EXIT_CODE: ${{ steps.fuzz.outputs.exit-code }}
         run: |
-          echo 'Unexpected error: ${{ steps.fuzz.outputs.exit-code }}'
+          echo "Unexpected error: ${EXIT_CODE}"
           exit 1
       - name: Upload crash (if any)
         if: ${{ steps.fuzz.outputs.fuzz-error == 'true' }}


### PR DESCRIPTION
Relates to #317, #395, #401, #735

## Summary

Update workflows based on [the blog post "Four tips to keep your GitHub Actions workflows secure"](https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure). Review was done manually.