### PR TITLE
Make "shell not supported" unit testable

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,16 +16,6 @@ import { getHelpersByPlatform } from "./src/platforms.js";
 import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
 
 /**
- * Build error messages for unsupported shells.
- *
- * @param {string} shellName The full name of a shell.
- * @returns {string} The unsupported shell error message.
- */
-function shellError(shellName) {
-  return `Shescape does not support the shell ${shellName}`;
-}
-
-/**
  * A class to escape user-controlled inputs to shell commands to prevent shell
  * injection.
  *
@@ -78,14 +68,8 @@ export class Shescape {
     const platform = os.platform();
     const helpers = getHelpersByPlatform({ env: process.env, platform });
 
-    const { flagProtection, shellName } = parseOptions(
-      { options, process },
-      helpers,
-    );
-
-    if (!helpers.isShellSupported(shellName)) {
-      throw new Error(shellError(shellName));
-    }
+    options = parseOptions({ env: process.env, options }, helpers);
+    const { flagProtection, shellName } = options;
 
     {
       const escape = helpers.getEscapeFunction(shellName);

--- a/src/options.js
+++ b/src/options.js
@@ -15,22 +15,33 @@ import { isString } from "./reflection.js";
 export const noShell = Symbol();
 
 /**
+ * Build error messages for unsupported shells.
+ *
+ * @param {string} shellName The full name of a shell.
+ * @returns {string} The unsupported shell error message.
+ */
+function shellError(shellName) {
+  return `Shescape does not support the shell ${shellName}`;
+}
+
+/**
  * Parses options provided to shescape.
  *
  * @param {object} args The arguments for this function.
+ * @param {Object<string, string>} args.env The environment variables.
  * @param {object} args.options The options for escaping.
  * @param {boolean} [args.options.flagProtection] Is flag protection enabled.
  * @param {boolean | string} [args.options.shell=true] The shell to escape for.
- * @param {object} args.process The `process` values.
- * @param {object} args.process.env The environment variables.
  * @param {object} deps The dependencies for this function.
  * @param {Function} deps.getDefaultShell Function to get the default shell.
  * @param {Function} deps.getShellName Function to get the name of a shell.
+ * @param {Function} deps.isShellSupported Function to see if a shell is usable.
  * @returns {object} The parsed arguments.
+ * @throws {Error} The shell is not supported.
  */
 export function parseOptions(
-  { options: { flagProtection, shell }, process: { env } },
-  { getDefaultShell, getShellName },
+  { env, options: { flagProtection, shell } },
+  { getDefaultShell, getShellName, isShellSupported },
 ) {
   flagProtection = flagProtection ? true : false;
 
@@ -41,6 +52,10 @@ export function parseOptions(
     }
 
     shellName = getShellName({ shell }, { resolveExecutable });
+  }
+
+  if (!isShellSupported(shellName)) {
+    throw new Error(shellError(shellName));
   }
 
   return { flagProtection, shellName };

--- a/test/integration/constructor.test.js
+++ b/test/integration/constructor.test.js
@@ -10,8 +10,5 @@ import { Shescape } from "shescape";
 test("shell is unsupported", (t) => {
   const shell = "not-actually-a-shell-that-exists";
 
-  t.throws(() => new Shescape({ shell }), {
-    instanceOf: Error,
-    message: `Shescape does not support the shell ${shell}`,
-  });
+  t.throws(() => new Shescape({ shell }));
 });


### PR DESCRIPTION
Merges into #963
Relates to #1067, #1125

## Summary

Refactor the code related to checking if a shell is supported such that it can be unit tested. Improving testability as well as composibility. Also included some additional refactoring to simplify the interface of the `parseOptions` function (replacing the `process` input by just `env`).