### PR TITLE
Integration test for "shell missing" and "shell unsupported"

### DIFF
--- a/test/integration/constructor/constructor.test.js
+++ b/test/integration/constructor/constructor.test.js
@@ -10,8 +10,14 @@ import { arbitrary, pollution } from "./_.js";
 
 import { Shescape } from "shescape";
 
-test("shell is unsupported", (t) => {
+test("shell does not exist", (t) => {
   const shell = "not-actually-a-shell-that-exists";
+
+  t.throws(() => new Shescape({ shell }), { instanceOf: Error });
+});
+
+test("shell is unsupported", (t) => {
+  const shell = "node";
 
   t.throws(() => new Shescape({ shell }), { instanceOf: Error });
 });


### PR DESCRIPTION
## Summary

Shell should be a program that exists on any system that runs this test suite but not a shell that is actually supported. The Node.js binary should exist when this test suite is run, but should not be a shell that is supported.

This adds coverage for the `if (!isShellSupported(shellName))` branch in `src/internal/options.js` (and correspondingly the `unsupportedError` function).