### PR TITLE
Improve executable resolution coverage for Windows

### DIFF
--- a/.github/workflows/fuzz-cmd.yml
+++ b/.github/workflows/fuzz-cmd.yml
@@ -27,5 +27,5 @@ jobs:
     with:
       duration: 600 # seconds == 10 minutes
       os: windows-2022
-      shell: cmd
+      shell: cmd.exe
       targets: '["exec", "exec-file", "spawn"]'

--- a/.github/workflows/fuzz-powershell.yml
+++ b/.github/workflows/fuzz-powershell.yml
@@ -27,5 +27,5 @@ jobs:
     with:
       duration: 600 # seconds == 10 minutes
       os: windows-2022
-      shell: powershell
+      shell: powershell.exe
       targets: '["exec", "exec-file", "spawn"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- Support `shell` values without `.exe` for Windows. ([#1137])
+- Support more valid `shell` values for Windows. ([#1137])
 
 ## [1.7.3] - 2023-08-07
 

--- a/test/_constants.cjs
+++ b/test/_constants.cjs
@@ -65,6 +65,8 @@ module.exports.binPowerShell = "powershell.exe";
 module.exports.shellsWindows = [
   module.exports.binCmd,
   "cmd.EXE",
+  "cmd",
   module.exports.binPowerShell,
   "powershell.EXE",
+  "powershell",
 ];

--- a/test/_constants.cjs
+++ b/test/_constants.cjs
@@ -64,5 +64,7 @@ module.exports.binPowerShell = "powershell.exe";
 
 module.exports.shellsWindows = [
   module.exports.binCmd,
+  "cmd.EXE",
   module.exports.binPowerShell,
+  "powershell.EXE",
 ];

--- a/test/_constants.cjs
+++ b/test/_constants.cjs
@@ -65,8 +65,6 @@ module.exports.binPowerShell = "powershell.exe";
 module.exports.shellsWindows = [
   module.exports.binCmd,
   "cmd.EXE",
-  "cmd",
   module.exports.binPowerShell,
   "powershell.EXE",
-  "powershell",
 ];

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -41,6 +41,9 @@ function getPlatformFixtures() {
  */
 function getShellFixtures(shell) {
   const fixtures = getPlatformFixtures();
+
+  shell = shell.toLowerCase();
+
   return {
     escape: Object.values(fixtures.escape[shell]).flat(),
     flag: Object.values(fixtures.flag[shell]).flat(),

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -43,6 +43,9 @@ function getShellFixtures(shell) {
   const fixtures = getPlatformFixtures();
 
   shell = shell.toLowerCase();
+  if (common.isWindows) {
+    shell = shell.endsWith(".exe") ? shell : `${shell}.exe`;
+  }
 
   return {
     escape: Object.values(fixtures.escape[shell]).flat(),

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -40,13 +40,9 @@ function getPlatformFixtures() {
  * @returns {object} All test fixtures for `shell`.
  */
 function getShellFixtures(shell) {
-  const fixtures = getPlatformFixtures();
-
   shell = shell.toLowerCase();
-  if (common.isWindows) {
-    shell = shell.endsWith(".exe") ? shell : `${shell}.exe`;
-  }
 
+  const fixtures = getPlatformFixtures();
   return {
     escape: Object.values(fixtures.escape[shell]).flat(),
     flag: Object.values(fixtures.flag[shell]).flat(),

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -99,15 +99,11 @@ testProp(
   "get shell name for supported shell",
   [arbitrary.env(), arbitrary.windowsPath(), arbitrary.windowsShell()],
   (t, env, basePath, shell) => {
-    const executable = shell.toLowerCase().endsWith(".exe")
-      ? shell
-      : `${shell}.exe`;
-
     const resolveExecutable = sinon.stub();
-    resolveExecutable.returns(path.join(basePath, executable));
+    resolveExecutable.returns(path.join(basePath, shell));
 
     const result = win.getShellName({ env, shell }, { resolveExecutable });
-    t.is(result, executable);
+    t.is(result, shell);
   },
 );
 

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -99,11 +99,15 @@ testProp(
   "get shell name for supported shell",
   [arbitrary.env(), arbitrary.windowsPath(), arbitrary.windowsShell()],
   (t, env, basePath, shell) => {
+    const executable = shell.toLowerCase().endsWith(".exe")
+      ? shell
+      : `${shell}.exe`;
+
     const resolveExecutable = sinon.stub();
-    resolveExecutable.returns(path.join(basePath, shell));
+    resolveExecutable.returns(path.join(basePath, executable));
 
     const result = win.getShellName({ env, shell }, { resolveExecutable });
-    t.is(result, shell);
+    t.is(result, executable);
   },
 );
 


### PR DESCRIPTION
Relates to #1125, #1137

## Summary

Avoid future regressions by improving the test coverage of different ways that executables can be resolved on Windows.