### PR TITLE
Update the What to Report section of the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,21 +37,25 @@ report the issue privately.
 [new github advisory]: https://github.com/ericcornelissen/shescape/security/advisories/new
 [security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28shescape%29
 
-### What to Report (Threat Model)
+### What to Report
 
 #### In Scope
 
+- Insecure suggestions or snippets in the documentation.
 - Insufficient escaping for any supported shell.
 - Logic bugs with a security implication (e.g. unexpected throw) that can be
   triggered through the public API.
 - Security misconfigurations in the continuous integration pipeline or software
   supply chain.
-- Insecure suggestions or snippets in the documentation.
 
 #### Out of Scope
 
-- Known vulnerabilities in third-party `dependencies` or `devDependencies`.
+> **Note**: These may still be reported but are not considered a security issue.
+
 - Bugs only affecting the `shescape/testing` module.
+- Insecure defaults or confusing API design.
+- Insufficient escaping for any unsupported shell.
+- Known vulnerabilities in third-party `dependencies` or `devDependencies`.
 
 ### What to Include in a Report
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,18 +39,24 @@ report the issue privately.
 
 ### What to Report
 
+Consider if the issue you found really is a security concern. Below you can find
+guidelines for what is and isn't considered a security issue. Any issue that
+does not fall into one of the listed categories should be reported based on your
+own judgement. If in doubt, report the issue privately.
+
+Any issue that is out of scope should still be reported, but can be reported
+publicly because it is not considered sensitive.
+
 #### In Scope
 
 - Insecure suggestions or snippets in the documentation.
 - Insufficient escaping for any supported shell.
-- Logic bugs with a security implication (e.g. unexpected throw) that can be
-  triggered through the public API.
+- Logic bugs with a security implication that can be triggered through the
+  public API.
 - Security misconfigurations in the continuous integration pipeline or software
   supply chain.
 
 #### Out of Scope
-
-> **Note**: These may still be reported but are not considered a security issue.
 
 - Bugs only affecting the `shescape/testing` module.
 - Insecure defaults or confusing API design.


### PR DESCRIPTION
Relates to #1254, #1261

## Summary

Update the what to report section of the Security Policy with:

- Removing the in my opinion currently unnecessary "threat model" string.
- Organizing things alphabetically.
- More items.
- Clarify what the scopes represent.