### PR TITLE
Update testing documentation w.r.t `Throwscape`

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,16 +19,12 @@ mocking ([for example with Jest][jest-module-mock]).
 // my-module.test.js
 
 import assert from "node:assert";
-import { Shescape as Stubscape, Throwscape } from "shescape/testing";
+import { Shescape as Stubscape } from "shescape/testing";
 import { functionUnderTest } from "./my-module.js";
 
 // Test good conditions
 const stubscape = new Stubscape();
 assert.ok(functionUnderTest(stubscape));
-
-// Test bad conditions
-const throwscape = new Throwscape();
-assert.ok(functionUnderTest(throwscape));
 ```
 
 ### Why Stubs

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,10 +33,10 @@ function functionUnderTest(Shescape) {
   return args;
 }
 
-// Test good conditions
+// Test good condition
 assert.ok(functionUnderTest(Stubscape));
 
-// Test bad conditions
+// Test bad condition
 assert.throws(() => functionUnderTest(Throwscape));
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,15 +16,28 @@ mocking ([for example with Jest][jest-module-mock]).
 > these stubs.
 
 ```javascript
-// my-module.test.js
-
 import assert from "node:assert";
-import { Shescape as Stubscape } from "shescape/testing";
-import { functionUnderTest } from "./my-module.js";
+import { Shescape as Stubscape, Throwscape } from "shescape/testing";
+
+// Test subject
+function functionUnderTest(Shescape) {
+  const options = {
+    /* ... */
+  };
+  const rawArgs = [
+    /*... */
+  ];
+
+  const shescape = new Shescape(options);
+  const args = shescape.escapeAll(rawArgs);
+  return args;
+}
 
 // Test good conditions
-const stubscape = new Stubscape();
-assert.ok(functionUnderTest(stubscape));
+assert.ok(functionUnderTest(Stubscape));
+
+// Test bad conditions
+assert.throws(() => functionUnderTest(Throwscape));
 ```
 
 ### Why Stubs


### PR DESCRIPTION
Relates to #1149

## Summary

Remove an example from the Testing module involving `Throwscape` because the way it's used is incorrect.