### PR TITLE
Upgrade to `pp-test-kit@0.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "lockfile-lint": "4.13.1",
         "markdownlint-cli": "0.40.0",
         "nve": "18.0.0",
-        "pp-test-kit": "0.1.1",
+        "pp-test-kit": "0.1.2",
         "prettier": "3.2.4",
         "publint": "0.2.8",
         "rollup": "4.18.0",
@@ -10954,9 +10954,9 @@
       }
     },
     "node_modules/pp-test-kit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pp-test-kit/-/pp-test-kit-0.1.1.tgz",
-      "integrity": "sha512-1Ev5or1EJYSE2/pTQb+EBNWgSlr6ojpYozViuNxsXUEGjRdYZH7mVFM0TTlfRa4xVGfrd5fgCOOcVzhbDQ6wKg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pp-test-kit/-/pp-test-kit-0.1.2.tgz",
+      "integrity": "sha512-VvNAa6ePrUFjtd+B9fa93EewP5Pf/d7wDTEd4E/WLVX0Uq3SfPFTh75bxmRIrfaty+yQzvMi+m3oS1xQbQvnvA==",
       "dev": true,
       "engines": {
         "node": "^22"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lockfile-lint": "4.13.1",
     "markdownlint-cli": "0.40.0",
     "nve": "18.0.0",
-    "pp-test-kit": "0.1.1",
+    "pp-test-kit": "0.1.2",
     "prettier": "3.2.4",
     "publint": "0.2.8",
     "rollup": "4.18.0",

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -6,6 +6,7 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
+import * as ppTestKit from "pp-test-kit/simulate";
 import sinon from "sinon";
 
 import { arbitrary } from "./_.js";
@@ -108,7 +109,11 @@ testProp(
 
     t.context.deps.which.resetHistory();
 
-    env = Object.assign(Object.create({ [pathName]: prototypePath }), env);
+    env = ppTestKit.simulatePollution({
+      subject: env,
+      property: pathName,
+      value: prototypePath,
+    });
 
     const { executable } = t.context;
     const args = { env, executable };

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -6,6 +6,7 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import * as ppTestKit from "pp-test-kit/simulate";
 
 import { arbitrary, constants } from "./_.js";
 
@@ -81,7 +82,11 @@ testProp(
   (t, env, prototypeOstype, platform) => {
     fc.pre(![...winOsTypes].includes(env.OSTYPE));
 
-    env = Object.assign(Object.create({ OSTYPE: prototypeOstype }), env);
+    env = ppTestKit.simulatePollution({
+      subject: env,
+      property: "OSTYPE",
+      value: prototypeOstype,
+    });
 
     const result = getHelpersByPlatform({
       env,

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -8,6 +8,7 @@ import path from "node:path/win32";
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
+import * as ppTestKit from "pp-test-kit/simulate";
 import sinon from "sinon";
 
 import { arbitrary, constants } from "./_.js";
@@ -61,7 +62,11 @@ testProp(
   (t, env, prototypeComSpec) => {
     fc.pre(env.ComSpec !== prototypeComSpec);
 
-    env = Object.assign(Object.create({ ComSpec: prototypeComSpec }), env);
+    env = ppTestKit.simulatePollution({
+      subject: env,
+      property: "ComSpec",
+      value: prototypeComSpec,
+    });
 
     const result = win.getDefaultShell({ env });
     t.not(result, prototypeComSpec);


### PR DESCRIPTION
Relates to #1610

## Summary

Upgrade the pp-test-kit dependency and use the new simulate API in tests that test behavior under the effect of a specific polluted property.