### PR TITLE
Correct initialization in examples & Shescape class type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ interface ShescapeOptions {
  *
  * @example
  * import { spawn } from "node:child_process";
- * const shescape = Shescape({ shell: false });
+ * const shescape = new Shescape({ shell: false });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.escape(userInput)],
@@ -42,7 +42,7 @@ interface ShescapeOptions {
  * );
  * @example
  * import { spawn } from "node:child_process";
- * const shescape = Shescape({ shell: false });
+ * const shescape = new Shescape({ shell: false });
  * spawn(
  *   "echo",
  *   shescape.escapeAll(["Hello", userInput]),
@@ -51,7 +51,7 @@ interface ShescapeOptions {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ shell: spawnOptions.shell });
+ * const shescape = new Shescape({ shell: spawnOptions.shell });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput)],
@@ -60,14 +60,14 @@ interface ShescapeOptions {
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ shell: spawnOptions.shell });
+ * const shescape = new Shescape({ shell: spawnOptions.shell });
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput]),
  *   spawnOptions
  * );
  */
-interface Shescape {
+export class Shescape {
   /**
    * Create a new {@link Shescape} instance.
    *
@@ -77,7 +77,7 @@ interface Shescape {
    * @throws {Error} The shell is not supported.
    * @since 2.0.0
    */
-  new (options: ShescapeOptions): Shescape;
+  constructor(options: ShescapeOptions);
 
   /**
    * Take a single value, the argument, and escape any dangerous characters.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  *
  * @example
  * import { spawn } from "node:child_process";
- * const shescape = Shescape({ shell: false });
+ * const shescape = new Shescape({ shell: false });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.escape(userInput)],
@@ -29,7 +29,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  * );
  * @example
  * import { spawn } from "node:child_process";
- * const shescape = Shescape({ shell: false });
+ * const shescape = new Shescape({ shell: false });
  * spawn(
  *   "echo",
  *   shescape.escapeAll(["Hello", userInput]),
@@ -38,7 +38,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ shell: spawnOptions.shell });
+ * const shescape = new Shescape({ shell: spawnOptions.shell });
  * spawn(
  *   "echo",
  *   ["Hello", shescape.quote(userInput)],
@@ -47,7 +47,7 @@ import { checkedToString, toArrayIfNecessary } from "./src/reflection.js";
  * @example
  * import { spawn } from "node:child_process";
  * const spawnOptions = { shell: true }; // `options.shell` SHOULD be truthy
- * const shescape = Shescape({ shell: spawnOptions.shell });
+ * const shescape = new Shescape({ shell: spawnOptions.shell });
  * spawn(
  *   "echo",
  *   shescape.quoteAll(["Hello", userInput]),


### PR DESCRIPTION
Merges into #963
Relates to #1130

## Summary

Update the `@example`s in the JSDoc for the `Shescape` class to actually initialize, rather than call, `Shescape` (both `.js` and `.ts`). Also correct the type decleration for the `Shescape` class to be a class rather than an interface (that way the `constructor` makes sense).