### PR TITLE
Support changing the release audit config

### DIFF
--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Insert release audit config
         env:
           NDMRC: ${{ vars.NDMRC }}
-          NPSRC: ${{ vars.NPSRC }}
+          NSPRC: ${{ vars.NSPRC }}
         run: |
           echo "${NDMRC}" | tee .ndmrc
-          echo "${NPSRC}" | tee .npsrc
+          echo "${NSPRC}" | tee .nsprc
       - name: Audit for vulnerabilities
         run: npm run audit:vulnerabilities:runtime
       - name: Audit for deprecation warnings


### PR DESCRIPTION
Relates to #1826

## Summary

Update the workflow to audit past releases with a step that loads the audit configuration from the GitHub Actions variables so that it can be changed if necessary, e.g. in case an audit warning is not relevant to the release (i.e. a new release is not necessary to resolve the warning).