### PR TITLE
Revert recent change to `audit-release.yml`

### DIFF
--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Audit for vulnerabilities
-        run: npm run audit:vulnerabilities:runtime
+        run: npm run audit:runtime


### PR DESCRIPTION
Relates to #1762, [Audit (release) rule 428](https://github.com/ericcornelissen/shescape/actions/runs/11676998917), [Audit (release) 429](https://github.com/ericcornelissen/shescape/actions/runs/11696658986)

## Summary


It was updated to use the new command for auditing runtime dependencies even though the latest release does not yet use this command. This should be updated with the next release.