### PR TITLE
Remove attribution requirement from scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ the full license text. The documentation text is licensed under [CC BY-SA 4.0];
 code snippets under the [MIT license].
 
 Supporting code, such a scripts and tests, is generally licensed under the `MIT`
-license. However, individual files may be licensed differently depending on the
-intend or origin.
+or `MIT-0` license. Individual files may be licensed differently depending on
+the intend or origin.
 
 The license under which a given file is available can always be found in the
 file's banner comment.

--- a/config/eslint.yml
+++ b/config/eslint.yml
@@ -122,6 +122,7 @@ rules:
     - error
     - allowedLicenses:
         - MIT
+        - MIT-0
         - MPL-2.0
       numericOnlyVariation: false
   jsdoc/empty-tags:

--- a/config/eslint.yml
+++ b/config/eslint.yml
@@ -118,13 +118,6 @@ rules:
     - exemptTagContexts: []
       noDefaults: false
       unifyParentAndChildTypeChecks: false
-  jsdoc/check-values:
-    - error
-    - allowedLicenses:
-        - MIT
-        - MIT-0
-        - MPL-2.0
-      numericOnlyVariation: false
   jsdoc/empty-tags:
     - error
     - tags:
@@ -540,11 +533,29 @@ settings:
       throws: throws
       yields: yields
 overrides:
+  # Source code
+  - files:
+      - src/**/*.js
+      - index.js
+      - stateless.js
+      - testing.js
+    rules:
+      jsdoc/check-values:
+        - error
+        - allowedLicenses:
+            - MPL-2.0
+      jsdoc/require-jsdoc: off
+
   # Tests
   - files:
       - test/**/*.test.cjs
       - test/**/*.test.js
     rules:
+      jsdoc/check-values:
+        - error
+        - allowedLicenses:
+            - MIT
+            - MPL-2.0
       jsdoc/require-jsdoc: off
 
   # Scripts
@@ -552,6 +563,10 @@ overrides:
       - .github/**/*.js
       - script/**/*.js
     rules:
+      jsdoc/check-values:
+        - error
+        - allowedLicenses:
+            - MIT-0
       jsdoc/require-jsdoc: off
 
   # JavaScript configuration files

--- a/config/eslint.yml
+++ b/config/eslint.yml
@@ -544,7 +544,6 @@ overrides:
         - error
         - allowedLicenses:
             - MPL-2.0
-      jsdoc/require-jsdoc: off
 
   # Tests
   - files:

--- a/script/_.js
+++ b/script/_.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provides script utilities.
- * @license MIT
+ * @license MIT-0
  */
 
 import * as fuzz from "../test/fuzz/_common.js";

--- a/script/_common.js
+++ b/script/_common.js
@@ -1,6 +1,6 @@
 /**
  * @overview Provide common utilities for scripts.
- * @license MIT
+ * @license MIT-0
  */
 
 import cp from "node:child_process";

--- a/script/check-runtime-deps.js
+++ b/script/check-runtime-deps.js
@@ -1,7 +1,7 @@
 /**
  * @overview Check if the version of runtime dependencies being depended upon
  * match the minimum version of the supported versions.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/clean.js
+++ b/script/clean.js
@@ -1,7 +1,7 @@
 /**
  * @overview Reset the repository to a clean state, removing any generated
  * files and folders.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/create-d-cts.js
+++ b/script/create-d-cts.js
@@ -1,6 +1,6 @@
 /**
  * @overview Create the `.d.cts` files for the published package.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/fuzz.js
+++ b/script/fuzz.js
@@ -1,6 +1,6 @@
 /**
  * @overview Start fuzzing using a specific fuzz target.
- * @license MIT
+ * @license MIT-0
  */
 
 import "dotenv/config";

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT-0
 
 get_stash_count () {
   readonly count="$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)"

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT-0
 
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT-0
 
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"

--- a/script/release/bump-changelog.js
+++ b/script/release/bump-changelog.js
@@ -1,7 +1,7 @@
 /**
  * @overview Sets the current version in the manifest as the latest release in
  * the CHANGELOG.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/release/bump-jsdoc.js
+++ b/script/release/bump-jsdoc.js
@@ -1,7 +1,7 @@
 /**
  * @overview Sets the current version in the manifest as the version in the
  * JSDoc of `index.js`.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/release/get-release-notes.js
+++ b/script/release/get-release-notes.js
@@ -1,7 +1,7 @@
 /**
  * @overview Outputs the release notes for the version currently specified in
  * the manifest.
- * @license MIT
+ * @license MIT-0
  */
 
 import fs from "node:fs";

--- a/script/run-platform-coverage.js
+++ b/script/run-platform-coverage.js
@@ -1,6 +1,6 @@
 /**
  * @overview Run coverage commands for the current platform.
- * @license MIT
+ * @license MIT-0
  */
 
 import process from "node:process";


### PR DESCRIPTION
Relates to #789, #1298

## Summary

Relicense scripts to remove the attribution requirement to make them easier to re-use.