### PR TITLE
Add `eslint-plugin-import-x`

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,13 +1,13 @@
 // Configuration file for ESLint (https://eslint.org/)
 
+import top from "@ericcornelissen/eslint-plugin-top";
+import json from "@eslint/json";
+import markdown from "@eslint/markdown";
 import ava from "eslint-plugin-ava";
 import depend from "eslint-plugin-depend";
 import imports from "eslint-plugin-import-x";
 import jsdoc from "eslint-plugin-jsdoc";
-import json from "@eslint/json";
-import markdown from "@eslint/markdown";
 import regexp from "eslint-plugin-regexp";
-import top from "@ericcornelissen/eslint-plugin-top";
 import unicorn from "eslint-plugin-unicorn";
 import yml from "eslint-plugin-yml";
 
@@ -941,6 +941,10 @@ export default [
       "imports/order": [
         "error",
         {
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
           "newlines-between": "always",
         },
       ],

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -2,6 +2,7 @@
 
 import ava from "eslint-plugin-ava";
 import depend from "eslint-plugin-depend";
+import imports from "eslint-plugin-import-x";
 import jsdoc from "eslint-plugin-jsdoc";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
@@ -890,6 +891,64 @@ export default [
     },
   },
   {
+    name: "Imports",
+    files: ["**/*.js"],
+    plugins: { imports },
+    rules: {
+      // https://github.com/un-ts/eslint-plugin-import-x#readme
+      "imports/consistent-type-specifier-style": ["error"],
+      "imports/default": ["error"],
+      "imports/export": ["error"],
+      "imports/exports-last": ["off"],
+      "imports/extensions": ["error", "always", { ignorePackages: true }],
+      "imports/first": ["error"],
+      "imports/group-exports": ["off"],
+      "imports/imports-first": ["error"],
+      "imports/max-dependencies": ["off"],
+      "imports/named": ["error"],
+      "imports/namespace": ["error"],
+      "imports/newline-after-import": ["error"],
+      "imports/no-absolute-path": ["error"],
+      "imports/no-amd": ["error"],
+      "imports/no-anonymous-default-export": ["error"],
+      "imports/no-commonjs": ["error"],
+      "imports/no-cycle": ["error"],
+      "imports/no-default-export": ["error"],
+      "imports/no-deprecated": ["error"],
+      "imports/no-duplicates": ["error"],
+      "imports/no-dynamic-require": ["error"],
+      "imports/no-empty-named-blocks": ["error"],
+      "imports/no-extraneous-dependencies": ["error"],
+      "imports/no-import-module-exports": ["error"],
+      "imports/no-internal-modules": ["off"],
+      "imports/no-mutable-exports": ["error"],
+      "imports/no-named-as-default": ["error"],
+      "imports/no-named-as-default-member": ["error"],
+      "imports/no-named-default": ["error"],
+      "imports/no-named-export": ["off"],
+      "imports/no-namespace": ["off"],
+      "imports/no-nodejs-modules": ["off"],
+      "imports/no-relative-packages": ["error"],
+      "imports/no-relative-parent-imports": ["off"],
+      "imports/no-rename-default": ["off"],
+      "imports/no-restricted-paths": ["error"],
+      "imports/no-self-import": ["error"],
+      "imports/no-unassigned-import": ["off"],
+      "imports/no-unresolved": ["error"],
+      "imports/no-unused-modules": ["error"],
+      "imports/no-useless-path-segments": ["error"],
+      "imports/no-webpack-loader-syntax": ["error"],
+      "imports/order": [
+        "error",
+        {
+          "newlines-between": "always",
+        },
+      ],
+      "imports/prefer-default-export": ["off"],
+      "imports/unambiguous": ["error"],
+    },
+  },
+  {
     name: "Source",
     files: ["src/**/*.js"],
     plugins: { jsdoc, top },
@@ -924,7 +983,7 @@ export default [
   {
     name: "Tests",
     files: ["test/**/*.js"],
-    plugins: { ava, jsdoc },
+    plugins: { ava, imports, jsdoc, unicorn },
     rules: {
       "guard-for-in": ["off"],
       "id-length": [
@@ -935,15 +994,6 @@ export default [
       ],
       "no-magic-numbers": ["off"],
       "max-params": ["off"],
-
-      // https://github.com/gajus/eslint-plugin-jsdoc#readme
-      "jsdoc/check-values": [
-        "error",
-        {
-          allowedLicenses: ["MIT", "MPL-2.0"],
-        },
-      ],
-      "jsdoc/require-jsdoc": ["off"],
 
       // https://github.com/avajs/eslint-plugin-ava#readme
       "ava/assertion-arguments": ["error"],
@@ -979,6 +1029,18 @@ export default [
       "ava/use-test": ["error"],
       "ava/use-true-false": ["error"],
 
+      // https://github.com/un-ts/eslint-plugin-import-x#readme
+      "imports/no-unresolved": ["off"],
+
+      // https://github.com/gajus/eslint-plugin-jsdoc#readme
+      "jsdoc/check-values": [
+        "error",
+        {
+          allowedLicenses: ["MIT", "MPL-2.0"],
+        },
+      ],
+      "jsdoc/require-jsdoc": ["off"],
+
       // https://github.com/sindresorhus/eslint-plugin-unicorn#readme
       "unicorn/no-useless-undefined": ["off"],
     },
@@ -1007,9 +1069,13 @@ export default [
   {
     name: "Configs",
     files: ["config/**/*"],
-    plugins: { jsdoc },
+    plugins: { imports, jsdoc },
     rules: {
       "no-magic-numbers": ["off"],
+
+      // https://github.com/un-ts/eslint-plugin-import-x#readme
+      "imports/no-anonymous-default-export": ["off"],
+      "imports/no-default-export": ["off"],
 
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/require-file-overview": ["off"],
@@ -1106,10 +1172,16 @@ export default [
   {
     name: "Documentation Snippets",
     files: ["**/*.md/*.js"],
+    plugins: { imports, jsdoc, unicorn },
     rules: {
       "id-length": ["off"],
       "no-console": ["off"],
       "no-magic-numbers": ["off"],
+
+      // https://github.com/un-ts/eslint-plugin-import-x#readme
+      "imports/no-unresolved": ["off"],
+      "imports/order": ["off"],
+      "imports/unambiguous": ["off"],
 
       // https://github.com/gajus/eslint-plugin-jsdoc#readme
       "jsdoc/require-description-complete-sentence": ["off"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "9.20.1",
         "eslint-plugin-ava": "15.0.1",
         "eslint-plugin-depend": "0.12.0",
+        "eslint-plugin-import-x": "4.6.1",
         "eslint-plugin-jsdoc": "50.4.1",
         "eslint-plugin-regexp": "2.6.0",
         "eslint-plugin-unicorn": "57.0.0",
@@ -2697,6 +2698,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2789,6 +2797,107 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.25.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vercel/nft": {
       "version": "0.27.9",
@@ -5145,6 +5254,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
@@ -5273,6 +5395,20 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -5615,6 +5751,28 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-plugin-ava": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-15.0.1.tgz",
@@ -5679,6 +5837,34 @@
         "fd-package-json": "^1.2.0",
         "module-replacements": "^2.1.0",
         "semver": "^7.6.3"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.6.1.tgz",
+      "integrity": "sha512-wluSUifMIb7UfwWXqx7Yx0lE/SGCcGXECLx/9bCmbY2nneLwvAZ4vkd1IXDjPKFvdcdUgr1BaRnaRpx3k2+Pfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/doctrine": "^0.0.9",
+        "@typescript-eslint/scope-manager": "^8.1.0",
+        "@typescript-eslint/utils": "^8.1.0",
+        "debug": "^4.3.4",
+        "doctrine": "^3.0.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-import-resolver-node": "^0.3.9",
+        "get-tsconfig": "^4.7.3",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "semver": "^7.6.3",
+        "stable-hash": "^0.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
@@ -7753,6 +7939,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -13475,6 +13674,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -14539,6 +14745,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -14567,6 +14794,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/responselike": {
@@ -15319,6 +15556,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
+      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -15685,6 +15929,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
@@ -15812,6 +16069,16 @@
       },
       "engines": {
         "node": ">= 18.6.0"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar": {
@@ -16046,6 +16313,19 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -16224,7 +16504,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint": "9.20.1",
     "eslint-plugin-ava": "15.0.1",
     "eslint-plugin-depend": "0.12.0",
+    "eslint-plugin-import-x": "4.6.1",
     "eslint-plugin-jsdoc": "50.4.1",
     "eslint-plugin-regexp": "2.6.0",
     "eslint-plugin-unicorn": "57.0.0",
@@ -98,7 +99,7 @@
     "sinon": "19.0.2"
   },
   "scripts": {
-    "_eslint": "eslint --config config/eslint.js --report-unused-disable-directives",
+    "_eslint": "eslint --config config/eslint.js",
     "_prettier": "prettier . --ignore-path .gitignore",
     "audit": "npm-run-all audit:*",
     "audit:deprecations": "depreman --errors-only --report-unused",

--- a/src/internal/unix.js
+++ b/src/internal/unix.js
@@ -8,12 +8,12 @@ import * as path from "node:path";
 
 import which from "which";
 
+import { noShell } from "./options.js";
 import * as bash from "./unix/bash.js";
 import * as csh from "./unix/csh.js";
 import * as dash from "./unix/dash.js";
 import * as nosh from "./unix/no-shell.js";
 import * as zsh from "./unix/zsh.js";
-import { noShell } from "./options.js";
 
 /**
  * The name of the Bourne-again shell (Bash) binary.

--- a/src/internal/win.js
+++ b/src/internal/win.js
@@ -8,11 +8,11 @@ import * as path from "node:path";
 
 import which from "which";
 
+import { noShell } from "./options.js";
+import { hasOwn } from "./reflection.js";
 import * as cmd from "./win/cmd.js";
 import * as nosh from "./win/no-shell.js";
 import * as powershell from "./win/powershell.js";
-import { noShell } from "./options.js";
-import { hasOwn } from "./reflection.js";
 
 /**
  * The name of the Windows Command Prompt binary.

--- a/test/_runners.js
+++ b/test/_runners.js
@@ -7,9 +7,9 @@
 import assert from "node:assert";
 import cp from "node:child_process";
 
-import * as constants from "./_constants.js";
-
 import { Shescape } from "shescape";
+
+import * as constants from "./_constants.js";
 
 /**
  * Checks if the fuzz shell is CMD.

--- a/test/breakage/index.test.js
+++ b/test/breakage/index.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import { Shescape } from "shescape";
 import { Shescape as Previouscape } from "shescape-previous";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "Shescape#constructor",

--- a/test/breakage/stateless.test.js
+++ b/test/breakage/stateless.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import * as shescape from "shescape/stateless";
 import * as previouscape from "shescape-previous/stateless";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "shescape.escape",

--- a/test/breakage/testing.test.js
+++ b/test/breakage/testing.test.js
@@ -5,14 +5,13 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "./_.js";
-
 import { Stubscape, Throwscape } from "shescape/testing";
 import {
   Shescape as Previoustub,
   Throwscape as Previousthrow,
 } from "shescape-previous/testing";
+
+import { arbitrary } from "./_.js";
 
 testProp(
   "Stubscape#constructor",

--- a/test/compat/index.test.js
+++ b/test/compat/index.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import { Shescape } from "../../src/modules/index.js";
+
+import { arbitrary } from "./_.js";
 
 export function testShescapeEscape() {
   fc.assert(

--- a/test/compat/stateless.test.js
+++ b/test/compat/stateless.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import * as shescape from "../../src/modules/stateless.js";
+
+import { arbitrary } from "./_.js";
 
 export function testShescapeEscape() {
   fc.assert(

--- a/test/compat/testing.test.js
+++ b/test/compat/testing.test.js
@@ -6,9 +6,9 @@
 
 import * as fc from "fast-check";
 
-import { arbitrary } from "./_.js";
-
 import { Stubscape, Throwscape } from "../../src/modules/testing.js";
+
+import { arbitrary } from "./_.js";
 
 export function testStubscapeEscape() {
   fc.assert(

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -5,7 +5,6 @@
 
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
-
 import * as constants from "../_constants.js";
 
 /**

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -3,9 +3,9 @@
  * @license MIT
  */
 
+import * as constants from "../_constants.js";
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
-import * as constants from "../_constants.js";
 
 /**
  * Returns the test fixtures for the current platform.

--- a/test/integration/_generators.js
+++ b/test/integration/_generators.js
@@ -6,7 +6,7 @@
 import * as fixturesUnix from "../fixtures/unix.js";
 import * as fixturesWindows from "../fixtures/win.js";
 
-import { constants } from "./_.js";
+import * as constants from "../_constants.js";
 
 /**
  * Returns the test fixtures for the current platform.

--- a/test/integration/constructor/constructor.test.js
+++ b/test/integration/constructor/constructor.test.js
@@ -6,10 +6,9 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as ppTestKit from "pp-test-kit/manual";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "./_.js";
-
-import { Shescape } from "shescape";
 
 test("shell does not exist", (t) => {
   const shell = "not-actually-a-shell-that-exists";

--- a/test/integration/escape-all/bash.test.js
+++ b/test/integration/escape-all/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/escape-all/cmd-exe.test.js
+++ b/test/integration/escape-all/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/escape-all/cmd.test.js
+++ b/test/integration/escape-all/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/escape-all/commonjs.test.js
+++ b/test/integration/escape-all/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/escape-all/commonjs.test.js
+++ b/test/integration/escape-all/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/escape-all/csh.test.js
+++ b/test/integration/escape-all/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/escape-all/dash.test.js
+++ b/test/integration/escape-all/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/escape-all/invalid.test.js
+++ b/test/integration/escape-all/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp("invalid arguments", [arbitrary.shescapeOptions()], (t, options) => {
   let shescape;

--- a/test/integration/escape-all/no-shell.test.js
+++ b/test/integration/escape-all/no-shell.test.js
@@ -4,10 +4,9 @@
  */
 
 import test from "ava";
+import { Shescape } from "shescape";
 
 import { generate } from "../_.js";
-
-import { Shescape } from "shescape";
 
 test(`input is escaped for no shell`, (t) => {
   for (const scenario of generate.escapeExamples(false)) {

--- a/test/integration/escape-all/powershell-exe.test.js
+++ b/test/integration/escape-all/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/escape-all/powershell.test.js
+++ b/test/integration/escape-all/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/escape-all/valid.test.js
+++ b/test/integration/escape-all/valid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "return values",

--- a/test/integration/escape-all/zsh.test.js
+++ b/test/integration/escape-all/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/escape/bash.test.js
+++ b/test/integration/escape/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/escape/cmd-exe.test.js
+++ b/test/integration/escape/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/escape/cmd.test.js
+++ b/test/integration/escape/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/escape/commonjs.test.js
+++ b/test/integration/escape/commonjs.test.js
@@ -7,8 +7,8 @@
 import { testProp } from "@fast-check/ava";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/escape/commonjs.test.js
+++ b/test/integration/escape/commonjs.test.js
@@ -5,10 +5,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/escape/csh.test.js
+++ b/test/integration/escape/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/escape/dash.test.js
+++ b/test/integration/escape/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/escape/invalid.test.js
+++ b/test/integration/escape/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp("invalid arguments", [arbitrary.shescapeOptions()], (t, options) => {
   let shescape;

--- a/test/integration/escape/no-shell.test.js
+++ b/test/integration/escape/no-shell.test.js
@@ -4,10 +4,9 @@
  */
 
 import test from "ava";
+import { Shescape } from "shescape";
 
 import { generate } from "../_.js";
-
-import { Shescape } from "shescape";
 
 test(`input is escaped for no shell`, (t) => {
   for (const scenario of generate.escapeExamples(false)) {

--- a/test/integration/escape/powershell-exe.test.js
+++ b/test/integration/escape/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/escape/powershell.test.js
+++ b/test/integration/escape/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/escape/valid.test.js
+++ b/test/integration/escape/valid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "return values",

--- a/test/integration/escape/zsh.test.js
+++ b/test/integration/escape/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/quote-all/bash.test.js
+++ b/test/integration/quote-all/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/quote-all/cmd-exe.test.js
+++ b/test/integration/quote-all/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/quote-all/cmd.test.js
+++ b/test/integration/quote-all/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/quote-all/commonjs.test.js
+++ b/test/integration/quote-all/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/quote-all/commonjs.test.js
+++ b/test/integration/quote-all/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/quote-all/csh.test.js
+++ b/test/integration/quote-all/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/quote-all/dash.test.js
+++ b/test/integration/quote-all/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/quote-all/invalid.test.js
+++ b/test/integration/quote-all/invalid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "quote without shell",

--- a/test/integration/quote-all/powershell-exe.test.js
+++ b/test/integration/quote-all/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/quote-all/powershell.test.js
+++ b/test/integration/quote-all/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/quote-all/valid.test.js
+++ b/test/integration/quote-all/valid.test.js
@@ -5,10 +5,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "quote with shell",

--- a/test/integration/quote-all/zsh.test.js
+++ b/test/integration/quote-all/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/quote/bash.test.js
+++ b/test/integration/quote/bash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binBash);
 

--- a/test/integration/quote/cmd-exe.test.js
+++ b/test/integration/quote/cmd-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmd);
 

--- a/test/integration/quote/cmd.test.js
+++ b/test/integration/quote/cmd.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCmdNoExt);
 

--- a/test/integration/quote/commonjs.test.js
+++ b/test/integration/quote/commonjs.test.js
@@ -7,8 +7,8 @@
 import { testProp } from "@fast-check/ava";
 import { Shescape } from "shescape";
 
-import { arbitrary } from "../_.js";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "esm === cjs",

--- a/test/integration/quote/commonjs.test.js
+++ b/test/integration/quote/commonjs.test.js
@@ -5,10 +5,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 import { Shescape as ShescapeCjs } from "../../../src/modules/index.cjs";
 
 testProp(

--- a/test/integration/quote/csh.test.js
+++ b/test/integration/quote/csh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binCsh);
 

--- a/test/integration/quote/dash.test.js
+++ b/test/integration/quote/dash.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binDash);
 

--- a/test/integration/quote/invalid.test.js
+++ b/test/integration/quote/invalid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary, constants } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "without shell",

--- a/test/integration/quote/powershell-exe.test.js
+++ b/test/integration/quote/powershell-exe.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShell);
 

--- a/test/integration/quote/powershell.test.js
+++ b/test/integration/quote/powershell.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binPowerShellNoExt);
 

--- a/test/integration/quote/valid.test.js
+++ b/test/integration/quote/valid.test.js
@@ -4,10 +4,9 @@
  */
 
 import { testProp } from "@fast-check/ava";
+import { Shescape } from "shescape";
 
 import { arbitrary } from "../_.js";
-
-import { Shescape } from "shescape";
 
 testProp(
   "with shell",

--- a/test/integration/quote/zsh.test.js
+++ b/test/integration/quote/zsh.test.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { common, constants, generate } from "../_.js";
-
 import { Shescape } from "shescape";
+
+import { common, constants, generate } from "../_.js";
 
 const runTest = common.getTestFn(constants.binZsh);
 

--- a/test/integration/stateless/commonjs.test.js
+++ b/test/integration/stateless/commonjs.test.js
@@ -6,10 +6,9 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
+import * as shescape from "shescape/stateless";
 
 import { arbitrary } from "../_.js";
-
-import * as shescape from "shescape/stateless";
 import * as shescapeCjs from "../../../src/modules/stateless.cjs";
 
 testProp(

--- a/test/integration/stateless/commonjs.test.js
+++ b/test/integration/stateless/commonjs.test.js
@@ -8,8 +8,8 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import * as shescape from "shescape/stateless";
 
-import { arbitrary } from "../_.js";
 import * as shescapeCjs from "../../../src/modules/stateless.cjs";
+import { arbitrary } from "../_.js";
 
 testProp(
   "shescape.escape (esm === cjs)",

--- a/test/integration/stateless/functional.test.js
+++ b/test/integration/stateless/functional.test.js
@@ -5,11 +5,10 @@
 
 import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import { Shescape } from "shescape";
 import * as shescape from "shescape/stateless";
+
+import { arbitrary } from "../_.js";
 
 testProp(
   "shescape.escape",

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -14,13 +14,13 @@ import {
   Throwscape,
 } from "shescape/testing";
 
-import { arbitrary } from "../_.js";
 import {
   injectionStrings as injectionStringsCjs,
   Failscape as FailscapeCjs,
   Stubscape as StubscapeCjs,
   Throwscape as ThrowscapeCjs,
 } from "../../../src/modules/testing.cjs";
+import { arbitrary } from "../_.js";
 
 test("injection strings", (t) => {
   for (const injectionStringCjs of injectionStringsCjs) {

--- a/test/integration/testing/commonjs.test.js
+++ b/test/integration/testing/commonjs.test.js
@@ -7,15 +7,14 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import {
   injectionStrings,
   Failscape,
   Stubscape,
   Throwscape,
 } from "shescape/testing";
+
+import { arbitrary } from "../_.js";
 import {
   injectionStrings as injectionStringsCjs,
   Failscape as FailscapeCjs,

--- a/test/integration/testing/functional.test.js
+++ b/test/integration/testing/functional.test.js
@@ -7,9 +7,6 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-
-import { arbitrary } from "../_.js";
-
 import { Shescape } from "shescape";
 import {
   injectionStrings,
@@ -17,6 +14,8 @@ import {
   Stubscape,
   Throwscape,
 } from "shescape/testing";
+
+import { arbitrary } from "../_.js";
 
 test("injection strings", (t) => {
   t.true(Array.isArray(injectionStrings));

--- a/test/unit/executables/resolve.test.js
+++ b/test/unit/executables/resolve.test.js
@@ -7,11 +7,11 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
-import sinon from "sinon";
-
-import { arbitrary } from "./_.js";
+import * as sinon from "sinon";
 
 import { resolveExecutable } from "../../../src/internal/executables.js";
+
+import { arbitrary } from "./_.js";
 
 test.before((t) => {
   const executable = "/bin/sh";

--- a/test/unit/options/parse-options.test.js
+++ b/test/unit/options/parse-options.test.js
@@ -6,12 +6,12 @@
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-import sinon from "sinon";
-
-import { arbitrary } from "./_.js";
+import * as sinon from "sinon";
 
 import { resolveExecutable } from "../../../src/internal/executables.js";
 import { noShell, parseOptions } from "../../../src/internal/options.js";
+
+import { arbitrary } from "./_.js";
 
 const arbitraryInput = () =>
   fc

--- a/test/unit/platforms/get-helpers.test.js
+++ b/test/unit/platforms/get-helpers.test.js
@@ -8,11 +8,11 @@ import { testProp } from "@fast-check/ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
 
-import { arbitrary, constants } from "./_.js";
-
 import { getHelpersByPlatform } from "../../../src/internal/platforms.js";
 import * as unix from "../../../src/internal/unix.js";
 import * as win from "../../../src/internal/win.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const unixPlatforms = [
   constants.osAix,

--- a/test/unit/reflection/checked-to-string.test.js
+++ b/test/unit/reflection/checked-to-string.test.js
@@ -9,9 +9,9 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { arbitrary, constants } from "./_.js";
-
 import { checkedToString } from "../../../src/internal/reflection.js";
+
+import { arbitrary, constants } from "./_.js";
 
 testProp("strings", [fc.string()], (t, value) => {
   const result = checkedToString(value);

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -8,9 +8,7 @@ import path from "node:path";
 import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
-import sinon from "sinon";
-
-import { arbitrary, constants } from "./_.js";
+import * as sinon from "sinon";
 
 import * as unix from "../../../src/internal/unix.js";
 import * as bash from "../../../src/internal/unix/bash.js";
@@ -19,6 +17,8 @@ import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
 import { noShell } from "../../../src/internal/options.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const shells = [
   { module: bash, shellName: constants.binBash },

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -10,13 +10,13 @@ import test from "ava";
 import * as fc from "fast-check";
 import * as sinon from "sinon";
 
-import * as unix from "../../../src/internal/unix.js";
+import { noShell } from "../../../src/internal/options.js";
 import * as bash from "../../../src/internal/unix/bash.js";
 import * as csh from "../../../src/internal/unix/csh.js";
 import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
-import { noShell } from "../../../src/internal/options.js";
+import * as unix from "../../../src/internal/unix.js";
 
 import { arbitrary, constants } from "./_.js";
 

--- a/test/unit/unix/shells.test.js
+++ b/test/unit/unix/shells.test.js
@@ -7,13 +7,13 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { constants, fixtures, macros } from "./_.js";
-
 import * as bash from "../../../src/internal/unix/bash.js";
 import * as csh from "../../../src/internal/unix/csh.js";
 import * as dash from "../../../src/internal/unix/dash.js";
 import * as nosh from "../../../src/internal/unix/no-shell.js";
 import * as zsh from "../../../src/internal/unix/zsh.js";
+
+import { constants, fixtures, macros } from "./_.js";
 
 const shells = {
   [null]: nosh,

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -11,11 +11,11 @@ import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
 import * as sinon from "sinon";
 
-import * as win from "../../../src/internal/win.js";
+import { noShell } from "../../../src/internal/options.js";
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
-import { noShell } from "../../../src/internal/options.js";
+import * as win from "../../../src/internal/win.js";
 
 import { arbitrary, constants } from "./_.js";
 

--- a/test/unit/win/index.test.js
+++ b/test/unit/win/index.test.js
@@ -9,15 +9,15 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 import * as ppTestKit from "pp-test-kit/simulate";
-import sinon from "sinon";
-
-import { arbitrary, constants } from "./_.js";
+import * as sinon from "sinon";
 
 import * as win from "../../../src/internal/win.js";
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
 import { noShell } from "../../../src/internal/options.js";
+
+import { arbitrary, constants } from "./_.js";
 
 const shells = [
   { module: cmd, shellName: "cmd.exe" },

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -7,11 +7,11 @@ import { testProp } from "@fast-check/ava";
 import test from "ava";
 import * as fc from "fast-check";
 
-import { constants, fixtures, macros } from "./_.js";
-
 import * as cmd from "../../../src/internal/win/cmd.js";
 import * as nosh from "../../../src/internal/win/no-shell.js";
 import * as powershell from "../../../src/internal/win/powershell.js";
+
+import { constants, fixtures, macros } from "./_.js";
 
 const shells = {
   [null]: nosh,


### PR DESCRIPTION
Relates to #1803, #1812, #1815, #1894

## Summary

Start using [eslint-plugin-import-x](https://www.npmjs.com/package/eslint-plugin-import-x) to enforce standardized `import`ing and `export`ing.

This dependency was chosen based on the recommendation by [eslint-plugin-depend](https://www.npmjs.com/package/eslint-plugin-depend) as an alternative to [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import).