### PR TITLE
Add `eslint-plugin-import`

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -983,7 +983,7 @@ export default [
   {
     name: "Tests",
     files: ["test/**/*.js"],
-    plugins: { ava, imports, jsdoc },
+    plugins: { ava, imports, jsdoc, unicorn },
     rules: {
       "guard-for-in": ["off"],
       "id-length": [
@@ -994,20 +994,6 @@ export default [
       ],
       "no-magic-numbers": ["off"],
       "max-params": ["off"],
-
-      // https://github.com/import-js/eslint-plugin-import#readme
-      "imports/no-unresolved": ["off"],
-      // "imports/order": ["error", {
-      // }],
-
-      // https://github.com/gajus/eslint-plugin-jsdoc#readme
-      "jsdoc/check-values": [
-        "error",
-        {
-          allowedLicenses: ["MIT", "MPL-2.0"],
-        },
-      ],
-      "jsdoc/require-jsdoc": ["off"],
 
       // https://github.com/avajs/eslint-plugin-ava#readme
       "ava/assertion-arguments": ["error"],
@@ -1042,6 +1028,18 @@ export default [
       "ava/use-t-well": ["error"],
       "ava/use-test": ["error"],
       "ava/use-true-false": ["error"],
+
+      // https://github.com/import-js/eslint-plugin-import#readme
+      "imports/no-unresolved": ["off"],
+
+      // https://github.com/gajus/eslint-plugin-jsdoc#readme
+      "jsdoc/check-values": [
+        "error",
+        {
+          allowedLicenses: ["MIT", "MPL-2.0"],
+        },
+      ],
+      "jsdoc/require-jsdoc": ["off"],
 
       // https://github.com/sindresorhus/eslint-plugin-unicorn#readme
       "unicorn/no-useless-undefined": ["off"],
@@ -1174,10 +1172,16 @@ export default [
   {
     name: "Documentation Snippets",
     files: ["**/*.md/*.js"],
+    plugins: { imports, jsdoc, unicorn },
     rules: {
       "id-length": ["off"],
       "no-console": ["off"],
       "no-magic-numbers": ["off"],
+
+      // https://github.com/import-js/eslint-plugin-import#readme
+      "imports/no-unresolved": ["off"],
+      "imports/order": ["off"],
+      "imports/unambiguous": ["off"],
 
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/require-description-complete-sentence": ["off"],

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -900,12 +900,12 @@ export default [
       "imports/default": ["error"],
       "imports/dynamic-import-chunkname": ["error"],
       "imports/export": ["error"],
-      "imports/exports-last": ["error"],
-      "imports/extensions": ["error"],
+      "imports/exports-last": ["off"],
+      "imports/extensions": ["error", "always", { ignorePackages: true }],
       "imports/first": ["error"],
-      "imports/group-exports": ["error"],
+      "imports/group-exports": ["off"],
       "imports/imports-first": ["error"],
-      "imports/max-dependencies": ["error"],
+      "imports/max-dependencies": ["off"],
       "imports/named": ["error"],
       "imports/newline-after-import": ["error"],
       "imports/namespace": ["error"],
@@ -921,25 +921,30 @@ export default [
       "imports/no-empty-named-blocks": ["error"],
       "imports/no-extraneous-dependencies": ["error"],
       "imports/no-import-module-exports": ["error"],
-      "imports/no-internal-modules": ["error"],
+      "imports/no-internal-modules": ["off"],
       "imports/no-mutable-exports": ["error"],
       "imports/no-named-default": ["error"],
-      "imports/no-named-export": ["error"],
+      "imports/no-named-export": ["off"],
       "imports/no-named-as-default": ["error"],
       "imports/no-named-as-default-member": ["error"],
-      "imports/no-namespace": ["error"],
-      "imports/no-nodejs-modules": ["error"],
+      "imports/no-namespace": ["off"],
+      "imports/no-nodejs-modules": ["off"],
       "imports/no-relative-packages": ["error"],
-      "imports/no-relative-parent-imports": ["error"],
+      "imports/no-relative-parent-imports": ["off"],
       "imports/no-restricted-paths": ["error"],
       "imports/no-self-import": ["error"],
-      "imports/no-unassigned-import": ["error"],
+      "imports/no-unassigned-import": ["off"],
       "imports/no-unresolved": ["error"],
       "imports/no-unused-modules": ["error"],
       "imports/no-useless-path-segments": ["error"],
       "imports/no-webpack-loader-syntax": ["error"],
-      "imports/order": ["error"],
-      "imports/prefer-default-export": ["error"],
+      "imports/order": [
+        "error",
+        {
+          "newlines-between": "always",
+        },
+      ],
+      "imports/prefer-default-export": ["off"],
       "imports/unambiguous": ["error"],
     },
   },
@@ -978,7 +983,7 @@ export default [
   {
     name: "Tests",
     files: ["test/**/*.js"],
-    plugins: { ava, jsdoc },
+    plugins: { ava, imports, jsdoc },
     rules: {
       "guard-for-in": ["off"],
       "id-length": [
@@ -989,6 +994,11 @@ export default [
       ],
       "no-magic-numbers": ["off"],
       "max-params": ["off"],
+
+      // https://github.com/import-js/eslint-plugin-import#readme
+      "imports/no-unresolved": ["off"],
+      // "imports/order": ["error", {
+      // }],
 
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/check-values": [
@@ -1061,9 +1071,13 @@ export default [
   {
     name: "Configs",
     files: ["config/**/*"],
-    plugins: { jsdoc },
+    plugins: { imports, jsdoc },
     rules: {
       "no-magic-numbers": ["off"],
+
+      // https://github.com/import-js/eslint-plugin-import#readme
+      "imports/no-anonymous-default-export": ["off"],
+      "imports/no-default-export": ["off"],
 
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/require-file-overview": ["off"],

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,13 +1,13 @@
 // Configuration file for ESLint (https://eslint.org/)
 
+import top from "@ericcornelissen/eslint-plugin-top";
+import json from "@eslint/json";
+import markdown from "@eslint/markdown";
 import ava from "eslint-plugin-ava";
 import depend from "eslint-plugin-depend";
 import imports from "eslint-plugin-import";
 import jsdoc from "eslint-plugin-jsdoc";
-import json from "@eslint/json";
-import markdown from "@eslint/markdown";
 import regexp from "eslint-plugin-regexp";
-import top from "@ericcornelissen/eslint-plugin-top";
 import unicorn from "eslint-plugin-unicorn";
 import yml from "eslint-plugin-yml";
 
@@ -941,6 +941,10 @@ export default [
       "imports/order": [
         "error",
         {
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
           "newlines-between": "always",
         },
       ],

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -2,6 +2,7 @@
 
 import ava from "eslint-plugin-ava";
 import depend from "eslint-plugin-depend";
+import imports from "eslint-plugin-import";
 import jsdoc from "eslint-plugin-jsdoc";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
@@ -887,6 +888,59 @@ export default [
       "unicorn/template-indent": ["error"],
       "unicorn/text-encoding-identifier-case": ["error"],
       "unicorn/throw-new-error": ["error"],
+    },
+  },
+  {
+    name: "Imports",
+    files: ["**/*.js"],
+    plugins: { imports },
+    rules: {
+      // https://github.com/import-js/eslint-plugin-import#readme
+      "imports/consistent-type-specifier-style": ["error"],
+      "imports/default": ["error"],
+      "imports/dynamic-import-chunkname": ["error"],
+      "imports/export": ["error"],
+      "imports/exports-last": ["error"],
+      "imports/extensions": ["error"],
+      "imports/first": ["error"],
+      "imports/group-exports": ["error"],
+      "imports/imports-first": ["error"],
+      "imports/max-dependencies": ["error"],
+      "imports/named": ["error"],
+      "imports/newline-after-import": ["error"],
+      "imports/namespace": ["error"],
+      "imports/no-absolute-path": ["error"],
+      "imports/no-amd": ["error"],
+      "imports/no-anonymous-default-export": ["error"],
+      "imports/no-commonjs": ["error"],
+      "imports/no-cycle": ["error"],
+      "imports/no-default-export": ["error"],
+      "imports/no-deprecated": ["error"],
+      "imports/no-duplicates": ["error"],
+      "imports/no-dynamic-require": ["error"],
+      "imports/no-empty-named-blocks": ["error"],
+      "imports/no-extraneous-dependencies": ["error"],
+      "imports/no-import-module-exports": ["error"],
+      "imports/no-internal-modules": ["error"],
+      "imports/no-mutable-exports": ["error"],
+      "imports/no-named-default": ["error"],
+      "imports/no-named-export": ["error"],
+      "imports/no-named-as-default": ["error"],
+      "imports/no-named-as-default-member": ["error"],
+      "imports/no-namespace": ["error"],
+      "imports/no-nodejs-modules": ["error"],
+      "imports/no-relative-packages": ["error"],
+      "imports/no-relative-parent-imports": ["error"],
+      "imports/no-restricted-paths": ["error"],
+      "imports/no-self-import": ["error"],
+      "imports/no-unassigned-import": ["error"],
+      "imports/no-unresolved": ["error"],
+      "imports/no-unused-modules": ["error"],
+      "imports/no-useless-path-segments": ["error"],
+      "imports/no-webpack-loader-syntax": ["error"],
+      "imports/order": ["error"],
+      "imports/prefer-default-export": ["error"],
+      "imports/unambiguous": ["error"],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "9.20.1",
         "eslint-plugin-ava": "15.0.1",
         "eslint-plugin-depend": "0.12.0",
+        "eslint-plugin-import": "2.31.0",
         "eslint-plugin-jsdoc": "50.4.1",
         "eslint-plugin-regexp": "2.6.0",
         "eslint-plugin-unicorn": "57.0.0",
@@ -2354,6 +2355,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -2722,6 +2730,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3158,14 +3173,14 @@
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3184,6 +3199,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array.prototype.flat": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
@@ -3195,6 +3252,25 @@
         "define-properties": "^1.2.0",
         "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3262,20 +3338,19 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3322,6 +3397,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/async-sema": {
@@ -3925,17 +4010,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4839,15 +4954,15 @@
       }
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4857,31 +4972,31 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -5145,6 +5260,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
@@ -5185,6 +5313,21 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5329,58 +5472,63 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
-        "gopd": "^1.0.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5397,14 +5545,11 @@
       "license": "MIT"
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5448,9 +5593,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5461,15 +5606,16 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5486,15 +5632,15 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5615,6 +5761,56 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-plugin-ava": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-15.0.1.tgz",
@@ -5679,6 +5875,84 @@
         "fd-package-json": "^1.2.0",
         "module-replacements": "^2.1.0",
         "semver": "^7.6.3"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
@@ -6379,13 +6653,19 @@
       "license": "ISC"
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -6461,16 +6741,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7624,17 +7906,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7707,6 +7994,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stdin": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
@@ -7738,15 +8039,15 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7900,13 +8201,13 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8046,11 +8347,14 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8079,11 +8383,14 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8092,9 +8399,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8434,15 +8741,15 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8526,14 +8833,15 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8549,28 +8857,51 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8643,12 +8974,14 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -8659,13 +8992,14 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8705,6 +9039,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -8716,6 +9066,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -8795,19 +9164,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-npm": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
@@ -8822,13 +9178,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8881,14 +9238,16 @@
       "license": "MIT"
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8911,13 +9270,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8940,13 +9299,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8956,13 +9316,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8972,13 +9334,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9000,14 +9362,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11000,6 +11395,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/md5-hex": {
@@ -13018,9 +13423,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13041,15 +13446,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -13147,6 +13554,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-cancelable": {
@@ -13475,6 +13900,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -13586,9 +14018,9 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14421,6 +14853,29 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexp-ast-analysis": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
@@ -14537,6 +14992,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
@@ -14772,15 +15248,16 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -14811,16 +15288,33 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14934,6 +15428,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -14989,16 +15498,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15453,16 +16019,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15472,15 +16041,19 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15529,6 +16102,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-final-newline": {
@@ -15683,6 +16266,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {
@@ -16046,6 +16642,32 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -16115,32 +16737,32 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16150,18 +16772,19 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16171,18 +16794,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
-      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0"
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16242,16 +16865,19 @@
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16574,33 +17200,84 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "sinon": "19.0.2"
   },
   "scripts": {
-    "_eslint": "eslint --config config/eslint.js --report-unused-disable-directives",
+    "_eslint": "eslint --config config/eslint.js",
     "_prettier": "prettier . --ignore-path .gitignore",
     "audit": "npm-run-all audit:*",
     "audit:deprecations": "depreman --errors-only --report-unused",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint": "9.20.1",
     "eslint-plugin-ava": "15.0.1",
     "eslint-plugin-depend": "0.12.0",
+    "eslint-plugin-import": "2.31.0",
     "eslint-plugin-jsdoc": "50.4.1",
     "eslint-plugin-regexp": "2.6.0",
     "eslint-plugin-unicorn": "57.0.0",

--- a/src/internal/unix.js
+++ b/src/internal/unix.js
@@ -8,12 +8,12 @@ import * as path from "node:path";
 
 import which from "which";
 
+import { noShell } from "./options.js";
 import * as bash from "./unix/bash.js";
 import * as csh from "./unix/csh.js";
 import * as dash from "./unix/dash.js";
 import * as nosh from "./unix/no-shell.js";
 import * as zsh from "./unix/zsh.js";
-import { noShell } from "./options.js";
 
 /**
  * The name of the Bourne-again shell (Bash) binary.

--- a/src/internal/win.js
+++ b/src/internal/win.js
@@ -8,11 +8,11 @@ import * as path from "node:path";
 
 import which from "which";
 
+import { noShell } from "./options.js";
+import { hasOwn } from "./reflection.js";
 import * as cmd from "./win/cmd.js";
 import * as nosh from "./win/no-shell.js";
 import * as powershell from "./win/powershell.js";
-import { noShell } from "./options.js";
-import { hasOwn } from "./reflection.js";
 
 /**
  * The name of the Windows Command Prompt binary.

--- a/test/_runners.js
+++ b/test/_runners.js
@@ -7,9 +7,9 @@
 import assert from "node:assert";
 import cp from "node:child_process";
 
-import * as constants from "./_constants.js";
-
 import { Shescape } from "shescape";
+
+import * as constants from "./_constants.js";
 
 /**
  * Checks if the fuzz shell is CMD.

--- a/test/breakage/index.test.js
+++ b/test/breakage/index.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import { Shescape } from "shescape";
 import { Shescape as Previouscape } from "shescape-previous";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "Shescape#constructor",

--- a/test/breakage/stateless.test.js
+++ b/test/breakage/stateless.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import * as shescape from "shescape/stateless";
 import * as previouscape from "shescape-previous/stateless";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "shescape.escape",

--- a/test/breakage/testing.test.js
+++ b/test/breakage/testing.test.js
@@ -5,14 +5,13 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import { Stubscape, Throwscape } from "shescape/testing";
 import {
   Shescape as Previoustub,
   Throwscape as Previousthrow,
 } from "shescape-previous/testing";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "Stubscape#constructor",

--- a/test/compat/index.test.js
+++ b/test/compat/index.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import { Shescape } from "../../src/modules/index.js";
+
+import { arbitrary } from "./_.js";
 
 export function testShescapeEscape() {
   fc.assert(

--- a/test/compat/stateless.test.js
+++ b/test/compat/stateless.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import * as shescape from "../../src/modules/stateless.js";
+
+import { arbitrary } from "./_.js";
 
 export function testShescapeEscape() {
   fc.assert(

--- a/test/compat/testing.test.js
+++ b/test/compat/testing.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import { Stubscape, Throwscape } from "../../src/modules/testing.js";
+
+import { arbitrary } from "./_.js";
 
 export function testStubscapeEscape() {
   fc.assert(

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -5,8 +5,7 @@
 
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
-
-import { constants } from "./_.js";
+import * as constants from "../_constants.js";
 
 /**
  * Returns the test fixtures for the current platform.

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -3,9 +3,9 @@
  * @license MIT
  */
 
+import * as constants from "../_constants.js";
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
-import * as constants from "../_constants.js";
 
 /**
  * Returns the test fixtures for the current platform.

--- a/test/integration/constructor/constructor.test.js
+++ b/test/integration/constructor/constructor.test.js
@@ -6,10 +6,9 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as ppTestKit from "pp-test-kit/manual";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "./_.js";
-
-import { Shescape } from "shescape";
 
 test("shell does not exist", (t) => {
   const shell = "not-actually-a-shell-that-exists";

--- a/test/integration/escape-all/bash.test.js
+++ b/test/integration/escape-all/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/escape-all/cmd-exe.test.js
+++ b/test/integration/escape-all/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/escape-all/cmd.test.js
+++ b/test/integration/escape-all/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/escape-all/commonjs.test.js
+++ b/test/integration/escape-all/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/escape-all/commonjs.test.js
+++ b/test/integration/escape-all/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/escape-all/csh.test.js
+++ b/test/integration/escape-all/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/escape-all/dash.test.js
+++ b/test/integration/escape-all/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/escape-all/invalid.test.js
+++ b/test/integration/escape-all/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp("invalid arguments", [arbitrary.shescapeOptions()], (t, options) => {
   let shescape;

--- a/test/integration/escape-all/no-shell.test.js
+++ b/test/integration/escape-all/no-shell.test.js
@@ -4,10 +4,9 @@
  */
 
 import test from "ava";
+import { Shescape } from "shescape";
 
 import { generate } from "../_.js";
-
-import { Shescape } from "shescape";
 
 test(`input is escaped for no shell`, (t) => {
   for (const scenario of generate.escapeExamples(false)) {

--- a/test/integration/escape-all/powershell-exe.test.js
+++ b/test/integration/escape-all/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/escape-all/powershell.test.js
+++ b/test/integration/escape-all/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/escape-all/valid.test.js
+++ b/test/integration/escape-all/valid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "return values",

--- a/test/integration/escape-all/zsh.test.js
+++ b/test/integration/escape-all/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/escape/bash.test.js
+++ b/test/integration/escape/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/escape/cmd-exe.test.js
+++ b/test/integration/escape/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/escape/cmd.test.js
+++ b/test/integration/escape/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/escape/commonjs.test.js
+++ b/test/integration/escape/commonjs.test.js
@@ -7,8 +7,8 @@
 import { testProp } from "@fast-check/ava";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/escape/commonjs.test.js
+++ b/test/integration/escape/commonjs.test.js
@@ -5,10 +5,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/escape/csh.test.js
+++ b/test/integration/escape/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/escape/dash.test.js
+++ b/test/integration/escape/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/escape/invalid.test.js
+++ b/test/integration/escape/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp("invalid arguments", [arbitrary.shescapeOptions()], (t, options) => {
   let shescape;

--- a/test/integration/escape/no-shell.test.js
+++ b/test/integration/escape/no-shell.test.js
@@ -4,10 +4,9 @@
  */
 
 import test from "ava";
+import { Shescape } from "shescape";
 
 import { generate } from "../_.js";
-
-import { Shescape } from "shescape";
 
 test(`input is escaped for no shell`, (t) => {
   for (const scenario of generate.escapeExamples(false)) {

--- a/test/integration/escape/powershell-exe.test.js
+++ b/test/integration/escape/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/escape/powershell.test.js
+++ b/test/integration/escape/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/escape/valid.test.js
+++ b/test/integration/escape/valid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "return values",

--- a/test/integration/escape/zsh.test.js
+++ b/test/integration/escape/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/quote-all/bash.test.js
+++ b/test/integration/quote-all/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/quote-all/cmd-exe.test.js
+++ b/test/integration/quote-all/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/quote-all/cmd.test.js
+++ b/test/integration/quote-all/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/quote-all/commonjs.test.js
+++ b/test/integration/quote-all/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/quote-all/commonjs.test.js
+++ b/test/integration/quote-all/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/quote-all/csh.test.js
+++ b/test/integration/quote-all/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/quote-all/dash.test.js
+++ b/test/integration/quote-all/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/quote-all/invalid.test.js
+++ b/test/integration/quote-all/invalid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "quote without shell",

--- a/test/integration/quote-all/powershell-exe.test.js
+++ b/test/integration/quote-all/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/quote-all/powershell.test.js
+++ b/test/integration/quote-all/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/quote-all/valid.test.js
+++ b/test/integration/quote-all/valid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "quote with shell",

--- a/test/integration/quote-all/zsh.test.js
+++ b/test/integration/quote-all/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/quote/bash.test.js
+++ b/test/integration/quote/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/quote/cmd-exe.test.js
+++ b/test/integration/quote/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/quote/cmd.test.js
+++ b/test/integration/quote/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/quote/commonjs.test.js
+++ b/test/integration/quote/commonjs.test.js
@@ -7,8 +7,8 @@
 import { testProp } from "@fast-check/ava";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/quote/commonjs.test.js
+++ b/test/integration/quote/commonjs.test.js
@@ -5,10 +5,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/quote/csh.test.js
+++ b/test/integration/quote/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/quote/dash.test.js
+++ b/test/integration/quote/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/quote/invalid.test.js
+++ b/test/integration/quote/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "without shell",

--- a/test/integration/quote/powershell-exe.test.js
+++ b/test/integration/quote/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/quote/powershell.test.js
+++ b/test/integration/quote/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/quote/valid.test.js
+++ b/test/integration/quote/valid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "with shell",

--- a/test/integration/quote/zsh.test.js
+++ b/test/integration/quote/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/stateless/commonjs.test.js
+++ b/test/integration/stateless/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import * as shescape from "shescape/stateless";
 
 import { arbitrary } from "../_.js";
-
-import * as shescape from "shescape/stateless";
 import * as shescapeCjs from "../../../src/modules/stateless.cjs";
 
 testProp(

--- a/test/integration/stateless/commonjs.test.js
+++ b/test/integration/stateless/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import * as shescape from "shescape/stateless";
 
-import { arbitrary } from "../_.js";
 import * as shescapeCjs from "../../../src/modules/stateless.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "shescape.escape (esm === cjs)",

--- a/test/integration/stateless/functional.test.js
+++ b/test/integration/stateless/functional.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import { Shescape } from "shescape";
 import * as shescape from "shescape/stateless";
+
+import { arbitrary } from "../_.js";
 
 testProp(
   "shescape.escape",

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -14,13 +14,13 @@ import {
   Throwscape,
 } from "shescape/testing";
 
-import { arbitrary } from "../_.js";
 import {
   injectionStrings as injectionStringsCjs,
   Failscape as FailscapeCjs,
   Stubscape as StubscapeCjs,
   Throwscape as ThrowscapeCjs,
 } from "../../../src/modules/testing.cjs";
+import { arbitrary } from "../_.js";
 
 test("injection strings", (t) => {
   for (const injectionStringCjs of injectionStringsCjs) {

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -7,15 +7,14 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import {
   injectionStrings,
   Failscape,
   Stubscape,
   Throwscape,
 } from "shescape/testing";
+
+import { arbitrary } from "../_.js";
 import {
   injectionStrings as injectionStringsCjs,
   Failscape as FailscapeCjs,

--- a/test/integration/testing/functional.test.js
+++ b/test/integration/testing/functional.test.js
@@ -7,9 +7,6 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import { Shescape } from "shescape";
 import {
   injectionStrings,
@@ -17,6 +14,8 @@ import {
   Stubscape,
   Throwscape,
 } from "shescape/testing";
+
+import { arbitrary } from "../_.js";
 
 test("injection strings", (t) => {
   t.true(Array.isArray(injectionStrings));

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -7,11 +7,11 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
-import sinon from "sinon";
-
-import { arbitrary } from "./_.js";
+import * as sinon from "sinon";
 
 import { resolveExecutable } from "../../../src/internal/executables.js";
+
+import { arbitrary } from "./_.js";
 
 test.before((t) => {
   const executable = "/bin/sh";

--- a/test/unit/options/parse-options.test.js
+++ b/test/unit/options/parse-options.test.js
@@ -6,12 +6,12 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-import sinon from "sinon";
-
-import { arbitrary } from "./_.js";
+import * as sinon from "sinon";
 
 import { resolveExecutable } from "../../../src/internal/executables.js";
 import { noShell, parseOptions } from "../../../src/internal/options.js";
+
+import { arbitrary } from "./_.js";
 
 const arbitraryInput = () =>
   fc

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -8,11 +8,11 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
 
-import { arbitrary, constants } from "./_.js";
-
 import { getHelpersByPlatform } from "../../../src/internal/platforms.js";
 import * as unix from "../../../src/internal/unix.js";
 import * as win from "../../../src/internal/win.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const unixPlatforms = [
   constants.osAix,

--- a/test/unit/reflection/checked-to-string.test.js
+++ b/test/unit/reflection/checked-to-string.test.js
@@ -9,9 +9,9 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { arbitrary, constants } from "./_.js";
-
 import { checkedToString } from "../../../src/internal/reflection.js";
+
+import { arbitrary, constants } from "./_.js";
 
 testProp("strings", [fc.string()], (t, value) => {
   const result = checkedToString(value);

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -8,9 +8,7 @@ import path from "node:path";
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-import sinon from "sinon";
-
-import { arbitrary, constants } from "./_.js";
+import * as sinon from "sinon";
 
 import * as unix from "../../../src/internal/unix.js";
 import * as bash from "../../../src/internal/unix/bash.js";
@@ -19,6 +17,8 @@ import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
 import { noShell } from "../../../src/internal/options.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const shells = [
   { module: bash, shellName: constants.binBash },

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -10,13 +10,13 @@ import test from "ava";
 import * as fc from "fast-check";
 import * as sinon from "sinon";
 
-import * as unix from "../../../src/internal/unix.js";
+import { noShell } from "../../../src/internal/options.js";
 import * as bash from "../../../src/internal/unix/bash.js";
 import * as csh from "../../../src/internal/unix/csh.js";
 import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
-import { noShell } from "../../../src/internal/options.js";
+import * as unix from "../../../src/internal/unix.js";
 
 import { arbitrary, constants } from "./_.js";
 

--- a/test/unit/unix/shells.test.js
+++ b/test/unit/unix/shells.test.js
@@ -7,13 +7,13 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { constants, fixtures, macros } from "./_.js";
-
 import * as bash from "../../../src/internal/unix/bash.js";
 import * as csh from "../../../src/internal/unix/csh.js";
 import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
+
+import { constants, fixtures, macros } from "./_.js";
 
 const shells = {
   [null]: nosh,

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -11,11 +11,11 @@ import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
 import * as sinon from "sinon";
 
-import * as win from "../../../src/internal/win.js";
+import { noShell } from "../../../src/internal/options.js";
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
-import { noShell } from "../../../src/internal/options.js";
+import * as win from "../../../src/internal/win.js";
 
 import { arbitrary, constants } from "./_.js";
 

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -9,15 +9,15 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
-import sinon from "sinon";
-
-import { arbitrary, constants } from "./_.js";
+import * as sinon from "sinon";
 
 import * as win from "../../../src/internal/win.js";
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
 import { noShell } from "../../../src/internal/options.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const shells = [
   { module: cmd, shellName: "cmd.exe" },

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -7,11 +7,11 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { constants, fixtures, macros } from "./_.js";
-
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
+
+import { constants, fixtures, macros } from "./_.js";
 
 const shells = {
   [null]: nosh,


### PR DESCRIPTION
Relates to #1803, #1812, #1815

## Summary

Start using [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) to enforce standardized `import`ing and `export`ing.

Interestingly, one of the reports from ESLint we get for this is about the plugin itself :monocle_face: (from [eslint-plugin-depend](https://www.npmjs.com/package/eslint-plugin-depend)):

```
.../shescape/config/eslint.js
   5:1  error  "eslint-plugin-import" should be replaced with an alternative package. Read more here: https://github.com/es-tooling/module-replacements/blob/main/docs/modules/eslint-plugin-import.md  depend/ban-dependencies
```