### PR TITLE
Allow unsupported shell error in compatibility tests

### DIFF
--- a/test/compat/index.test.js
+++ b/test/compat/index.test.js
@@ -21,7 +21,10 @@ export function testShescapeEscape() {
         try {
           shescape = new Shescape(options);
         } catch (error) {
-          const known = ["No executable could be found for "];
+          const known = [
+            "No executable could be found for ",
+            "Shescape does not support the shell ",
+          ];
 
           if (!known.some((knownError) => error.message.includes(knownError))) {
             throw new Error(`Unexpected error:\n${error}`);
@@ -56,7 +59,10 @@ export function testShescapeEscapeAll() {
         try {
           shescape = new Shescape(options);
         } catch (error) {
-          const known = ["No executable could be found for "];
+          const known = [
+            "No executable could be found for ",
+            "Shescape does not support the shell ",
+          ];
 
           if (!known.some((knownError) => error.message.includes(knownError))) {
             throw new Error(`Unexpected error:\n${error}`);
@@ -91,7 +97,10 @@ export function testShescapeQuote() {
         try {
           shescape = new Shescape(options);
         } catch (error) {
-          const known = ["No executable could be found for "];
+          const known = [
+            "No executable could be found for ",
+            "Shescape does not support the shell ",
+          ];
 
           if (!known.some((knownError) => error.message.includes(knownError))) {
             throw new Error(`Unexpected error:\n${error}`);
@@ -127,7 +136,10 @@ export function testShescapeQuoteAll() {
         try {
           shescape = new Shescape(options);
         } catch (error) {
-          const known = ["No executable could be found for "];
+          const known = [
+            "No executable could be found for ",
+            "Shescape does not support the shell ",
+          ];
 
           if (!known.some((knownError) => error.message.includes(knownError))) {
             throw new Error(`Unexpected error:\n${error}`);


### PR DESCRIPTION
Relates to #1203

## Summary

Fix the compatibility tests in some environments by allowing [the unsupported shell error](https://github.com/ericcornelissen/shescape/blob/e861d4256fc439efdd8bc044d179cb81cc563c3b/src/options.js#L24) in those tests. This error should be allowed because it does not indicate a compatibility problem.