### PR TITLE
Disallow fuzzing fork with a shell

### DIFF
--- a/test/fuzz/fork.test.cjs
+++ b/test/fuzz/fork.test.cjs
@@ -4,10 +4,15 @@
  * @license MIT
  */
 
-const { runners } = require("./_.cjs");
+const { common, runners } = require("./_.cjs");
 
 async function fuzz(buf) {
   const arg = buf.toString();
+  const shell = common.getFuzzShell();
+
+  if (shell !== false) {
+    throw new Error("Fuzzing fork requires a falsy shell");
+  }
 
   try {
     await runners.fork(arg);


### PR DESCRIPTION
Relates to #963

## Summary

Fork can't be run with a shell, so trying to fuzz it with a shell can be misleading. This changes the fuzz target to throw immediately if a non-falsy shell is configured to avoid such confusion.