### PR TITLE
Fix `bump-changelog.js` script

### DIFF
--- a/script/release/bump-changelog.js
+++ b/script/release/bump-changelog.js
@@ -7,6 +7,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { common } from "../_.js";
+
 const STR_UNRELEASED = "## [Unreleased]";
 const STR_NO_CHANGES = "- _No changes yet_";
 


### PR DESCRIPTION
Relates to #1160

## Summary

Fix a mistake in the `bump-changelog.js` script. It's currently incorrect and failing due to a missing import.