### PR TITLE
Update deprecation ignore reason for glob 7

### DIFF
--- a/.ndmrc
+++ b/.ndmrc
@@ -4,7 +4,7 @@
       "*": {
         "glob@^7.0.0": {
           "*": {
-            "#ignore": "tracked in https://github.com/vercel/nft/issues/389"
+            "#ignore": "tracked in https://github.com/avajs/ava/pull/3368"
           }
         }
       }


### PR DESCRIPTION
Relates to #1805

## Summary

The problem has been resolved at the level previously mentioned and is now blocked by an intermediate dependency.

I'm opening this as a placeholder, depending on when the linked PR is merged, this may be superceded by a version bump of `ava` instead.