### PR TITLE
Further harden against polluted properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- Harden against polluted prototypes. ([#1280])
+- Harden against polluted prototypes. ([#1280], [#1285])
 
 ## [2.0.1] - 2023-10-28
 
@@ -319,6 +319,7 @@ Versioning].
 [#1142]: https://github.com/ericcornelissen/shescape/pull/1142
 [#1149]: https://github.com/ericcornelissen/shescape/pull/1149
 [#1280]: https://github.com/ericcornelissen/shescape/pull/1280
+[#1285]: https://github.com/ericcornelissen/shescape/pull/1285
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/executables.js
+++ b/src/executables.js
@@ -3,6 +3,8 @@
  * @license MPL-2.0
  */
 
+import { hasOwn } from "./reflection.js";
+
 /**
  * Build error messages for when executables cannot be found.
  *
@@ -37,7 +39,12 @@ export function resolveExecutable(
 ) {
   let resolved = executable;
   try {
-    resolved = which(resolved, { path: env.PATH || env.Path });
+    const path = hasOwn(env, "PATH")
+      ? env.PATH
+      : hasOwn(env, "Path")
+      ? env.Path
+      : undefined;
+    resolved = which(resolved, { path });
   } catch (_) {
     throw new Error(notFoundError(executable));
   }

--- a/src/executables.js
+++ b/src/executables.js
@@ -42,8 +42,8 @@ export function resolveExecutable(
     const path = hasOwn(env, "PATH")
       ? env.PATH
       : hasOwn(env, "Path")
-      ? env.Path
-      : undefined;
+        ? env.Path
+        : undefined;
     resolved = which(resolved, { path });
   } catch (_) {
     throw new Error(notFoundError(executable));

--- a/src/options.js
+++ b/src/options.js
@@ -4,7 +4,7 @@
  */
 
 import { resolveExecutable } from "./executables.js";
-import { isString } from "./reflection.js";
+import { hasOwn, isString } from "./reflection.js";
 
 /**
  * The identifier for 'no shell' or the absence of a shell.
@@ -22,20 +22,6 @@ export const noShell = Symbol();
  */
 function unsupportedError(shellName) {
   return `Shescape does not support the shell ${shellName}`;
-}
-
-/**
- * Check if the given object has the given property as an own property.
- *
- * This custom function is used over `Object.hasOwn` because that isn't
- * available in all supported Node.js versions.
- *
- * @param {object} object The object of interest.
- * @param {string} property The property of interest.
- * @returns {boolean} `true` if property is an own-property, `false` otherwise.
- */
-function hasOwn(object, property) {
-  return Object.prototype.hasOwnProperty.call(object, property);
 }
 
 /**

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -4,6 +4,7 @@
  * @license MPL-2.0
  */
 
+import { hasOwn } from "./reflection.js";
 import * as unix from "./unix.js";
 import * as win from "./win.js";
 
@@ -40,7 +41,8 @@ const win32 = "win32";
  * @returns {boolean} `true` if the system is Windows, `false` otherwise.
  */
 function isWindow({ env, platform }) {
-  return env.OSTYPE === cygwin || env.OSTYPE === msys || platform === win32;
+  const osType = hasOwn(env, "OSTYPE") ? env.OSTYPE : undefined;
+  return osType === cygwin || osType === msys || platform === win32;
 }
 
 /**

--- a/src/reflection.js
+++ b/src/reflection.js
@@ -29,6 +29,20 @@ const typeofFunction = "function";
 const typeofString = "string";
 
 /**
+ * Check if the given object has the given property as an own property.
+ *
+ * This custom function is used over `Object.hasOwn` because that isn't
+ * available in all supported Node.js versions.
+ *
+ * @param {object} object The object of interest.
+ * @param {string} property The property of interest.
+ * @returns {boolean} `true` if property is an own-property, `false` otherwise.
+ */
+export function hasOwn(object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+/**
  * Checks if a value can be converted into a string and converts it if possible.
  *
  * @param {any} value The value of interest.

--- a/src/win.js
+++ b/src/win.js
@@ -12,6 +12,7 @@ import * as cmd from "./win/cmd.js";
 import * as nosh from "./win/no-shell.js";
 import * as powershell from "./win/powershell.js";
 import { noShell } from "./options.js";
+import { hasOwn } from "./reflection.js";
 
 /**
  * The name of the Windows Command Prompt binary.
@@ -37,10 +38,10 @@ const binPowerShell = "powershell.exe";
  *
  * @param {object} args The arguments for this function.
  * @param {Object<string, string>} args.env The environment variables.
- * @param {string} [args.env.ComSpec] The %COMSPEC% value.
  * @returns {string} The default shell.
  */
-export function getDefaultShell({ env: { ComSpec } }) {
+export function getDefaultShell({ env }) {
+  const ComSpec = hasOwn(env, "ComSpec") ? env.ComSpec : undefined;
   if (ComSpec !== undefined) {
     return ComSpec;
   }

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -37,7 +37,7 @@ test.beforeEach((t) => {
 
 testProp(
   "env.PATH is defined",
-  [arbitrary.env(), fc.string()],
+  [arbitrary.env({ keys: ["PATH", "Path"] }), fc.string()],
   (t, env, envPath) => {
     t.context.deps.which.resetHistory();
 
@@ -58,7 +58,7 @@ testProp(
 
 testProp(
   "env.Path is defined (not env.PATH)",
-  [arbitrary.env(), fc.string()],
+  [arbitrary.env({ keys: ["PATH", "Path"] }), fc.string()],
   (t, env, envPath) => {
     t.context.deps.which.resetHistory();
 
@@ -99,7 +99,7 @@ testProp("env.PATH and env.Path are missing", [arbitrary.env()], (t, env) => {
 test("env.PATH is polluted", (t) => {
   fc.assert(
     fc.property(
-      arbitrary.env(),
+      arbitrary.env({ keys: ["PATH", "Path"] }),
       fc.constantFrom("PATH", "Path"),
       fc.string(),
       (env, pathName, prototypePath) => {

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -96,47 +96,33 @@ testProp("env.PATH and env.Path are missing", [arbitrary.env()], (t, env) => {
   );
 });
 
-testProp(
-  "env.PATH is polluted",
-  [arbitrary.env(), fc.string()],
-  (t, env, prototypePath) => {
-    t.context.deps.which.resetHistory();
+test("env.PATH is polluted", (t) => {
+  fc.assert(
+    fc.property(
+      arbitrary.env(),
+      fc.constantFrom("PATH", "Path"),
+      fc.string(),
+      (env, pathName, prototypePath) => {
+        fc.pre(env.PATH !== prototypePath && env.Path !== prototypePath);
 
-    env = Object.assign(Object.create({ PATH: prototypePath }), env);
+        t.context.deps.which.resetHistory();
 
-    const { executable } = t.context;
-    const args = { env, executable };
+        env = Object.assign(Object.create({ [pathName]: prototypePath }), env);
 
-    resolveExecutable(args, t.context.deps);
-    t.is(t.context.deps.which.callCount, 1);
-    t.false(
-      t.context.deps.which.calledWithExactly(sinon.match.any, {
-        path: prototypePath,
-      }),
-    );
-  },
-);
+        const { executable } = t.context;
+        const args = { env, executable };
 
-testProp(
-  "env.Path is polluted",
-  [arbitrary.env(), fc.string()],
-  (t, env, prototypePath) => {
-    t.context.deps.which.resetHistory();
-
-    env = Object.assign(Object.create({ Path: prototypePath }), env);
-
-    const { executable } = t.context;
-    const args = { env, executable };
-
-    resolveExecutable(args, t.context.deps);
-    t.is(t.context.deps.which.callCount, 1);
-    t.false(
-      t.context.deps.which.calledWithExactly(sinon.match.any, {
-        path: prototypePath,
-      }),
-    );
-  },
-);
+        resolveExecutable(args, t.context.deps);
+        t.is(t.context.deps.which.callCount, 1);
+        t.false(
+          t.context.deps.which.calledWithExactly(sinon.match.any, {
+            path: prototypePath,
+          }),
+        );
+      },
+    ),
+  );
+});
 
 test("the executable cannot be resolved", (t) => {
   const { env, executable } = t.context;

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -37,7 +37,7 @@ test.beforeEach((t) => {
 
 testProp(
   "env.PATH is defined",
-  [arbitrary.env(), fc.string({ minLength: 1 })],
+  [arbitrary.env(), fc.string()],
   (t, env, envPath) => {
     t.context.deps.which.resetHistory();
 
@@ -58,7 +58,7 @@ testProp(
 
 testProp(
   "env.Path is defined (not env.PATH)",
-  [arbitrary.env(), fc.string({ minLength: 1 })],
+  [arbitrary.env(), fc.string()],
   (t, env, envPath) => {
     t.context.deps.which.resetHistory();
 
@@ -78,7 +78,7 @@ testProp(
   },
 );
 
-testProp("env.PATH is missing", [arbitrary.env()], (t, env) => {
+testProp("env.PATH and env.Path are missing", [arbitrary.env()], (t, env) => {
   t.context.deps.which.resetHistory();
 
   delete env.PATH;
@@ -97,8 +97,8 @@ testProp("env.PATH is missing", [arbitrary.env()], (t, env) => {
 });
 
 testProp(
-  "env.PATH is missing and polluted",
-  [arbitrary.env(), fc.string({ minLength: 1 })],
+  "env.PATH is polluted",
+  [arbitrary.env(), fc.string()],
   (t, env, prototypePath) => {
     t.context.deps.which.resetHistory();
 
@@ -118,8 +118,8 @@ testProp(
 );
 
 testProp(
-  "env.Path is missing and polluted",
-  [arbitrary.env(), fc.string({ minLength: 1 })],
+  "env.Path is polluted",
+  [arbitrary.env(), fc.string()],
   (t, env, prototypePath) => {
     t.context.deps.which.resetHistory();
 

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -5,6 +5,7 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import * as fc from "fast-check";
 
 import { arbitrary, constants } from "./_.js";
 
@@ -12,14 +13,18 @@ import { getHelpersByPlatform } from "../../../src/platforms.js";
 import * as unix from "../../../src/unix.js";
 import * as win from "../../../src/win.js";
 
-for (const platform of [
+const unixPlatforms = [
   constants.osAix,
   constants.osDarwin,
   constants.osFreebsd,
   constants.osLinux,
   constants.osOpenbsd,
   constants.osSunos,
-]) {
+];
+const winPlatforms = [constants.osWin32];
+const winOsTypes = [constants.ostypeCygwin, constants.ostypeMsys];
+
+for (const platform of unixPlatforms) {
   testProp(`platform is Unix for ${platform}`, [arbitrary.env()], (t, env) => {
     delete env.OSTYPE;
 
@@ -32,7 +37,7 @@ for (const platform of [
   });
 }
 
-for (const platform of [constants.osWin32]) {
+for (const platform of winPlatforms) {
   testProp(
     `platform is Windows for ${platform}`,
     [arbitrary.env()],
@@ -49,7 +54,7 @@ for (const platform of [constants.osWin32]) {
   );
 }
 
-for (const osType of [constants.ostypeCygwin, constants.ostypeMsys]) {
+for (const osType of winOsTypes) {
   testProp(
     `platform is Windows for OS type ${osType}`,
     [arbitrary.env(), arbitrary.platform()],
@@ -65,3 +70,18 @@ for (const osType of [constants.ostypeCygwin, constants.ostypeMsys]) {
     },
   );
 }
+
+testProp(
+  "env.OSTYPE is polluted",
+  [arbitrary.env(), fc.constant(...unixPlatforms), fc.constant(...winOsTypes)],
+  (t, env, platform, prototypeOstype) => {
+    env = Object.assign(Object.create({ OSTYPE: prototypeOstype }), env);
+
+    const result = getHelpersByPlatform({
+      env,
+      platform,
+    });
+
+    t.deepEqual(result, unix);
+  },
+);

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -75,9 +75,9 @@ for (const osType of winOsTypes) {
 test("env.OSTYPE is polluted", (t) => {
   fc.assert(
     fc.property(
-      arbitrary.env(),
-      fc.constantFrom(...unixPlatforms),
+      arbitrary.env({ keys: ["OSTYPE"] }),
       fc.constantFrom(...winOsTypes),
+      fc.constantFrom(...unixPlatforms),
       (env, prototypeOstype, platform) => {
         fc.pre(![...winOsTypes].includes(env.OSTYPE));
 

--- a/test/unit/reflection/has-own.test.js
+++ b/test/unit/reflection/has-own.test.js
@@ -1,0 +1,27 @@
+/**
+ * @overview Contains unit tests for the `hasOwn` function.
+ * @license MIT
+ */
+
+import { testProp } from "@fast-check/ava";
+import * as fc from "fast-check";
+
+import { hasOwn } from "../../../src/reflection.js";
+
+testProp("not present", [fc.object(), fc.string()], (t, object, property) => {
+  const actual = hasOwn(object, property);
+  const expected = Object.hasOwn(object, property);
+  t.is(actual, expected);
+});
+
+testProp(
+  "present",
+  [fc.object(), fc.string(), fc.string()],
+  (t, object, property, value) => {
+    object[property] = value;
+
+    const actual = hasOwn(object, property);
+    const expected = Object.hasOwn(object, property);
+    t.is(actual, expected);
+  },
+);

--- a/test/unit/reflection/has-own.test.js
+++ b/test/unit/reflection/has-own.test.js
@@ -25,3 +25,15 @@ testProp(
     t.is(actual, expected);
   },
 );
+
+testProp(
+  "polluted",
+  [fc.object(), fc.string(), fc.string()],
+  (t, object, property, value) => {
+    object = Object.assign(Object.create({ [property]: value }), object);
+
+    const actual = hasOwn(object, property);
+    const expected = Object.hasOwn(object, property);
+    t.is(actual, expected);
+  },
+);

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -55,6 +55,17 @@ testProp(
   },
 );
 
+testProp(
+  "the default shell when %COMSPEC% is polluted",
+  [arbitrary.env(), fc.string()],
+  (t, env, prototypeComSpec) => {
+    env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+
+    const result = win.getDefaultShell({ env });
+    t.is(result, constants.binCmd);
+  },
+);
+
 test("escape function for no shell", (t) => {
   const actual = win.getEscapeFunction(noShell);
   const expected = nosh.getEscapeFunction();

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -57,14 +57,18 @@ testProp(
 
 test("the default shell when %COMSPEC% is polluted", (t) => {
   fc.assert(
-    fc.property(arbitrary.env(), fc.string(), (env, prototypeComSpec) => {
-      fc.pre(!Object.hasOwn(env, "ComSpec"));
+    fc.property(
+      arbitrary.env({ keys: ["ComSpec"] }),
+      fc.string(),
+      (env, prototypeComSpec) => {
+        fc.pre(env.ComSpec !== prototypeComSpec);
 
-      env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+        env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
 
-      const result = win.getDefaultShell({ env });
-      t.is(result, constants.binCmd);
-    }),
+        const result = win.getDefaultShell({ env });
+        t.not(result, prototypeComSpec);
+      },
+    ),
   );
 });
 

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -55,16 +55,18 @@ testProp(
   },
 );
 
-testProp(
-  "the default shell when %COMSPEC% is polluted",
-  [arbitrary.env(), fc.string()],
-  (t, env, prototypeComSpec) => {
-    env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+test("the default shell when %COMSPEC% is polluted", (t) => {
+  fc.assert(
+    fc.property(arbitrary.env(), fc.string(), (env, prototypeComSpec) => {
+      fc.pre(!Object.hasOwn(env, "ComSpec"));
 
-    const result = win.getDefaultShell({ env });
-    t.is(result, constants.binCmd);
-  },
-);
+      env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+
+      const result = win.getDefaultShell({ env });
+      t.is(result, constants.binCmd);
+    }),
+  );
+});
 
 test("escape function for no shell", (t) => {
   const actual = win.getEscapeFunction(noShell);


### PR DESCRIPTION
Relates to #1280

## Summary

Update the internals of the project to protect against the potential of polluted properties based on manual evaluation of the source code. Re-use the `hasOwn` function from `options.js` (moved to `reflection.js`) to achieve this.

- `executables.js`: Explicitly check that `PATH` (or `Path`) isn't being inherited. This is the most obvious place where this is necessary as the code already accounts for the potential of `PATH` being undefined.
- `platforms.js`: Safely get `OSTYPE` in case it isn't defined in order to avoid wrongly concluding the current system is a Windows system as a result of a polluted `OSTYPE` value.
- `win.js`: Safely get `ComSpec` in case it isn't defined (already taken into account as well) to avoid using a default shell defined by a polluted property.

As before, because this is standard Node.js behavior I consider this a hardening measure, not a security bugfix.