### PR TITLE
Explicitly configure what to `--include` in coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "pretest:integration": "npm run transpile",
     "prevet:deps": "npm run transpile",
     "prevet:package.json": "npm run transpile",
-    "_coverage": "c8 --reporter=lcov --reporter=text",
+    "_coverage": "c8 --include src/ --include index.js --include index.cjs --include testing.js --include testing.cjs --reporter=lcov --reporter=text",
     "_eslint": "eslint . --report-unused-disable-directives",
     "_prettier": "prettier . --ignore-path .gitignore",
     "audit": "better-npm-audit audit",


### PR DESCRIPTION
Relates to #1140

## Summary

Update the helper `_coverage` command to explicitly specify what files should be reported on for coverage. This follows observed coverage reporting for certain files that aren't of interest.