### PR TITLE
Use script to copy .d.ts files to .d.cts

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "test:e2e": "ava test/e2e/**/*.test.js --timeout 1m",
     "test:integration": "ava test/integration/**/*.test.js --timeout 1m",
     "test:unit": "ava test/unit/**/*.test.js",
-    "transpile": "rollup --config rollup.config.js && cp index.d.ts index.d.cts && cp testing.d.ts testing.d.cts",
+    "transpile": "rollup --config rollup.config.js && node script/create-d-cts.js",
     "verify": "npm run format:check && npm run license-check && npm run lint && npm run coverage && npm run vet",
     "vet": "npm run vet:deps && npm run vet:package.json",
     "vet:deps": "knip --config .knip.jsonc",

--- a/script/create-d-cts.js
+++ b/script/create-d-cts.js
@@ -1,0 +1,18 @@
+/**
+ * @overview Create the `.d.cts` files for the published package.
+ * @license MIT
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const files = ["index.d.ts", "testing.d.ts"];
+
+for (const file of files) {
+  const copy = file.replace(".d.ts", ".d.cts");
+
+  const filePath = path.resolve(file);
+  const copyPath = path.resolve(copy);
+
+  fs.copyFileSync(filePath, copyPath);
+}


### PR DESCRIPTION
Relates to #1083

## Summary

The command `cp` isn't (always) available on Windows. Creating the script is simple enough, and it reduces friction for contributors on Windows, so I think it's worth it.