### PR TITLE
Tests for non-own property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Harden against polluted prototypes. ([#1280])
 
 ## [2.0.1] - 2023-10-28
 
@@ -318,6 +318,7 @@ Versioning].
 [#1137]: https://github.com/ericcornelissen/shescape/pull/1137
 [#1142]: https://github.com/ericcornelissen/shescape/pull/1142
 [#1149]: https://github.com/ericcornelissen/shescape/pull/1149
+[#1280]: https://github.com/ericcornelissen/shescape/pull/1280
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/script/run-platform-coverage.js
+++ b/script/run-platform-coverage.js
@@ -15,4 +15,5 @@ if (!testType) {
   process.exit(1);
 }
 
-common.npm(["run", `coverage:${testType}:${platform}`]);
+const cmd = common.npm(["run", `coverage:${testType}:${platform}`]);
+cmd.on("close", (code) => process.exit(code));

--- a/src/options.js
+++ b/src/options.js
@@ -25,6 +25,20 @@ function unsupportedError(shellName) {
 }
 
 /**
+ * Check if the given object has the given property as an own property.
+ *
+ * This custom function is used over `Object.hasOwn` because that isn't
+ * available in all supported Node.js versions.
+ *
+ * @param {object} object The object of interest.
+ * @param {string} property The property of interest.
+ * @returns {boolean} `true` if property is an own-property, `false` otherwise.
+ */
+function hasOwn(object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+/**
  * Parses options provided to shescape.
  *
  * @param {object} args The arguments for this function.
@@ -41,10 +55,10 @@ export function parseOptions(
   { env, options },
   { getDefaultShell, getShellName, isShellSupported },
 ) {
-  let flagProtection = Object.hasOwn(options, "flagProtection")
+  let flagProtection = hasOwn(options, "flagProtection")
     ? options.flagProtection
     : undefined;
-  let shell = Object.hasOwn(options, "shell") ? options.shell : undefined;
+  let shell = hasOwn(options, "shell") ? options.shell : undefined;
 
   flagProtection =
     flagProtection === undefined ? true : flagProtection ? true : false;

--- a/src/options.js
+++ b/src/options.js
@@ -30,8 +30,6 @@ function unsupportedError(shellName) {
  * @param {object} args The arguments for this function.
  * @param {Object<string, string>} args.env The environment variables.
  * @param {object} args.options The options for escaping.
- * @param {boolean} [args.options.flagProtection] Is flag protection enabled.
- * @param {boolean | string} [args.options.shell=true] The shell to escape for.
  * @param {object} deps The dependencies for this function.
  * @param {Function} deps.getDefaultShell Function to get the default shell.
  * @param {Function} deps.getShellName Function to get the name of a shell.
@@ -40,9 +38,14 @@ function unsupportedError(shellName) {
  * @throws {Error} The shell is not supported or could not be found.
  */
 export function parseOptions(
-  { env, options: { flagProtection, shell } },
+  { env, options },
   { getDefaultShell, getShellName, isShellSupported },
 ) {
+  let flagProtection = Object.hasOwn(options, "flagProtection")
+    ? options.flagProtection
+    : undefined;
+  let shell = Object.hasOwn(options, "shell") ? options.shell : undefined;
+
   flagProtection =
     flagProtection === undefined ? true : flagProtection ? true : false;
 

--- a/test/integration/constructor/_.js
+++ b/test/integration/constructor/_.js
@@ -1,0 +1,9 @@
+/**
+ * @overview Provides testing utilities.
+ * @license MIT
+ */
+
+import * as arbitrary from "../../_arbitraries.js";
+import * as pollution from "./_pollution.js";
+
+export { arbitrary, pollution };

--- a/test/integration/constructor/_pollution.js
+++ b/test/integration/constructor/_pollution.js
@@ -1,0 +1,98 @@
+/**
+ * @overview Contains helpers to detect non-own property access.
+ * @license MIT
+ */
+
+import assert from "node:assert/strict";
+
+/**
+ * A store for non-own property accesses by proxy.
+ */
+const pollutionState = new Map();
+
+/**
+ * Check whether or not a value is nil (`null` or `undefined`).
+ *
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is nil, `false` otherwise.
+ */
+function isNil(value) {
+  return value === null || value === undefined;
+}
+
+/**
+ * Check whether or not a value is a primitive value.
+ *
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is primitive, `false` otherwise.
+ */
+function isPrimitive(value) {
+  return typeof value === "number" || typeof value === "string";
+}
+
+/**
+ * Check whether or not a value can be wrapped by a `Proxy`.
+ *
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if `value` is proxyable, `false` otherwise.
+ */
+function isProxyable(value) {
+  return !(isNil(value) || isPrimitive(value));
+}
+
+/**
+ * Wrap the provided target in in order to monitor it for access to properties
+ * not present on the target.
+ *
+ * @param {any} target The value to wrap.
+ * @returns {any} The wrapped value (or original if wrapping isn't possible).
+ */
+export function wrap(target) {
+  if (!isProxyable(target)) {
+    return target;
+  }
+
+  const nonOwnAccesses = new Set();
+  const proxy = new Proxy(target, {
+    get(target, property, _proxy) {
+      if (!Object.hasOwn(target, property)) {
+        nonOwnAccesses.add(property);
+      }
+
+      // Return normal lookup to ensure normal test execution.
+      return target[property];
+    },
+  });
+
+  pollutionState.set(proxy, nonOwnAccesses);
+  return proxy;
+}
+
+/**
+ * Check if non-own property access was detected on the given wrapped object.
+ *
+ * @param {any} wrapped A `wrap`ped value.
+ * @throws {Error} If non-own property access was detected.
+ */
+export function check(wrapped) {
+  if (!isProxyable(wrapped)) {
+    return;
+  }
+
+  assert.ok(pollutionState.has(wrapped), "target not found");
+  const nonOwnAccesses = pollutionState.get(wrapped);
+
+  // Remove the proxy from the state so re-use of it does not result in errors
+  // from one test to affect other tests. (Also just to reduce memory usage.)
+  pollutionState.delete(wrapped);
+
+  const actual = nonOwnAccesses.size;
+  const expected = 0;
+  const propertiesList = Array.from(nonOwnAccesses.values()).join(", ");
+
+  assert.equal(
+    actual,
+    expected,
+    `Non0own access to ${actual} property(s) detected: ${propertiesList}`,
+  );
+}

--- a/test/integration/constructor/_pollution.js
+++ b/test/integration/constructor/_pollution.js
@@ -93,6 +93,6 @@ export function check(wrapped) {
   assert.equal(
     actual,
     expected,
-    `Non0own access to ${actual} property(s) detected: ${propertiesList}`,
+    `Non-own access to ${actual} property(s) detected: ${propertiesList}`,
   );
 }

--- a/test/integration/constructor/constructor.test.js
+++ b/test/integration/constructor/constructor.test.js
@@ -3,7 +3,11 @@
  * @license MIT
  */
 
+import { testProp } from "@fast-check/ava";
 import test from "ava";
+
+import * as pollution from "./_pollution.js";
+import { arbitrary } from "../_.js";
 
 import { Shescape } from "shescape";
 
@@ -12,3 +16,16 @@ test("shell is unsupported", (t) => {
 
   t.throws(() => new Shescape({ shell }), { instanceOf: Error });
 });
+
+testProp(
+  "affected by prototype pollution",
+  [arbitrary.shescapeOptions().map(pollution.wrap)],
+  (t, options) => {
+    try {
+      new Shescape(options);
+    } catch (_) {}
+
+    pollution.check(options);
+    t.pass();
+  },
+);

--- a/test/integration/constructor/constructor.test.js
+++ b/test/integration/constructor/constructor.test.js
@@ -6,8 +6,7 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 
-import * as pollution from "./_pollution.js";
-import { arbitrary } from "../_.js";
+import { arbitrary, pollution } from "./_.js";
 
 import { Shescape } from "shescape";
 


### PR DESCRIPTION
## Summary

Add a test to check for non-own property access which could be manipulated by prototype pollution. Fix such accesses to check if it is an own property first.

Because this is standard Node.js behavior I consider this a hardening measure, not a security bugfix.