### PR TITLE
Bump `@fast-check/ava` from 1.2.0 to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "0.13.3",
         "@ericcornelissen/eslint-plugin-top": "2.1.0",
-        "@fast-check/ava": "1.2.0",
+        "@fast-check/ava": "1.2.1",
         "@gitlab-org/jsfuzz": "1.2.2",
         "@stryker-mutator/core": "8.0.0",
         "@stryker-mutator/tap-runner": "8.0.0",
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@fast-check/ava": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@fast-check/ava/-/ava-1.2.0.tgz",
-      "integrity": "sha512-kkppuG5ssQE6qV/8074YcXT1MtC2zzbMp8yFjQO+xB3OQ4CvZsHuRMJS9jzdZRvdgNzB+Y5GvnnLkC+vyiR3nQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@fast-check/ava/-/ava-1.2.1.tgz",
+      "integrity": "sha512-d7O8CjYV2e+JFnN67Yofw+tt16fJI7kuX1K7OZCNxqQL5XNrkipWBmAmW9sPxYVjaItPBPvTPp7nORsO9KuBgg==",
       "dev": true,
       "funding": [
         {
@@ -1040,7 +1040,7 @@
         "fast-check": "^3.0.0"
       },
       "peerDependencies": {
-        "ava": ">=4.0.0"
+        "ava": "^4 || ^5 || ^6"
       }
     },
     "node_modules/@gitlab-org/jsfuzz": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "0.13.3",
     "@ericcornelissen/eslint-plugin-top": "2.1.0",
-    "@fast-check/ava": "1.2.0",
+    "@fast-check/ava": "1.2.1",
     "@gitlab-org/jsfuzz": "1.2.2",
     "@stryker-mutator/core": "8.0.0",
     "@stryker-mutator/tap-runner": "8.0.0",

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -96,33 +96,32 @@ testProp("env.PATH and env.Path are missing", [arbitrary.env()], (t, env) => {
   );
 });
 
-test("env.PATH is polluted", (t) => {
-  fc.assert(
-    fc.property(
-      arbitrary.env({ keys: ["PATH", "Path"] }),
-      fc.constantFrom("PATH", "Path"),
-      fc.string(),
-      (env, pathName, prototypePath) => {
-        fc.pre(env.PATH !== prototypePath && env.Path !== prototypePath);
+testProp(
+  "env.PATH is polluted",
+  [
+    arbitrary.env({ keys: ["PATH", "Path"] }),
+    fc.constantFrom("PATH", "Path"),
+    fc.string(),
+  ],
+  (t, env, pathName, prototypePath) => {
+    fc.pre(env.PATH !== prototypePath && env.Path !== prototypePath);
 
-        t.context.deps.which.resetHistory();
+    t.context.deps.which.resetHistory();
 
-        env = Object.assign(Object.create({ [pathName]: prototypePath }), env);
+    env = Object.assign(Object.create({ [pathName]: prototypePath }), env);
 
-        const { executable } = t.context;
-        const args = { env, executable };
+    const { executable } = t.context;
+    const args = { env, executable };
 
-        resolveExecutable(args, t.context.deps);
-        t.is(t.context.deps.which.callCount, 1);
-        t.false(
-          t.context.deps.which.calledWithExactly(sinon.match.any, {
-            path: prototypePath,
-          }),
-        );
-      },
-    ),
-  );
-});
+    resolveExecutable(args, t.context.deps);
+    t.is(t.context.deps.which.callCount, 1);
+    t.false(
+      t.context.deps.which.calledWithExactly(sinon.match.any, {
+        path: prototypePath,
+      }),
+    );
+  },
+);
 
 test("the executable cannot be resolved", (t) => {
   const { env, executable } = t.context;

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -5,7 +5,6 @@
  */
 
 import { testProp } from "@fast-check/ava";
-import test from "ava";
 import * as fc from "fast-check";
 
 import { arbitrary, constants } from "./_.js";
@@ -72,24 +71,23 @@ for (const osType of winOsTypes) {
   );
 }
 
-test("env.OSTYPE is polluted", (t) => {
-  fc.assert(
-    fc.property(
-      arbitrary.env({ keys: ["OSTYPE"] }),
-      fc.constantFrom(...winOsTypes),
-      fc.constantFrom(...unixPlatforms),
-      (env, prototypeOstype, platform) => {
-        fc.pre(![...winOsTypes].includes(env.OSTYPE));
+testProp(
+  "env.OSTYPE is polluted",
+  [
+    arbitrary.env({ keys: ["OSTYPE"] }),
+    fc.constantFrom(...winOsTypes),
+    fc.constantFrom(...unixPlatforms),
+  ],
+  (t, env, prototypeOstype, platform) => {
+    fc.pre(![...winOsTypes].includes(env.OSTYPE));
 
-        env = Object.assign(Object.create({ OSTYPE: prototypeOstype }), env);
+    env = Object.assign(Object.create({ OSTYPE: prototypeOstype }), env);
 
-        const result = getHelpersByPlatform({
-          env,
-          platform,
-        });
+    const result = getHelpersByPlatform({
+      env,
+      platform,
+    });
 
-        t.deepEqual(result, unix);
-      },
-    ),
-  );
-});
+    t.deepEqual(result, unix);
+  },
+);

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -55,22 +55,18 @@ testProp(
   },
 );
 
-test("the default shell when %COMSPEC% is polluted", (t) => {
-  fc.assert(
-    fc.property(
-      arbitrary.env({ keys: ["ComSpec"] }),
-      fc.string(),
-      (env, prototypeComSpec) => {
-        fc.pre(env.ComSpec !== prototypeComSpec);
+testProp(
+  "the default shell when %COMSPEC% is polluted",
+  [arbitrary.env({ keys: ["ComSpec"] }), fc.string()],
+  (t, env, prototypeComSpec) => {
+    fc.pre(env.ComSpec !== prototypeComSpec);
 
-        env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+    env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
 
-        const result = win.getDefaultShell({ env });
-        t.not(result, prototypeComSpec);
-      },
-    ),
-  );
-});
+    const result = win.getDefaultShell({ env });
+    t.not(result, prototypeComSpec);
+  },
+);
 
 test("escape function for no shell", (t) => {
   const actual = win.getEscapeFunction(noShell);


### PR DESCRIPTION
Relates to #1334

## Summary

Bump `@fast-check/ava` from 1.2.0 to 1.2.1 and partially revert 2a85be8c76ba97715ca2b43952f7070c6027f454 to again use `testProp` for property tests using `fc.pre`.