### PR TITLE
Add "What to Report" to the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,22 @@ report the issue privately.
 [new github advisory]: https://github.com/ericcornelissen/shescape/security/advisories/new
 [security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28shescape%29
 
+### What to Report (Thread Model)
+
+#### In Scope
+
+- Insufficient escaping for any supported shell.
+- Logic bugs with a security implication (e.g. unexpected throw) that can be
+  triggered through the public API.
+- Security misconfigurations in the continuous integration pipeline or software
+  supply chain.
+- Insecure suggestions or snippets in the documentation.
+
+#### Out of Scope
+
+- Known vulnerabilities in third-party (`dependencies` or `devDependencies`).
+- Bugs only affecting the `shescape/testing` module.
+
 ### What to Include in a Report
 
 Try to include as many of the following items as possible in a security report:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ report the issue privately.
 [new github advisory]: https://github.com/ericcornelissen/shescape/security/advisories/new
 [security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28shescape%29
 
-### What to Report (Thread Model)
+### What to Report (Threat Model)
 
 #### In Scope
 
@@ -50,7 +50,7 @@ report the issue privately.
 
 #### Out of Scope
 
-- Known vulnerabilities in third-party (`dependencies` or `devDependencies`).
+- Known vulnerabilities in third-party `dependencies` or `devDependencies`.
 - Bugs only affecting the `shescape/testing` module.
 
 ### What to Include in a Report


### PR DESCRIPTION
Relates to #906

## Summary

Update the Security Policy to include a section on "what to report", which can be seen as a basic threat model.