### PR TITLE
Improve manual Release Guidelines

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,12 +28,15 @@ version (using `v2.7.2` as an example):
    ```shell
    git checkout main
    git pull origin main
+   npm clean-install
    ```
 
    Or clone:
 
    ```shell
    git clone git@github.com:ericcornelissen/shescape.git
+   cd shescape
+   npm clean-install
    ```
 
 1. Update the version number in the package manifest and lockfile:
@@ -134,6 +137,7 @@ version (using `v2.7.2` as an example):
 1. Publish to [npm]:
 
    ```shell
+   npm clean-install
    npm publish
    ```
 


### PR DESCRIPTION
Relates to #441

## Summary

Update the manual Release Guidelines to include commands/options to avoid errors while executing the commands while following the steps.

When syncing the repository, dependencies must be installed because the helper scripts to bump the JSDoc and changelog need them. Similarly, ensure dependencies are installed when publishing because that's needed to be able to transpile. This is included separately because of the delay in between initiating the release and finally publishing (that is, the opening, and waiting for validation, of the release Pull Request).