### PR TITLE
Bump micromatch from 4.0.7 to 4.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8287,9 +8287,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Relates to [Audit / npm (#1040)](https://github.com/ericcornelissen/shescape/actions/runs/10535239050)

## Summary

Bump micromatch from 4.0.7 to 4.0.8 to resolve CVE-2024-4067