### PR TITLE
Try out `eslint-plugin-depend`

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,6 +1,7 @@
 // Check out ESLint at: https://eslint.org/
 
 import ava from "eslint-plugin-ava";
+import depend from "eslint-plugin-depend";
 import jsdoc from "eslint-plugin-jsdoc";
 import json from "@eslint/json";
 import regexp from "eslint-plugin-regexp";
@@ -324,8 +325,11 @@ export default [
   {
     name: "Source",
     files: ["src/**/*.js"],
-    plugins: { jsdoc, regexp, top },
+    plugins: { depend, jsdoc, regexp, top },
     rules: {
+      // https://github.com/es-tooling/eslint-plugin-depend#readme
+      "depend/ban-dependencies": ["error"],
+
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/check-values": [
         "error",
@@ -549,8 +553,11 @@ export default [
   {
     name: "Tests",
     files: ["test/**/*.js"],
-    plugins: { ava, jsdoc },
+    plugins: { depend, ava, jsdoc },
     rules: {
+      // https://github.com/es-tooling/eslint-plugin-depend#readme
+      "depend/ban-dependencies": ["error"],
+
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/check-values": [
         "error",
@@ -598,8 +605,11 @@ export default [
   {
     name: "Scripts",
     files: [".github/**/*.js", "script/**/*.js"],
-    plugins: { jsdoc },
+    plugins: { depend, jsdoc },
     rules: {
+      // https://github.com/es-tooling/eslint-plugin-depend#readme
+      "depend/ban-dependencies": ["error"],
+
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/check-values": [
         "error",
@@ -645,6 +655,8 @@ export default [
       // https://github.com/eslint/json/blob/main/README.md#rules
       "json/no-duplicate-keys": ["error"],
       "json/no-empty-keys": ["error"],
+      "json/no-unnormalized-keys": ["error"],
+      "json/no-unsafe-values": ["error"],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "dotenv": "16.3.1",
         "eslint": "9.14.0",
         "eslint-plugin-ava": "15.0.0",
+        "eslint-plugin-depend": "0.12.0",
         "eslint-plugin-jsdoc": "50.4.1",
         "eslint-plugin-regexp": "2.6.0",
         "eslint-plugin-yml": "1.14.0",
@@ -5548,6 +5549,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-depend": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-0.12.0.tgz",
+      "integrity": "sha512-bS5ESnC3eXDJPNv0RKkzRbLO45hRRLR/dleAUdbysXChWz1bAxa4MRh14EtDREn7fZieueqz4L7TfQQbzvdYHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^1.2.0",
+        "module-replacements": "^2.1.0",
+        "semver": "^7.6.3"
+      }
+    },
     "node_modules/eslint-plugin-jsdoc": {
       "version": "50.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.1.tgz",
@@ -5981,6 +5994,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-1.2.0.tgz",
+      "integrity": "sha512-45LSPmWf+gC5tdCQMNH4s9Sr00bIkiD9aN7dc5hqkrEw1geRYyDQS1v1oMHAW3ysfxfndqGsrDREHHjNNbKUfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^3.0.1"
       }
     },
     "node_modules/fetch-node-website": {
@@ -11291,6 +11314,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-replacements": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.6.0.tgz",
+      "integrity": "sha512-LL+VhVXMIie3aO/uqPPAGaP7fhJb6yr98FW5IcSSJv+0gmJvS2c/L3C8WIaAA/HPyVhabKFKBKcfeLLi7WnRvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/move-file": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "dotenv": "16.3.1",
     "eslint": "9.14.0",
     "eslint-plugin-ava": "15.0.0",
+    "eslint-plugin-depend": "0.12.0",
     "eslint-plugin-jsdoc": "50.4.1",
     "eslint-plugin-regexp": "2.6.0",
     "eslint-plugin-yml": "1.14.0",


### PR DESCRIPTION
## Summary

Add `eslint-plugin-depend` as a dependency and use it with ESLint to suggest alternatives to various dependencies with the goal of preventing dependency tree bloat.

As of this commit the plugin does not detect any problems, but the idea is that it would prevent problems from being introduced later OR being detected as the plugin is updated.
