### PR TITLE
Disable `npm` lifecycle scripts by default

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -203,10 +203,7 @@ jobs:
         run: npm clean-install
       - name: Simulate publish
         run: |
-          # Dry run publish to trigger any hooks
-          npm publish --dry-run
-
-          # Pack to produce the archive that would be published
+          npm run transpile
           npm pack
       - name: Compute checksum
         run: shasum -- *.tgz | tee checksums.txt
@@ -216,7 +213,7 @@ jobs:
           rm -- *.tgz
       - name: Simulate publish again
         run: |
-          npm publish --dry-run
+          npm run transpile
           npm pack
       - name: Verify checksum
         run: shasum --check checksums.txt --strict
@@ -302,7 +299,7 @@ jobs:
       - name: Install compatible npm version
         run: npm install --global npm@8.1.2
       - name: Install dependencies
-        run: npm clean-install --ignore-scripts
+        run: npm clean-install
       - name: Run compatibility tests
         run: npm run coverage:compat
       - name: Upload coverage to Codecov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,4 +166,6 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance
+        run: |
+          npm run transpile
+          npm publish --provenance

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 audit=false
+ignore-scripts=true
 lockfile-version=3
 save-exact=true
 @gitlab-org:registry=https://gitlab.com/api/v4/packages/npm/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,11 +115,9 @@ If you decide to make a contribution, please do use the following workflow:
 ### Development Details
 
 Before you start making changes you should run `npm install`. This ensures your
-local development environment is setup and ready to go.
-
-We use [husky] to automatically install git hooks. Please enable it when
-contributing to this project. If you have npm installation scripts disabled, run
-`npm run prepare` after installing dependencies.
+local development environment is setup and ready to go. Run `npm run setup`
+afterwards if you want to enable git hooks that automatically validate your
+changes.
 
 When making contributions, make sure your changes are [tested](#testing),
 [documented](#documentation), [well-formatted](#formatting-and-linting), and
@@ -326,11 +324,24 @@ The Node.js compatibility tests aim to test that the library is backwards
 compatible with older versions of Node.js. All compatibility test suites go into
 the `test/compat/` folder.
 
-To run compatibility tests run `npm run test:compat`. However, this does not
-fully cover compatibility testing as it will only run the suite on the Node.js
-version you're currently using. Using [nve], `npm run test:compat-all` runs the
-compatibility tests on all applicable Node.js versions. The project's continuous
-integration also runs the compatibility tests on all supported Node.js versions.
+To run compatibility tests use:
+
+```shell
+npm run transpile
+npm run test:compat
+```
+
+However, this does not fully cover compatibility testing as it will only run the
+suite on the Node.js version you're currently using. Using [nve]:
+
+```shell
+npm run transpile
+npm run test:compat-all
+```
+
+runs the compatibility tests on all applicable Node.js versions. The project's
+continuous integration also runs the compatibility tests on all supported
+Node.js versions.
 
 The test suite uses a home grown test runner so that they can always be run on
 the oldest supported Node.js version. Test files in the test folder should
@@ -638,7 +649,6 @@ const john = "John Doe";
 [feature request]: https://github.com/ericcornelissen/shescape/issues/new?labels=enhancement
 [fuzz tests]: https://en.wikipedia.org/wiki/Fuzzing
 [git]: https://git-scm.com/
-[husky]: https://github.com/typicode/husky
 [jsdoc]: https://jsdoc.app/
 [jsfuzz]: https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz
 [licensee]: https://www.npmjs.com/package/licensee

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,24 +324,11 @@ The Node.js compatibility tests aim to test that the library is backwards
 compatible with older versions of Node.js. All compatibility test suites go into
 the `test/compat/` folder.
 
-To run compatibility tests use:
-
-```shell
-npm run transpile
-npm run test:compat
-```
-
-However, this does not fully cover compatibility testing as it will only run the
-suite on the Node.js version you're currently using. Using [nve]:
-
-```shell
-npm run transpile
-npm run test:compat-all
-```
-
-runs the compatibility tests on all applicable Node.js versions. The project's
-continuous integration also runs the compatibility tests on all supported
-Node.js versions.
+To run compatibility tests run `npm run test:compat`. However, this does not
+fully cover compatibility testing as it will only run the suite on the Node.js
+version you're currently using. Using [nve], `npm run test:compat-all` runs the
+compatibility tests on all applicable Node.js versions. The project's continuous
+integration also runs the compatibility tests on all supported Node.js versions.
 
 The test suite uses a home grown test runner so that they can always be run on
 the oldest supported Node.js version. Test files in the test folder should

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -134,6 +134,7 @@ version (using `v2.7.2` as an example):
 1. Publish to [npm]:
 
    ```shell
+   npm run transpile
    npm publish
    ```
 

--- a/package.json
+++ b/package.json
@@ -93,11 +93,6 @@
     "sinon": "17.0.1"
   },
   "scripts": {
-    "prepare": "is-ci || husky install script/hooks",
-    "prepublishOnly": "npm run transpile",
-    "premutation:integration": "npm run transpile",
-    "pretest:integration": "npm run transpile",
-    "prevet:package.json": "npm run transpile",
     "_eslint": "eslint . --config config/eslint.yml --report-unused-disable-directives",
     "_prettier": "prettier . --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
@@ -125,20 +120,21 @@
     "lint:sh": "node script/maybe-run.js shellcheck script/hooks/*.sh script/hooks/pre-*",
     "lint:yml": "npm run _eslint -- --ext .yml",
     "mutation": "npm run mutation:unit && npm run mutation:integration",
-    "mutation:integration": "stryker run config/stryker/integration.js",
+    "mutation:integration": "npm run transpile && stryker run config/stryker/integration.js",
     "mutation:unit": "stryker run config/stryker/unit.js",
+    "setup": "husky install script/hooks",
     "test": "npm run test:unit && npm run test:integration && npm run test:e2e && npm run test:compat && npm run test:breakage",
     "test:breakage": "ava test/breakage/**/*.test.js",
     "test:compat": "node test/compat/runner.js",
     "test:compat-all": "nve 14.18.0,16.13.0,18.0.0,19.0.0,20.0.0 npm run test:compat",
     "test:e2e": "ava test/e2e/**/*.test.js --timeout 1m",
-    "test:integration": "ava test/integration/**/*.test.js --timeout 2m",
+    "test:integration": "npm run transpile && ava test/integration/**/*.test.js --timeout 2m",
     "test:unit": "ava test/unit/**/*.test.js",
     "transpile": "rollup --config config/rollup.js && node script/create-d-cts.js",
     "verify": "npm run format:check && npm run license-check && npm run lint && npm run coverage && npm run vet",
     "vet": "npm run vet:deps && npm run vet:package.json && npm run vet:package-lock.json",
     "vet:deps": "knip --config config/knip.jsonc",
-    "vet:package.json": "publint --strict && attw --pack .",
+    "vet:package.json": "npm run transpile && publint --strict && attw --pack .",
     "vet:package-lock.json": "lockfile-lint --path package-lock.json --allowed-hosts npm gitlab.com --validate-https"
   }
 }


### PR DESCRIPTION
## Summary

Update the repository configuration to disable lifecycle scripts (such as installation scripts) by default. Adjust all current usage of such scripts to avoid relying on them and use alternatives instead.