### PR TITLE
Update breakage tests to run against v2.0.1

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,7 @@ meta:
   - .shellcheckrc
 
 test:
+  - test/breakage/**
   - test/compat/**
   - test/e2e/**
   - test/fixtures/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "prettier": "3.0.3",
         "publint": "0.2.4",
         "rollup": "4.1.4",
-        "shescape-previous": "npm:shescape@2.0.0",
+        "shescape-previous": "npm:shescape@2.0.1",
         "sinon": "17.0.0"
       },
       "engines": {
@@ -11829,9 +11829,9 @@
     },
     "node_modules/shescape-previous": {
       "name": "shescape",
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.0.0.tgz",
-      "integrity": "sha512-5NO165joyGNZHTEm5BLiZ+lbq9UEZnhRD3Z4FiQ3nYOUN/bXQfgXtyNNEDjWtI7vLDyrfpvfBGmT5mPLSURa5A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.0.1.tgz",
+      "integrity": "sha512-tnBHgeM+tj0bpyZHVeJCwVkzrvJuXzR//d4qfrAuYVyBiYunQWR43Uif0wC/dySCaRr7HA+l6VYXXa+fn5ksnw==",
       "dev": true,
       "dependencies": {
         "which": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prettier": "3.0.3",
     "publint": "0.2.4",
     "rollup": "4.1.4",
-    "shescape-previous": "npm:shescape@2.0.0",
+    "shescape-previous": "npm:shescape@2.0.1",
     "sinon": "17.0.0"
   },
   "scripts": {

--- a/test/breakage/testing.test.js
+++ b/test/breakage/testing.test.js
@@ -9,7 +9,10 @@ import * as fc from "fast-check";
 import { arbitrary } from "./_.js";
 
 import { Shescape as Stubscape, Throwscape } from "shescape/testing";
-import { Shescape as Previoustub } from "shescape-previous/testing";
+import {
+  Shescape as Previoustub,
+  Throwscape as Previousthrow,
+} from "shescape-previous/testing";
 
 testProp(
   "Stubscape#constructor",
@@ -91,9 +94,7 @@ testProp(
   },
 );
 
-// TODO: unskip upon release 2.0.1/2.1.0. It's currently skipped because the
-// implementation was incorrect in 2.0.0 and has been fixed since (in 4f03fd8).
-testProp.skip(
+testProp(
   "Stubscape#quote",
   [arbitrary.shescapeOptions(), fc.anything()],
   (t, options, arg) => {
@@ -120,9 +121,7 @@ testProp.skip(
   },
 );
 
-// TODO: unskip upon release 2.0.1/2.1.0. It's currently skipped because the
-// implementation was incorrect in 2.0.0 and has been fixed since (in 4f03fd8).
-testProp.skip(
+testProp(
   "Stubscape#quoteAll",
   [
     arbitrary.shescapeOptions(),
@@ -152,9 +151,7 @@ testProp.skip(
   },
 );
 
-// TODO: unskip upon release 2.0.1/2.1.0. It's currently skipped because the
-// `Throwscape` class was not yet release in 2.0.0 (added in 4f03fd8).
-testProp.skip(
+testProp(
   "Throwscape#constructor",
   [arbitrary.shescapeOptions()],
   (t, options) => {


### PR DESCRIPTION
Relates to #1233, #1268

## Summary

Update the breakage tests to run against v2.0.1. This keeps the breakage tests up-to-date and allows for unskipping all tests that either fixed bugs observable by the breakage tests or were for previously unreleased APIs.