### PR TITLE
Adopt more explicit licensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to _Shescape_ will be documented in this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The _Shescape_ project welcomes contributions and corrections of all forms. This

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Shescape
 
 [![GitHub Actions][ci-image]][ci-url]
@@ -77,6 +79,13 @@ Read the [tips] for additional ways to protect against shell injection.
 The source code is licensed under the `MPL-2.0` license, see [LICENSE] for
 the full license text. The documentation text is licensed under [CC BY-SA 4.0];
 code snippets under the [MIT license].
+
+Supporting code, such a scripts and tests, is generally licensed under the `MIT`
+license. However, individual files may be licensed differently depending on the
+intend or origin.
+
+The license under which a given file is available can always be found in the
+file's banner comment.
 
 [ci-url]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml
 [ci-image]: https://github.com/ericcornelissen/shescape/actions/workflows/checks.yml/badge.svg

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 If you need to release a new version of _Shescape_, follow the guidelines found

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _Shescape_ project take security issues seriously. We

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Shescape API
 
 This document provides a description of the full Application Programming

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Shescape Recipes
 
 This document provides examples, called _recipes_, for how to use Shescape in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Testing with Shescape
 
 This document provides an overview of why and how to use Shescape's testing

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Tips
 
 This document provides tips to avoid shell injection beyond using a shell

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
 
 get_stash_count () {
   readonly count="$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)"

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
+
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT
+
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -1,3 +1,8 @@
+/**
+ * @overview Contains TypeScript type definitions for shescape/testing.
+ * @license MPL-2.0
+ */
+
 import type { Shescape as ShescapeType } from "shescape";
 
 /**


### PR DESCRIPTION
Relates to #789, #852, #1116

## Summary

Add more file-specific license details using the [SPDX license ID] standard. The primary goal is to cover files whose licensing was previously missing or ambiguous.

This follows the existing practice of defining explicitly the applicable license for all source code (including scripts and tests) as well as external facing documentation per file.

[SPDX license ID]: https://spdx.dev/learn/handling-license-info/