### PR TITLE
Create nightly job to test against latest dependency versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -309,12 +309,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Install Zsh
-        if: ${{ matrix.name == 'Ubuntu' }}
-        run: sudo apt-get --assume-yes install zsh
       - name: Install csh
         if: ${{ matrix.name == 'Ubuntu' }}
         run: sudo apt-get --assume-yes install csh
+      - name: Install Zsh
+        if: ${{ matrix.name == 'Ubuntu' }}
+        run: sudo apt-get --assume-yes install zsh
       - name: Run end-to-end tests
         run: npm run coverage:e2e
       - name: Upload coverage to Codecov

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
-          disable-sudo: true
+          disable-sudo: false
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,59 @@ jobs:
     uses: ericcornelissen/shescape/.github/workflows/reusable-audit.yml@main
     with:
       refs: '["main", "v1"]'
+  test:
+    name: Test against latest dependency versions (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: MacOS
+            os: macos-12
+          - name: Ubuntu
+            os: ubuntu-22.04
+          - name: Windows
+            os: windows-2022
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
+            api.github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            azure.archive.ubuntu.com:80
+            codecov.io:443
+            github.com:443
+            gitlab.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Bump runtime dependencies to latest compatible
+        run: npm update --omit dev --omit optional --omit peer
+      - name: Install csh
+        if: ${{ matrix.name == 'Ubuntu' }}
+        run: sudo apt-get --assume-yes install csh
+      - name: Install Zsh
+        if: ${{ matrix.name == 'Ubuntu' }}
+        run: sudo apt-get --assume-yes install zsh
+      - name: Run integration tests
+        run: npm run test:integration
+      - name: Run end-to-end tests
+        run: npm run test:e2e
   tooling:
     name: Tool update
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Bump runtime dependencies to latest compatible
-        run: npm update --omit dev --omit optional --omit peer
+        run: |
+          npm update --omit dev --omit optional --omit peer
+          npm install
       - name: Install csh
         if: ${{ matrix.name == 'Ubuntu' }}
         run: sudo apt-get --assume-yes install csh

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -71,12 +71,12 @@ jobs:
           key: fuzz-${{ steps.run-id.outputs.result }}-${{ github.run_number }}
           restore-keys: |
             fuzz-${{ steps.run-id.outputs.result }}
-      - name: Install Zsh
-        if: ${{ inputs.shell == '/bin/zsh' }}
-        run: sudo apt-get --assume-yes install zsh
       - name: Install csh
         if: ${{ inputs.shell == '/bin/csh' }}
         run: sudo apt-get --assume-yes install csh
+      - name: Install Zsh
+        if: ${{ inputs.shell == '/bin/zsh' }}
+        run: sudo apt-get --assume-yes install zsh
       - name: Install dependencies
         run: npm clean-install
       - name: Fuzz (target '${{ matrix.target }}')


### PR DESCRIPTION
## Summary

Add an (experimental) job to the nightly workflow that will run tests after updating runtime dependencies to the latest available(&compatible) version using `npm update`. This is in an effort to ensure compatibility with runtime dependencies is true for the latest versions, while keeping compatibility with the oldest version.

---

##### [Job preview](https://github.com/ericcornelissen/shescape/actions/runs/6041885151)