### PR TITLE
Add "shell missing" and "shell unsupported" cases to arbitrary options

### DIFF
--- a/test/_arbitraries.js
+++ b/test/_arbitraries.js
@@ -196,6 +196,8 @@ export const shescapeOptions = () =>
           fc.boolean(),
           fc.constantFrom(null, undefined),
           constants.isWindows ? windowsShell() : unixShell(),
+          fc.constant("not-actually-a-shell-that-exists"),
+          fc.constant("node"),
         ),
       },
       { withDeletedKeys: true },


### PR DESCRIPTION
Relates to #1407

## Summary

Update the `shescapeOptions` arbitrary to be able to generate options with either a missing shell `"not-actually-a-shell-that-exists"` or a shell that (should) exists but isn't supported `"node"`.

Note that the Node.js binary should exist when test are run, but should not be a shell that is supported by Shescape.

This ensures increased coverage in `src/internal/options.js` and `src/internal/executables.js`.