### PR TITLE
Apply `npm pkg fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ericcornelissen/shescape"
+    "url": "git+https://github.com/ericcornelissen/shescape.git"
   },
   "bugs": {
     "url": "https://github.com/ericcornelissen/shescape/issues"


### PR DESCRIPTION
## Summary

Based on [this blog post](https://github.blog/changelog/2023-09-27-block-npm-package-publishes-when-names-and-versions-dont-match-between-manifest-and-tarball-package-json/). The packages being published weren't incorrect perse, but this is just a simple improvement for correctness and ecosystem consistency.