### PR TITLE
Update license information in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ View the [testing] documentation for how to test code that uses Shescape.
 
 Read the [tips] for additional ways to protect against shell injection.
 
----
+## License
 
-_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
+The source code is licensed under the `MPL-2.0` license, see [LICENSE] for
+the full license text. The documentation text is licensed under [CC BY-SA 4.0];
+code snippets under the [MIT license].
 
 [ci-url]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml
 [ci-image]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml/badge.svg
@@ -84,7 +86,7 @@ _Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
 [cmd.exe]: https://en.wikipedia.org/wiki/Cmd.exe
 [csh]: https://en.wikipedia.org/wiki/C_shell
 [dash]: https://en.wikipedia.org/wiki/Almquist_shell#Dash "Debian Almquist Shell"
-[license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE
+[license]: ./LICENSE
 [mit license]: https://opensource.org/license/mit/
 [powershell]: https://en.wikipedia.org/wiki/PowerShell
 [recipes]: docs/recipes.md


### PR DESCRIPTION
Relates to #852

## Summary

Update the README.md to replace the "footer" with license information about the file itself with a "License" section covering both the source code license and file(/documentation) license. This aims to improve discoverability of the license information.