### PR TITLE
Exit with non-zero exit code when runtime dependency violations found

### DIFF
--- a/script/check-runtime-deps.js
+++ b/script/check-runtime-deps.js
@@ -63,6 +63,8 @@ if (violations.length > 0) {
     "violation(s) found.",
     "Update either the version range or installed version of each violation.",
   );
+
+  process.exit(1);
 } else {
   console.log("No problems detected");
 }


### PR DESCRIPTION
Relates to #497, #963

## Summary

Make the script with custom checks for runtime dependency exit with a non-zero exit code (aka fail) when any violations are found. This should help better ensure the check is adhered to as it will make CI fail.