### PR TITLE
Extend ReDoS testing with general performance tests for escaping logic

### DIFF
--- a/test/unit/_macros.js
+++ b/test/unit/_macros.js
@@ -3,7 +3,10 @@
  * @license MIT
  */
 
+import { performance } from "node:perf_hooks";
+
 import test from "ava";
+import fc from "fast-check";
 
 /**
  * Transforms a string by replacing control characters with unicode point codes
@@ -91,6 +94,36 @@ export const flag = test.macro({
     input = escapeControlCharacters(input);
 
     return `flag protect '${input}' for ${shellName}`;
+  },
+});
+
+/**
+ * The flag macro tests the behaviour of the function returned by the provided
+ * `getFlagProtectionFunction`.
+ *
+ * @param {object} t The AVA test object.
+ * @param {object} args The arguments for this function.
+ * @param {any} args.arbitraries The arbitraries to test with.
+ * @param {number} args.maxMillis The maximum duration in milliseconds.
+ * @param {Function} args.setup A function to setup the function to test.
+ */
+export const duration = test.macro({
+  exec(t, { arbitraries, maxMillis, setup }) {
+    fc.assert(
+      fc.property(...arbitraries, (...args) => {
+        const fn = setup();
+
+        const startTime = performance.now();
+        try {
+          fn(...args);
+        } catch (_) {
+          // not concerned about functional correctness
+        }
+        const endTime = performance.now();
+
+        t.true(endTime - startTime < maxMillis);
+      }),
+    );
   },
 });
 

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -3,8 +3,6 @@
  * @license MIT
  */
 
-import { performance } from "node:perf_hooks";
-
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
@@ -41,22 +39,11 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     t.is(typeof result, "string");
   });
 
-  testProp(
-    `escape performance for ${shellName}`,
-    [fc.string({ size: "xlarge" })],
-    (t, arg) => {
-      const escapeFn = shellExports.getEscapeFunction();
-
-      const startTime = performance.now();
-      try {
-        escapeFn(arg);
-      } catch (_) {}
-      const endTime = performance.now();
-
-      t.true(endTime - startTime < 50);
-    },
-    { endOnFailure: true },
-  );
+  test(`escape performance for ${shellName}`, macros.duration, {
+    arbitraries: [fc.string({ size: "xlarge" })],
+    maxMillis: 50,
+    setup: shellExports.getEscapeFunction,
+  });
 
   flagFixtures.forEach(({ input, expected }) => {
     test(macros.flag, {
@@ -77,22 +64,11 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     },
   );
 
-  testProp(
-    `flag protection performance for ${shellName}`,
-    [fc.string({ size: "xlarge" })],
-    (t, arg) => {
-      const flagProtect = shellExports.getFlagProtectionFunction();
-
-      const startTime = performance.now();
-      try {
-        flagProtect(arg);
-      } catch (_) {}
-      const endTime = performance.now();
-
-      t.true(endTime - startTime < 50);
-    },
-    { endOnFailure: true },
-  );
+  test(`flag protection performance for ${shellName}`, macros.duration, {
+    arbitraries: [fc.string({ size: "xlarge" })],
+    maxMillis: 50,
+    setup: shellExports.getFlagProtectionFunction,
+  });
 
   if (shellExports !== nosh) {
     quoteFixtures.forEach(({ input, expected }) => {
@@ -112,21 +88,13 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       t.is(typeof result, "string");
     });
 
-    testProp(
-      `quote function performance for ${shellName}`,
-      [fc.string({ size: "xlarge" })],
-      (t, arg) => {
+    test(`quote performance for ${shellName}`, macros.duration, {
+      arbitraries: [fc.string({ size: "xlarge" })],
+      maxMillis: 50,
+      setup: () => {
         const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
-
-        const startTime = performance.now();
-        try {
-          quoteFn(escapeFn(arg));
-        } catch (_) {}
-        const endTime = performance.now();
-
-        t.true(endTime - startTime < 50);
+        return (arg) => quoteFn(escapeFn(arg));
       },
-      { endOnFailure: true },
-    );
+    });
   }
 }

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -3,6 +3,8 @@
  * @license MIT
  */
 
+import { performance } from "node:perf_hooks";
+
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
@@ -39,6 +41,23 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     t.is(typeof result, "string");
   });
 
+  testProp(
+    `escape performance for ${shellName}`,
+    [fc.string({ size: "xlarge" })],
+    (t, arg) => {
+      const escapeFn = shellExports.getEscapeFunction();
+
+      const startTime = performance.now();
+      try {
+        escapeFn(arg);
+      } catch (_) {}
+      const endTime = performance.now();
+
+      t.true(endTime - startTime < 50);
+    },
+    { endOnFailure: true },
+  );
+
   flagFixtures.forEach(({ input, expected }) => {
     test(macros.flag, {
       expected: expected.unquoted,
@@ -58,6 +77,23 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     },
   );
 
+  testProp(
+    `flag protection performance for ${shellName}`,
+    [fc.string({ size: "xlarge" })],
+    (t, arg) => {
+      const flagProtect = shellExports.getFlagProtectionFunction();
+
+      const startTime = performance.now();
+      try {
+        flagProtect(arg);
+      } catch (_) {}
+      const endTime = performance.now();
+
+      t.true(endTime - startTime < 50);
+    },
+    { endOnFailure: true },
+  );
+
   if (shellExports !== nosh) {
     quoteFixtures.forEach(({ input, expected }) => {
       test(macros.quote, {
@@ -75,5 +111,22 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       const result = quoteFn(intermediate);
       t.is(typeof result, "string");
     });
+
+    testProp(
+      `quote function performance for ${shellName}`,
+      [fc.string({ size: "xlarge" })],
+      (t, arg) => {
+        const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
+
+        const startTime = performance.now();
+        try {
+          quoteFn(escapeFn(arg));
+        } catch (_) {}
+        const endTime = performance.now();
+
+        t.true(endTime - startTime < 50);
+      },
+      { endOnFailure: true },
+    );
   }
 }


### PR DESCRIPTION
Relates to #373, 552e8eab56861720b1d4e5474fb65741643358f9

## Summary

Add general performance/ReDoS tests modeled after [`fast-check`'s blog post on the topic](https://fast-check.dev/blog/2023/10/05/finding-back-a-redos-vulnerability-in-zod/).

This complements the ReDoS regression tests (for Unix) in that these tests will only catch some ReDoS regression. In fact, based on testing, this project's ReDoS CVEs wouldn't have been caught by the tests being added here.