### PR TITLE
Bump `runs-on:` values

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -280,7 +280,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
@@ -331,7 +331,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -284,7 +284,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
@@ -335,7 +335,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/fuzz-cmd.yml
+++ b/.github/workflows/fuzz-cmd.yml
@@ -26,6 +26,6 @@ jobs:
     uses: ./.github/workflows/reusable-fuzz.yml
     with:
       duration: 600 # seconds == 10 minutes
-      os: windows-2022
+      os: windows-2025
       shell: cmd.exe
       targets: '["exec", "exec-file", "spawn"]'

--- a/.github/workflows/fuzz-no-shell-win.yml
+++ b/.github/workflows/fuzz-no-shell-win.yml
@@ -26,6 +26,6 @@ jobs:
     uses: ./.github/workflows/reusable-fuzz.yml
     with:
       duration: 600 # seconds == 10 minutes
-      os: windows-2022
+      os: windows-2025
       shell: "" # false
       targets: '["exec-file", "fork", "spawn"]'

--- a/.github/workflows/fuzz-powershell.yml
+++ b/.github/workflows/fuzz-powershell.yml
@@ -26,6 +26,6 @@ jobs:
     uses: ./.github/workflows/reusable-fuzz.yml
     with:
       duration: 600 # seconds == 10 minutes
-      os: windows-2022
+      os: windows-2025
       shell: powershell.exe
       targets: '["exec", "exec-file", "spawn"]'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows


### PR DESCRIPTION
Relates to #576, #1416
Supersedes #1825

## Summary

Following <https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/>.