### PR TITLE
Change `package.json` "linting" to "vetting"

### DIFF
--- a/.github/workflows/config-npm.yml
+++ b/.github/workflows/config-npm.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Validate package.json
-        run: npm run lint:package.json
+        run: npm run vet:package.json

--- a/package.json
+++ b/package.json
@@ -88,13 +88,13 @@
     "prefuzz": "npm run transpile",
     "prepare": "is-ci || husky install script/hooks",
     "prepublishOnly": "npm run transpile",
-    "prelint:package.json": "npm run transpile",
     "premutation:integration": "npm run transpile",
     "pretest:compat": "npm run transpile",
     "pretest:compat-all": "npm run transpile",
     "pretest:e2e": "npm run transpile",
     "pretest:integration": "npm run transpile",
     "prevet:deps": "npm run transpile",
+    "prevet:package.json": "npm run transpile",
     "_coverage": "c8 --reporter=lcov --reporter=text",
     "_eslint": "eslint . --report-unused-disable-directives",
     "_prettier": "prettier . --ignore-path .gitignore",
@@ -117,7 +117,6 @@
     "lint:js": "npm run _eslint -- --ext .js,.cjs",
     "lint:json": "npm run _eslint -- --ext .json,.jsonc",
     "lint:md": "markdownlint --dot --ignore-path .gitignore .",
-    "lint:package.json": "publint --strict && attw --pack .",
     "lint:sh": "shellcheck script/hooks/*.sh script/hooks/pre-*",
     "lint:yml": "npm run _eslint -- --ext .yml",
     "mutation": "npm run mutation:unit && npm run mutation:integration",
@@ -131,7 +130,8 @@
     "test:unit": "ava test/unit/**/*.test.js",
     "transpile": "rollup --config rollup.config.js && cp index.d.ts index.d.cts && cp testing.d.ts testing.d.cts",
     "verify": "npm run format:check && npm run license-check && npm run lint && npm run coverage && npm run vet",
-    "vet": "npm run vet:deps",
-    "vet:deps": "knip --config .knip.jsonc"
+    "vet": "npm run vet:deps && npm run vet:package.json",
+    "vet:deps": "knip --config .knip.jsonc",
+    "vet:package.json": "publint --strict && attw --pack ."
   }
 }


### PR DESCRIPTION
Relates to #673, #1083

## Summary

Since it's more about finding problems than stylistic things. Also, now it makes more sense to execute it "by default" when `npm run vet` is invoked. This also (unintentionally) fixes the [Formatting and Linting](https://github.com/ericcornelissen/shescape/blob/aa1e8273257a0e12bc9e3d3bd17586cd2b40c460/CONTRIBUTING.md#formatting-and-linting) section of the Contributing Guidelines.