### PR TITLE
Update egress policy for jobs using Codecov

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -230,6 +230,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             cli.codecov.io:443
@@ -282,6 +283,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             cli.codecov.io:443
@@ -337,6 +339,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             azure.archive.ubuntu.com:80
@@ -398,6 +401,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             azure.archive.ubuntu.com:80
@@ -543,6 +547,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             actions-results-receiver-production.githubapp.com:443
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             cli.codecov.io:443


### PR DESCRIPTION
Relates to #1489

## Summary

Allow `api.codecov.io:443` for test job. Should address the warning currently emitted by the Codecov action:

> Test
> Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/c16abc29c95fcf9174b58eb7e1abf4c866893bc8/dist/codecov' failed with exit code 1
