### PR TITLE
Drop commit SHA from artifact IDs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -391,11 +391,6 @@ jobs:
             registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Get git context
-        id: git
-        run: |
-          COMMIT_SHA="$(git rev-parse HEAD)"
-          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Install Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
@@ -416,7 +411,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ failure() || success() }}
         with:
-          name: mutation-unit-report-${{ steps.git.outputs.commit-sha }}
+          name: mutation-unit-report
           path: |
             _reports/mutation/unit.html
             .cache/stryker-incremental-unit.json
@@ -443,11 +438,6 @@ jobs:
             registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Get git context
-        id: git
-        run: |
-          COMMIT_SHA="$(git rev-parse HEAD)"
-          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Install Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
@@ -468,7 +458,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ failure() || success() }}
         with:
-          name: mutation-integration-report-${{ steps.git.outputs.commit-sha }}
+          name: mutation-integration-report
           path: |
             _reports/mutation/integration.html
             .cache/stryker-incremental-integration.json

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -44,12 +44,6 @@ jobs:
             registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Get git context
-        shell: bash
-        id: git
-        run: |
-          COMMIT_SHA="$(git rev-parse HEAD)"
-          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Create identifier
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: run-id
@@ -117,7 +111,7 @@ jobs:
         if: ${{ steps.fuzz.outputs.fuzz-error == 'true' }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: fuzz-crash-${{ steps.run-id.outputs.result }}-${{ steps.git.outputs.commit-sha }}
+          name: fuzz-crash-${{ steps.run-id.outputs.result }}
           path: |
             .corpus/
             crash-*


### PR DESCRIPTION
Relates to #854, #862, #864, #940

## Summary

This was originally added in an attempt to make it easy to identify what commit and artifact was created for, however it's incorrect on Pull Requests and thus confusing. Removing this for now.