### PR TITLE
Bump transitive dependency `npm-license-corrections`

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -16,13 +16,8 @@
     ]
   },
   "packages": {
-    "@andrewbranch/untar.js": "1.0.3",
-    "atomically": "2.0.3",
     "depreman": "^0.3.0",
-    "jsonp": "0.2.1",
-    "shescape": "*",
-    "stubborn-fs": "1.2.5",
-    "when-exit": "2.1.3"
+    "shescape": "*"
   },
   "corrections": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11895,9 +11895,9 @@
       }
     },
     "node_modules/npm-license-corrections": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/npm-license-corrections/-/npm-license-corrections-1.6.2.tgz",
-      "integrity": "sha512-U66tDCdutNSdzbbPu3IWpgUwcrekT3XW+5fPdRleQmW2kiDqCnurRJnI2kQswRYng1dg/GpgxXE8mT6r6s40rg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/npm-license-corrections/-/npm-license-corrections-1.9.0.tgz",
+      "integrity": "sha512-9Tq6y6zop5lsZy6dInbgrCLnqtuN+3jBc9NCusKjbeQL4LRudDkvmCYyInsDOaKN7GIVbBSvDto5MnEqYXVhxQ==",
       "dev": true,
       "license": "CC0-1.0"
     },


### PR DESCRIPTION
## Summary

Update `npm-license-corrections` to the latest available version to benefit from the contributions I made for the licensee package exceptions present in this project, which have now been removed.