### PR TITLE
Stop using njsscan

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,37 +141,6 @@ jobs:
       - name: Lint YAML
         if: ${{ failure() || success() }}
         run: npm run lint:yml
-  njsscan:
-    name: njsscan
-    runs-on: ubuntu-22.04
-    permissions:
-      security-events: write # To upload SARIF results
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            ghcr.io:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pkg-containers.githubusercontent.com:443
-            uploads.github.com:443
-      - name: Checkout repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - name: Perform njsscan analysis
-        id: njsscan
-        uses: ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81 # v7
-        with:
-          args: . --sarif --output njsscan-results.sarif || true
-      - name: Upload njsscan report to GitHub
-        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
-        if: ${{ failure() || success() }}
-        with:
-          sarif_file: njsscan-results.sarif
   reproducible:
     name: Reproducible build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

This removes the continuous integration with njsscan. The Action is a bit of a supply chain risk (unpinnable and potentially unmaintained) and has otherwise not been used (never received an alert from it). Additionally, per the description of #793, it seems to build on top of Semgrep which is already being used in this project too.