### PR TITLE
Re-export as `Stubscape` from shescape/testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ mocking ([for example with Jest][jest-module-mock]).
 
 ```javascript
 import assert from "node:assert";
-import { Shescape as Stubscape, Throwscape } from "shescape/testing";
+import { Stubscape, Throwscape } from "shescape/testing";
 
 // Test subject
 function functionUnderTest(Shescape) {

--- a/test/breakage/testing.test.js
+++ b/test/breakage/testing.test.js
@@ -8,7 +8,7 @@ import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";
 
-import { Shescape as Stubscape, Throwscape } from "shescape/testing";
+import { Stubscape, Throwscape } from "shescape/testing";
 import {
   Shescape as Previoustub,
   Throwscape as Previousthrow,

--- a/test/compat/testing.test.js
+++ b/test/compat/testing.test.js
@@ -9,7 +9,7 @@ import * as fc from "fast-check";
 
 import { arbitrary } from "./_.js";
 
-import { Shescape as Stubscape, Throwscape } from "../../testing.js";
+import { Stubscape, Throwscape } from "../../testing.js";
 
 testProp(
   "Stubscape#escape",

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -10,14 +10,10 @@ import * as fc from "fast-check";
 
 import { arbitrary } from "../_.js";
 
-import {
-  injectionStrings,
-  Shescape as Stubscape,
-  Throwscape,
-} from "shescape/testing";
+import { injectionStrings, Stubscape, Throwscape } from "shescape/testing";
 import {
   injectionStrings as injectionStringsCjs,
-  Shescape as StubscapeCjs,
+  Stubscape as StubscapeCjs,
   Throwscape as ThrowscapeCjs,
 } from "../../../testing.cjs";
 

--- a/test/integration/testing/functional.test.js
+++ b/test/integration/testing/functional.test.js
@@ -11,11 +11,7 @@ import * as fc from "fast-check";
 import { arbitrary } from "../_.js";
 
 import { Shescape } from "shescape";
-import {
-  injectionStrings,
-  Shescape as Stubscape,
-  Throwscape,
-} from "shescape/testing";
+import { injectionStrings, Stubscape, Throwscape } from "shescape/testing";
 
 test("injection strings", (t) => {
   t.true(Array.isArray(injectionStrings));

--- a/test/unit/testing/stubscape.test.js
+++ b/test/unit/testing/stubscape.test.js
@@ -9,7 +9,7 @@ import * as fc from "fast-check";
 
 import { arbitrary, constants } from "./_.js";
 
-import { Shescape as Stubscape } from "../../../testing.js";
+import { Stubscape } from "../../../testing.js";
 
 testProp(
   "escape valid arguments",

--- a/testing.js
+++ b/testing.js
@@ -63,6 +63,19 @@ export class Shescape {
 }
 
 /**
+ * An optimistic test stub of Shescape that has the same input-output profile as
+ * the real Shescape implementation.
+ *
+ * In particular:
+ * - The constructor never fails.
+ * - Returns a string for all stringable inputs.
+ * - Errors on non-stringable inputs.
+ * - Errors on non-array inputs where arrays are expected.
+ * - Errors when trying to quote when `shell: false`.
+ */
+export const Stubscape = Shescape;
+
+/**
  * A test stub of Shescape that can't be instantiated. This can be used to
  * simulate a failure to instantiate Shescape in your code.
  */


### PR DESCRIPTION
Relates to #710

## Summary

Simplify importing the default stub implementation of Shescape as `Stubscape` by re-exporting it under that name.

As of writing, I'm not sure whether exporting this stub as `Shescape` or `Stubscape` is better. I think both have pros and cons. In any case, the export named `Shescape` can't just be removed because that would be a breaking change.