### PR TITLE
Use concurrency groups to reduce CI load of fuzzing

### DIFF
--- a/.github/workflows/fuzz-bash.yml
+++ b/.github/workflows/fuzz-bash.yml
@@ -20,6 +20,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
+
 jobs:
   fuzz:
     name: Fuzz

--- a/.github/workflows/fuzz-cmd.yml
+++ b/.github/workflows/fuzz-cmd.yml
@@ -15,10 +15,14 @@ on:
     branches:
       - main
   schedule:
-    - cron: "5 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz:

--- a/.github/workflows/fuzz-csh.yml
+++ b/.github/workflows/fuzz-csh.yml
@@ -15,10 +15,14 @@ on:
     branches:
       - main
   schedule:
-    - cron: "10 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz:

--- a/.github/workflows/fuzz-dash.yml
+++ b/.github/workflows/fuzz-dash.yml
@@ -15,10 +15,14 @@ on:
     branches:
       - main
   schedule:
-    - cron: "15 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz:

--- a/.github/workflows/fuzz-no-shell.yml
+++ b/.github/workflows/fuzz-no-shell.yml
@@ -17,15 +17,22 @@ on:
     branches:
       - main
   schedule:
-    - cron: "25 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz-unix:
     name: Fuzz Unix
     uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
+    concurrency:
+      group: fuzz-no-shell
+      cancel-in-progress: false
     with:
       duration: 600 # seconds == 10 minutes
       os: ubuntu-22.04
@@ -34,6 +41,9 @@ jobs:
   fuzz-windows:
     name: Fuzz Windows
     uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
+    concurrency:
+      group: fuzz-no-shell
+      cancel-in-progress: false
     with:
       duration: 600 # seconds == 10 minutes
       os: windows-2022

--- a/.github/workflows/fuzz-powershell.yml
+++ b/.github/workflows/fuzz-powershell.yml
@@ -15,10 +15,14 @@ on:
     branches:
       - main
   schedule:
-    - cron: "20 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz:

--- a/.github/workflows/fuzz-zsh.yml
+++ b/.github/workflows/fuzz-zsh.yml
@@ -15,10 +15,14 @@ on:
     branches:
       - main
   schedule:
-    - cron: "30 2 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
+
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
 
 jobs:
   fuzz:


### PR DESCRIPTION
Relates to #1043

## Summary

Use a workflow concurrency group to limit fuzzing to one target at the time. Additionally, use a job concurrency group for no-shell to only run one of the no-shell fuzz jobs at the time.