### PR TITLE
Verify reproducibility of published package

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -201,14 +201,20 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Transpile to CommonJS
-        run: npm run transpile
+      - name: Simulate publish
+        run: |
+          npm publish --dry-run
+          npm pack
       - name: Compute checksum
-        run: shasum index.cjs testing.cjs | tee checksums.txt
+        run: shasum -- *.tgz | tee checksums.txt
       - name: Reset to a clean state
-        run: npm run clean
-      - name: Transpile to CommonJS again
-        run: npm run transpile
+        run: |
+          npm run clean
+          rm -f -- *.tgz
+      - name: Simulate publish again
+        run: |
+          npm publish --dry-run
+          npm pack
       - name: Verify checksum
         run: shasum --check checksums.txt --strict
   test-breakage:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -203,14 +203,17 @@ jobs:
         run: npm clean-install
       - name: Simulate publish
         run: |
+          # Dry run publish to trigger any hooks
           npm publish --dry-run
+          
+          # Pack to produce the archive that would be published
           npm pack
       - name: Compute checksum
         run: shasum -- *.tgz | tee checksums.txt
       - name: Reset to a clean state
         run: |
           npm run clean
-          rm -f -- *.tgz
+          rm -- *.tgz
       - name: Simulate publish again
         run: |
           npm publish --dry-run

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           # Dry run publish to trigger any hooks
           npm publish --dry-run
-          
+
           # Pack to produce the archive that would be published
           npm pack
       - name: Compute checksum

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules/
 .npm/
 .node_repl_history
 npm-debug.log*
+shescape-*.tgz


### PR DESCRIPTION
Relates to #1279

## Summary

Update the continuous reproducibility check to not just verify that the transpilation(/build) is reproducible, but the published package bits that go to the npm registry.