### PR TITLE
Redo alerts (i.e. notes and warnings) in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,10 @@ When you open a Pull Request that implements an issue make sure to link to that
 issue in the Pull Request description and explain how you implemented the issue
 as clearly as possible.
 
-> **Note** If you, for whatever reason, can no longer continue your contribution
-> please share this in the issue or your Pull Request. This gives others the
-> opportunity to work on it. If we don't hear from you for an extended period of
-> time we may decide to allow others to work on the issue you were assigned to.
+**NOTE:** If you, for whatever reason, can no longer continue your contribution
+please share this in the issue or your Pull Request. This gives others the
+opportunity to work on it. If we don't hear from you for an extended period of
+time we may decide to allow others to work on the issue you were assigned to.
 
 ### Prerequisites
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,9 +101,9 @@ version (using `v2.7.2` as an example):
 1. Merge the Pull Request if the changes look OK and all continuous integration
    checks are passing.
 
-   > **Note** At this point, the continuous delivery automation may pick up and
-   > complete the release process. If not, or only partially, continue following
-   > the remaining steps.
+   **NOTE:** At this point, the continuous delivery automation may pick up and
+   complete the release process. If not, or only partially, continue following
+   the remaining steps.
 
 1. Immediately after the Pull Request is merged, sync the `main` branch:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,8 +83,8 @@ Try to include as many of the following items as possible in a security report:
 
 ## Advisories
 
-> **Note**: Advisories will be created only for vulnerabilities present in
-> released versions of the project.
+**NOTE:** Advisories will be created only for vulnerabilities present in
+released versions of the project.
 
 | ID               | Date       | Affected versions | Patched versions |
 | :--------------- | :--------- | :---------------- | :--------------- |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -156,9 +156,9 @@ prevent argument splitting. This comes with some caveats:
   splitting is a concern, use `Shescape#quote` instead.
 - On Windows, PowerShell will strip whitespace at the beginning of arguments.
 
-> **Warning**: If possible, it is advised to rewrite your code so that you can
-> use `Shescape#quote` as shown above. Or use a different function from the
-> `child_process` API, as shown further down below.
+**WARNING:** If possible, it is advised to rewrite your code so that you can
+use `Shescape#quote` as shown above. Or use a different function from the
+`child_process` API, as shown further down below.
 
 ```javascript
 import { exec } from "node:child_process";
@@ -300,9 +300,9 @@ truthy value, use `Shescape#quoteAll` to escape all `args`. If `options.shell`
 is set to a falsy value (or omitted), use `Shescape#escapeAll` to escape all
 `args`.
 
-> **Warning**: Due to a bug in Node.js (<18.7.0), using `execFileSync` with a
-> shell may result in `args` not being passed properly to the `command`,
-> depending on the shell being used. See [nodejs/node#43333].
+**WARNING:** Due to a bug in Node.js (<18.7.0), using `execFileSync` with a
+shell may result in `args` not being passed properly to the `command`, depending
+on the shell being used. See [nodejs/node#43333].
 
 ```javascript
 import { execFileSync } from "node:child_process";

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,8 +14,8 @@ Shescape [test stub]s are provided as named imports at `"shescape/testing"`. Use
 them in your tests through [dependency injection] (example below) or module
 mocking ([for example with Jest][jest-module-mock]).
 
-> **Warning**: If the code under test invokes a command you should **not** use
-> these stubs.
+**WARNING:** If the code under test invokes a command you should not use these
+stubs.
 
 ```javascript
 import assert from "node:assert";

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -95,7 +95,7 @@ try {
 Some CLI program support the special option `--`. If supported, arguments after
 this option will not be interpreted as options/flags.
 
-> **Note**: Always verify that the program you're invoking supports `--`.
+**NOTE:** Always verify that the program you're invoking supports `--`.
 
 ```javascript
 import { exec } from "node:child_process";


### PR DESCRIPTION
Closes #1340

## Summary

Update the "alerts" present in the MarkDown documentation to move adopt a style that works independently of where it is rendered.

The previous format was an old variant of the GitHub flavored markdown syntax that created properly rendered alerts on GitHub. This syntax has changed since, however the new one is
1. Not as clear outside the context of GitHub, and
2. Not implemented correctly (it doesn't render correctly in all scenarios, e.g. it wouldn't render properly for the use case in the Release Guidelines).

Given those considerations, this adopts a semantically correct (no block quotes) and standard-markdown way to have alerts (i.e. text blocks that stand out from the rest of the text in some way).