### PR TITLE
Track breakage and compatibility coverage with Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,13 +16,11 @@ coverage:
           - integration-Ubuntu
           - integration-Windows
       relaxed:
-        default: false
         target: 10%
         flags:
           - breakage
           - compatibility
       strict:
-        default: false
         target: 100%
         flags:
           - unit

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,26 +6,26 @@ coverage:
   range: 80...100
   status:
     project:
-      default: false
-      target: 95%
-      flags:
-        - e2e-MacOS
-        - e2e-Ubuntu
-        - e2e-Windows
-        - integration-MacOS
-        - integration-Ubuntu
-        - integration-Windows
-    strict:
-      default: false
-      target: 100%
-      flags:
-        - unit
-    relaxed:
-      default: false
-      target: 10%
-      flags:
-        - breakage
-        - compatibility
+      default:
+        target: 95%
+        flags:
+          - e2e-MacOS
+          - e2e-Ubuntu
+          - e2e-Windows
+          - integration-MacOS
+          - integration-Ubuntu
+          - integration-Windows
+      relaxed:
+        default: false
+        target: 10%
+        flags:
+          - breakage
+          - compatibility
+      strict:
+        default: false
+        target: 100%
+        flags:
+          - unit
 
 comment:
   layout: diff, flags, files

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,9 +7,25 @@ coverage:
   status:
     project:
       default: false
-      source:
-        paths:
-          - src/
+      target: 95%
+      flags:
+        - e2e-MacOS
+        - e2e-Ubuntu
+        - e2e-Windows
+        - integration-MacOS
+        - integration-Ubuntu
+        - integration-Windows
+    strict:
+      default: false
+      target: 100%
+      flags:
+        - unit
+    relaxed:
+      default: false
+      target: 10%
+      flags:
+        - breakage
+        - compatibility
 
 comment:
   layout: diff, flags, files

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,6 +19,18 @@ comment:
   require_head: yes
 
 flags:
+  breakage:
+    carryforward: true
+    paths:
+      - src/
+      - index.js
+      - testing.js
+  compatibility:
+    carryforward: true
+    paths:
+      - src/
+      - index.js
+      - testing.js
   e2e-MacOS:
     carryforward: true
     paths:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -255,7 +255,7 @@ jobs:
         run: npm run coverage:breakage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           file: ./_reports/coverage/breakage/lcov.info
           flags: breakage
@@ -367,7 +367,7 @@ jobs:
         run: npm run coverage:e2e
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           file: ./_reports/coverage/e2e/lcov.info
           flags: e2e-${{ matrix.name }}
@@ -425,7 +425,7 @@ jobs:
         run: npm run coverage:integration
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           file: ./_reports/coverage/integration/lcov.info
           flags: integration-${{ matrix.name }}
@@ -560,7 +560,7 @@ jobs:
         run: npm run coverage:unit
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           file: ./_reports/coverage/unit/lcov.info
           flags: unit

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -251,6 +251,12 @@ jobs:
         run: npm clean-install
       - name: Run breakage tests
         run: npm run coverage:breakage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        if: ${{ always() }}
+        with:
+          file: ./_reports/coverage/breakage/lcov.info
+          flags: breakage
   test-compatibility:
     name: Compatibility
     runs-on: ubuntu-22.04
@@ -298,6 +304,12 @@ jobs:
           name: index-common-js
       - name: Run compatibility tests
         run: npm run coverage:compat --ignore-scripts
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        if: ${{ matrix.node-version == '20.0.0' }}
+        with:
+          file: ./_reports/coverage/compat/lcov.info
+          flags: compatibility
   test-e2e:
     name: End-to-end (${{ matrix.name }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -235,11 +235,13 @@ jobs:
             actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
+            codecov.io:443
             github.com:443
             gitlab.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            uploader.codecov.io:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Install Node.js
@@ -282,11 +284,13 @@ jobs:
             actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
+            codecov.io:443
             github.com:443
             gitlab.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            uploader.codecov.io:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Install Node.js

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -241,6 +241,7 @@ jobs:
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            storage.googleapis.com:443
             uploader.codecov.io:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -290,6 +291,7 @@ jobs:
             nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            storage.googleapis.com:443
             uploader.codecov.io:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0


### PR DESCRIPTION
Relates to #1130, #1343

## Summary

Expand the usage of [Codecov](https://app.codecov.io/gh/ericcornelissen/shescape) to include tracking the breakage test coverage and compatibility test coverage over time.