### PR TITLE
Allow unsupported shell error in stateless.js compatibility tests

### DIFF
--- a/test/compat/stateless.test.js
+++ b/test/compat/stateless.test.js
@@ -21,6 +21,7 @@ export function testShescapeEscape() {
         } catch (error) {
           const known = [
             "No executable could be found for ",
+            "Shescape does not support the shell ",
             "Cannot read property 'escape' of undefined",
             "Cannot read properties of undefined (reading 'escape')",
           ];
@@ -45,6 +46,7 @@ export function testShescapeEscapeAll() {
         } catch (error) {
           const known = [
             "No executable could be found for ",
+            "Shescape does not support the shell ",
             "Cannot read property 'escapeAll' of undefined",
             "Cannot read properties of undefined (reading 'escapeAll')",
           ];
@@ -69,6 +71,7 @@ export function testShescapeQuote() {
         } catch (error) {
           const known = [
             "No executable could be found for ",
+            "Shescape does not support the shell ",
             "Cannot read property 'quote' of undefined",
             "Cannot read properties of undefined (reading 'quote')",
             "Quoting is not supported when no shell is used",
@@ -94,6 +97,7 @@ export function testShescapeQuoteAll() {
         } catch (error) {
           const known = [
             "No executable could be found for ",
+            "Shescape does not support the shell ",
             "Cannot read property 'quoteAll' of undefined",
             "Cannot read properties of undefined (reading 'quoteAll')",
             "Quoting is not supported when no shell is used",


### PR DESCRIPTION
Relates to #1130, #1351

## Summary

Fix the compatibility tests for `stateless.js` in some environments by allowing [the unsupported shell error](https://github.com/ericcornelissen/shescape/blob/e861d4256fc439efdd8bc044d179cb81cc563c3b/src/options.js#L24) in those tests. This error should be allowed because it does not indicate a compatibility problem.