### PR TITLE
Update compatibility tests

### DIFF
--- a/test/compat/index.test.cjs
+++ b/test/compat/index.test.cjs
@@ -15,8 +15,7 @@ describe("index.cjs", function () {
 
     const input = "Hello world!";
     const result = shescape.escape(input);
-    assert.notStrictEqual(result, "");
-    assert.ok(!/^(?<q>["']).*\k<q>$/u.test(result));
+    assert.strictEqual(typeof result, "string");
   });
 
   it("has a functioning `escapeAll` function", function () {
@@ -26,8 +25,7 @@ describe("index.cjs", function () {
     const inputs = ["foo", "bar"];
     const result = shescape.escapeAll(inputs);
     for (const output of result) {
-      assert.notStrictEqual(output, "");
-      assert.ok(!/^(?<q>["']).*\k<q>$/u.test(output));
+      assert.strictEqual(typeof output, "string");
     }
   });
 
@@ -37,8 +35,7 @@ describe("index.cjs", function () {
 
     const input = "Hello world!";
     const result = shescape.quote(input);
-    assert.notStrictEqual(result, "");
-    assert.ok(/^(?<q>["']).*\k<q>$/u.test(result));
+    assert.strictEqual(typeof result, "string");
   });
 
   it("has a functioning `quoteAll` function", function () {
@@ -48,8 +45,7 @@ describe("index.cjs", function () {
     const inputs = ["foo", "bar"];
     const result = shescape.quoteAll(inputs);
     for (const output of result) {
-      assert.notStrictEqual(output, "");
-      assert.ok(/^(?<q>["']).*\k<q>$/u.test(output));
+      assert.strictEqual(typeof output, "string");
     }
   });
 });


### PR DESCRIPTION
## Summary

The current assertions fail on Windows (because quoting no longer puts quotes at the start and end of the input for CMD), so they're updated in line with the assertions for corresponding integration tests.