### PR TITLE
Create test stub that fails when used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add a `Shescape` stub with failing methods to the testing module. ([#1530])
 
 ## [2.1.0] - 2023-12-23
 
@@ -333,6 +333,7 @@ Versioning].
 [#1280]: https://github.com/ericcornelissen/shescape/pull/1280
 [#1285]: https://github.com/ericcornelissen/shescape/pull/1285
 [#1308]: https://github.com/ericcornelissen/shescape/pull/1308
+[#1530]: https://github.com/ericcornelissen/shescape/pull/1530
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/modules/testing.d.ts
+++ b/src/modules/testing.d.ts
@@ -18,6 +18,12 @@ import type { Shescape as ShescapeType } from "./index.d.ts";
 export const injectionStrings: string[];
 
 /**
+ * A test stub of Shescape that can be instantiated but all methods always fail.
+ * This can be used to simulate a failure when using Shescape in your code.
+ */
+export const Failscape: ShescapeType;
+
+/**
  * An optimistic test stub of Shescape that has the same input-output profile as
  * the real Shescape implementation.
  *

--- a/src/modules/testing.js
+++ b/src/modules/testing.js
@@ -26,6 +26,32 @@ export const injectionStrings = [
 ];
 
 /**
+ * A test stub of Shescape that can be instantiated but all methods always fail.
+ * This can be used to simulate a failure when using Shescape in your code.
+ */
+export class Failscape {
+  constructor(_options) {
+    // Nothing to do here
+  }
+
+  escape(_arg) {
+    throw new Error("escape can't succeed");
+  }
+
+  escapeAll(_args) {
+    throw new Error("escapeAll can't succeed");
+  }
+
+  quote(_arg) {
+    throw new Error("quote can't succeed");
+  }
+
+  quoteAll(_args) {
+    throw new Error("quoteAll can't succeed");
+  }
+}
+
+/**
  * An optimistic test stub of Shescape that has the same input-output profile as
  * the real Shescape implementation.
  *

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -10,9 +10,15 @@ import * as fc from "fast-check";
 
 import { arbitrary } from "../_.js";
 
-import { injectionStrings, Stubscape, Throwscape } from "shescape/testing";
+import {
+  injectionStrings,
+  Failscape,
+  Stubscape,
+  Throwscape,
+} from "shescape/testing";
 import {
   injectionStrings as injectionStringsCjs,
+  Failscape as FailscapeCjs,
   Stubscape as StubscapeCjs,
   Throwscape as ThrowscapeCjs,
 } from "../../../src/modules/testing.cjs";
@@ -26,6 +32,102 @@ test("injection strings", (t) => {
     t.true(injectionStringsCjs.includes(injectionString));
   }
 });
+
+testProp(
+  "Failscape#escape (esm === cjs)",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const failscape = new Failscape(options);
+    const failscapeCjs = new FailscapeCjs(options);
+
+    let erroredEsm, erroredCjs;
+    try {
+      failscape.escape(arg);
+    } catch (_) {
+      erroredEsm = true;
+    }
+
+    try {
+      failscapeCjs.escape(arg);
+    } catch (_) {
+      erroredCjs = true;
+    }
+
+    t.is(erroredEsm, erroredCjs);
+  },
+);
+
+testProp(
+  "Failscape#escapeAll (esm === cjs)",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const failscape = new Failscape(options);
+    const failscapeCjs = new FailscapeCjs(options);
+
+    let erroredEsm, erroredCjs;
+    try {
+      failscape.escapeAll(args);
+    } catch (_) {
+      erroredEsm = true;
+    }
+
+    try {
+      failscapeCjs.escapeAll(args);
+    } catch (_) {
+      erroredCjs = true;
+    }
+
+    t.is(erroredEsm, erroredCjs);
+  },
+);
+
+testProp(
+  "Failscape#quote (esm === cjs)",
+  [arbitrary.shescapeArg(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const failscape = new Failscape(options);
+    const failscapeCjs = new FailscapeCjs(options);
+
+    let erroredEsm, erroredCjs;
+    try {
+      failscape.quote(arg);
+    } catch (_) {
+      erroredEsm = true;
+    }
+
+    try {
+      failscapeCjs.quote(arg);
+    } catch (_) {
+      erroredCjs = true;
+    }
+
+    t.is(erroredEsm, erroredCjs);
+  },
+);
+
+testProp(
+  "Failscape#quoteAll (esm === cjs)",
+  [fc.array(arbitrary.shescapeArg()), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const failscape = new Failscape(options);
+    const failscapeCjs = new FailscapeCjs(options);
+
+    let erroredEsm, erroredCjs;
+    try {
+      failscape.quoteAll(args);
+    } catch (_) {
+      erroredEsm = true;
+    }
+
+    try {
+      failscapeCjs.quoteAll(args);
+    } catch (_) {
+      erroredCjs = true;
+    }
+
+    t.is(erroredEsm, erroredCjs);
+  },
+);
 
 testProp(
   "Stubscape#escape (esm === cjs)",

--- a/test/integration/testing/functional.test.js
+++ b/test/integration/testing/functional.test.js
@@ -33,7 +33,10 @@ testProp(
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
     const failscape = new Failscape(options);
-    t.throws(() => failscape.escape(arg));
+    t.throws(() => failscape.escape(arg), {
+      instanceOf: Error,
+      message: "escape can't succeed",
+    });
   },
 );
 
@@ -42,7 +45,10 @@ testProp(
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, args, options) => {
     const failscape = new Failscape(options);
-    t.throws(() => failscape.escapeAll(args));
+    t.throws(() => failscape.escapeAll(args), {
+      instanceOf: Error,
+      message: "escapeAll can't succeed",
+    });
   },
 );
 
@@ -51,7 +57,10 @@ testProp(
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, arg, options) => {
     const failscape = new Failscape(options);
-    t.throws(() => failscape.quote(arg));
+    t.throws(() => failscape.quote(arg), {
+      instanceOf: Error,
+      message: "quote can't succeed",
+    });
   },
 );
 
@@ -60,7 +69,10 @@ testProp(
   [fc.anything(), arbitrary.shescapeOptions()],
   (t, args, options) => {
     const failscape = new Failscape(options);
-    t.throws(() => failscape.quoteAll(args));
+    t.throws(() => failscape.quoteAll(args), {
+      instanceOf: Error,
+      message: "quoteAll can't succeed",
+    });
   },
 );
 

--- a/test/integration/testing/functional.test.js
+++ b/test/integration/testing/functional.test.js
@@ -11,7 +11,12 @@ import * as fc from "fast-check";
 import { arbitrary } from "../_.js";
 
 import { Shescape } from "shescape";
-import { injectionStrings, Stubscape, Throwscape } from "shescape/testing";
+import {
+  injectionStrings,
+  Failscape,
+  Stubscape,
+  Throwscape,
+} from "shescape/testing";
 
 test("injection strings", (t) => {
   t.true(Array.isArray(injectionStrings));
@@ -22,6 +27,42 @@ test("injection strings", (t) => {
     t.true(injectionString.length > 0);
   }
 });
+
+testProp(
+  "Failscape#escape",
+  [fc.anything(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const failscape = new Failscape(options);
+    t.throws(() => failscape.escape(arg));
+  },
+);
+
+testProp(
+  "Failscape#escapeAll",
+  [fc.anything(), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const failscape = new Failscape(options);
+    t.throws(() => failscape.escapeAll(args));
+  },
+);
+
+testProp(
+  "Failscape#quote",
+  [fc.anything(), arbitrary.shescapeOptions()],
+  (t, arg, options) => {
+    const failscape = new Failscape(options);
+    t.throws(() => failscape.quote(arg));
+  },
+);
+
+testProp(
+  "Failscape#quoteAll",
+  [fc.anything(), arbitrary.shescapeOptions()],
+  (t, args, options) => {
+    const failscape = new Failscape(options);
+    t.throws(() => failscape.quoteAll(args));
+  },
+);
 
 testProp(
   "Stubscape#escape (stubscape =~ shescape)",


### PR DESCRIPTION
Closes #1307
Relates to #1149

## Summary

Expand the set of test stubs with one to simulate that using shescape to escape or quote fails.