### PR TITLE
Improve quoting for CMD

### DIFF
--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,6 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
+    .replace(/%/gu, '"%"')
     .replace(/"(.*)</gu, '"$1^<')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -33,7 +33,10 @@ export function getEscapeFunction() {
  * @returns {string} The escaped argument.
  */
 function escapeArgForQuoted(arg) {
-  return escapeArg(arg)
+  return arg
+    .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
+    .replace(/\n/gu, " ")
+    .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -33,7 +33,9 @@ export function getEscapeFunction() {
  * @returns {string} The escaped argument.
  */
 function escapeArgForQuoted(arg) {
-  return escapeArg(arg).replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
+  return escapeArg(arg)
+    .replace(/(?<!\\)(\\*)$/gu, "$1$1")
+    .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }
 
 /**

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -36,9 +36,9 @@ function escapeArgForQuoted(arg) {
   return arg
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
-    .replace(/(?<!\\)(\\*)(?="|$)/gu, "$1$1")
     .replace(/"/gu, '""')
-    .replace(/([%&<>^|])/gu, '"^$1"');
+    .replace(/([%&<>^|])/gu, '"^$1"')
+    .replace(/(?<!\\)(\\*)(?="|$)/gu, "$1$1");
 }
 
 /**

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([<^|])/gu, "^$1")
+    .replace(/([<^])/gu, "^$1")
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,8 +37,8 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([%&<>^|])/gu, '"^$1"')
-    .replace(/\\|/gu, '"|"')
+    .replace(/([%&<>^])/gu, '"^$1"')
+    .replace(/([%|])/gu, '"$1"')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1");
 }
 

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,8 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/%/gu, '"%"')
-    .replace(/"(.*)</gu, '"$1^<')
+    .replace(/(["%&<>^|])/gu, '"^$1"')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1");
 }
 

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([<^])/gu, "^$1")
+    .replace(/([\^])/gu, "^$1")
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,6 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([\^])/gu, "^$1")
     .replace(/"(.*)</gu, '"$1^<')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -38,8 +38,7 @@ function escapeArgForQuoted(arg) {
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
     .replace(/"(.*)</gu, '"$1^<')
-    .replace(/(?<!\\)(\\*)$/gu, "$1$1")
-    .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
+    .replace(/(?<!\\)(\\*)$/gu, "$1$1");
 }
 
 /**

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -38,6 +38,7 @@ function escapeArgForQuoted(arg) {
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
     .replace(/([\^])/gu, "^$1")
+    .replace(/"</gu, '"^<')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,8 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/(["%&<>^|])/gu, '"^$1"')
+    .replace(/([%&<>^|])/gu, '"^$1"')
+    .replace(/\\|/gu, '"|"')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1");
 }
 

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([%<>^|])/gu, "^$1")
+    .replace(/([<>^|])/gu, "^$1")
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,6 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
+    .replace(/([%<>^|])/gu, "^$1")
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -36,10 +36,9 @@ function escapeArgForQuoted(arg) {
   return arg
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
-    .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([%&<>^])/gu, '"^$1"')
-    .replace(/([%|])/gu, '"$1"')
-    .replace(/(?<!\\)(\\*)$/gu, "$1$1");
+    .replace(/(?<!\\)(\\*)(?="|$)/gu, "$1$1")
+    .replace(/"/gu, '""')
+    .replace(/([%&<>^|])/gu, '"^$1"');
 }
 
 /**

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -38,7 +38,7 @@ function escapeArgForQuoted(arg) {
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
     .replace(/([\^])/gu, "^$1")
-    .replace(/"</gu, '"^<')
+    .replace(/"(.*)</gu, '"$1^<')
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -43,7 +43,7 @@ function escapeArgForQuoted(arg) {
  * @returns {string} The quoted argument.
  */
 function quoteArg(arg) {
-  return arg.replace(/([\t ]+)/gu, '"$1"');
+  return `"${arg}"`;
 }
 
 /**

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -37,7 +37,7 @@ function escapeArgForQuoted(arg) {
     .replace(/[\0\u0008\r\u001B\u009B]/gu, "")
     .replace(/\n/gu, " ")
     .replace(/(?<!\\)(\\*)"/gu, '$1$1\\"')
-    .replace(/([<>^|])/gu, "^$1")
+    .replace(/([<^|])/gu, "^$1")
     .replace(/(?<!\\)(\\*)$/gu, "$1$1")
     .replace(/(?<!\\)(\\*)([\t ])/gu, "$1$1$2");
 }

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -4490,47 +4490,47 @@ export const quote = {
     "double quotes ('\"')": [
       {
         input: 'a"b',
-        expected: '"a\\^"b"',
+        expected: '"a\\"b"',
       },
       {
         input: 'a"b"c',
-        expected: '"a\\^"b\\^"c"',
+        expected: '"a\\"b\\"c"',
       },
       {
         input: 'a"',
-        expected: '"a\\^""',
+        expected: '"a\\""',
       },
       {
         input: '"a',
-        expected: '"\\^"a"',
+        expected: '"\\"a"',
       },
       {
         input: 'a""b',
-        expected: '"a\\^"\\^"b"',
+        expected: '"a\\"\\"b"',
       },
     ],
     "double quotes ('\"') + whitespace": [
       {
         input: 'a "b',
-        expected: '"a \\^"b"',
+        expected: '"a \\"b"',
       },
       {
         input: 'a" b',
-        expected: '"a\\^" b"',
+        expected: '"a\\" b"',
       },
       {
         input: 'a " b',
-        expected: '"a \\^" b"',
+        expected: '"a \\" b"',
       },
     ],
     "double quotes ('\"') + backslashes ('\\')": [
       {
         input: 'a\\"b',
-        expected: '"a\\\\\\^"b"',
+        expected: '"a\\\\\\"b"',
       },
       {
         input: 'a\\\\"b',
-        expected: '"a\\\\\\\\\\^"b"',
+        expected: '"a\\\\\\\\\\"b"',
       },
     ],
     "backticks ('`')": [
@@ -4572,15 +4572,15 @@ export const quote = {
     "carets ('^') + double quotes ('\"')": [
       {
         input: 'a"b^c',
-        expected: '"a\\^"b^^c"',
+        expected: '"a\\"b^^c"',
       },
       {
         input: 'a"b"c^d',
-        expected: '"a\\^"b\\^"c^^d"',
+        expected: '"a\\"b\\"c^^d"',
       },
       {
         input: 'a^b"c',
-        expected: '"a^^b\\^"c"',
+        expected: '"a^^b\\"c"',
       },
     ],
     "dollar signs ('$')": [
@@ -4604,65 +4604,65 @@ export const quote = {
     "percentage signs ('%')": [
       {
         input: "a%b",
-        expected: '"a^%b"',
+        expected: '"a%b"',
       },
       {
         input: "a%b%c",
-        expected: '"a^%b^%c"',
+        expected: '"a%b%c"',
       },
       {
         input: "a%",
-        expected: '"a^%"',
+        expected: '"a%"',
       },
       {
         input: "%a",
-        expected: '"^%a"',
+        expected: '"%a"',
       },
     ],
     "percentage signs ('%') + double quotes ('\"')": [
       {
         input: 'a"b%c',
-        expected: '"a\\^"b^%c"',
+        expected: '"a\\"b%c"',
       },
       {
         input: 'a"b"c%d',
-        expected: '"a\\^"b\\^"c^%d"',
+        expected: '"a\\"b\\"c%d"',
       },
       {
         input: 'a%b"c',
-        expected: '"a^%b\\^"c"',
+        expected: '"a%b\\"c"',
       },
     ],
     "ampersands ('&')": [
       {
         input: "a&b",
-        expected: '"a^&b"',
+        expected: '"a&b"',
       },
       {
         input: "a&b&c",
-        expected: '"a^&b^&c"',
+        expected: '"a&b&c"',
       },
       {
         input: "a&",
-        expected: '"a^&"',
+        expected: '"a&"',
       },
       {
         input: "&a",
-        expected: '"^&a"',
+        expected: '"&a"',
       },
     ],
     "ampersands ('&') + double quotes ('\"')": [
       {
         input: 'a"b&c',
-        expected: '"a\\^"b^&c"',
+        expected: '"a\\"b&c"',
       },
       {
         input: 'a"b"c&d',
-        expected: '"a\\^"b\\^"c^&d"',
+        expected: '"a\\"b\\"c&d"',
       },
       {
         input: 'a&b"c',
-        expected: '"a^&b\\^"c"',
+        expected: '"a&b\\"c"',
       },
     ],
     "hyphens ('-')": [
@@ -4704,97 +4704,97 @@ export const quote = {
     "pipes ('|')": [
       {
         input: "a|b",
-        expected: '"a^|b"',
+        expected: '"a|b"',
       },
       {
         input: "a|b|c",
-        expected: '"a^|b^|c"',
+        expected: '"a|b|c"',
       },
       {
         input: "a|",
-        expected: '"a^|"',
+        expected: '"a|"',
       },
       {
         input: "|a",
-        expected: '"^|a"',
+        expected: '"|a"',
       },
     ],
     "pipes ('|') + double quotes ('\"')": [
       {
         input: 'a"b|c',
-        expected: '"a\\^"b^|c"',
+        expected: '"a\\"b|c"',
       },
       {
         input: 'a"b"c|d',
-        expected: '"a\\^"b\\^"c^|d"',
+        expected: '"a\\"b\\"c|d"',
       },
       {
         input: 'a|b"c',
-        expected: '"a^|b\\^"c"',
+        expected: '"a|b\\"c"',
       },
     ],
     "angle brackets ('<', '>')": [
       {
         input: "a<b",
-        expected: '"a^<b"',
+        expected: '"a<b"',
       },
       {
         input: "a<b<c",
-        expected: '"a^<b^<c"',
+        expected: '"a<b<c"',
       },
       {
         input: "a<",
-        expected: '"a^<"',
+        expected: '"a<"',
       },
       {
         input: "<a",
-        expected: '"^<a"',
+        expected: '"<a"',
       },
       {
         input: "a>b",
-        expected: '"a^>b"',
+        expected: '"a>b"',
       },
       {
         input: "a>b>c",
-        expected: '"a^>b^>c"',
+        expected: '"a>b>c"',
       },
       {
         input: "a>",
-        expected: '"a^>"',
+        expected: '"a>"',
       },
       {
         input: ">a",
-        expected: '"^>a"',
+        expected: '">a"',
       },
       {
         input: "a<b>c",
-        expected: '"a^<b^>c"',
+        expected: '"a<b>c"',
       },
     ],
     "angle brackets ('<', '>') + double quotes ('\"')": [
       {
         input: 'a"b>c',
-        expected: '"a\\^"b^>c"',
+        expected: '"a\\"b>c"',
       },
       {
         input: 'a"b<c',
-        expected: '"a\\^"b^<c"',
+        expected: '"a\\"b<c"',
       },
       {
         input: 'a"b"c>d',
-        expected: '"a\\^"b\\^"c^>d"',
+        expected: '"a\\"b\\"c>d"',
       },
       {
         input: 'a"b"c<d',
-        expected: '"a\\^"b\\^"c^<d"',
+        expected: '"a\\"b\\"c<d"',
       },
       {
         input: 'a>b"c',
-        expected: '"a^>b\\^"c"',
+        expected: '"a>b\\"c"',
       },
       {
         input: 'a<b"c',
-        expected: '"a^<b\\^"c"',
+        expected: '"a<b\\"c"',
       },
     ],
     "left double quotation mark ('“')": [

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -4266,661 +4266,661 @@ export const quote = {
     "sample strings": [
       {
         input: "foobar",
-        expected: "foobar",
+        expected: '"foobar"',
       },
     ],
     "<null> (\\0)": [
       {
         input: "a\u0000b",
-        expected: "ab",
+        expected: '"ab"',
       },
       {
         input: "a\u0000b\u0000c",
-        expected: "abc",
+        expected: '"abc"',
       },
       {
         input: "a\u0000",
-        expected: "a",
+        expected: '"a"',
       },
       {
         input: "\u0000a",
-        expected: "a",
+        expected: '"a"',
       },
     ],
     "<backspace> (\\b)": [
       {
         input: "a\bb",
-        expected: "ab",
+        expected: '"ab"',
       },
       {
         input: "a\bb\bc",
-        expected: "abc",
+        expected: '"abc"',
       },
       {
         input: "a\b",
-        expected: "a",
+        expected: '"a"',
       },
       {
         input: "\ba",
-        expected: "a",
+        expected: '"a"',
       },
     ],
     "<character tabulation> (\\t)": [
       {
         input: "a\tb",
-        expected: 'a"\t"b',
+        expected: '"a\tb"',
       },
       {
         input: "a\tb\tc",
-        expected: 'a"\t"b"\t"c',
+        expected: '"a\tb\tc"',
       },
       {
         input: "a\t",
-        expected: 'a"\t"',
+        expected: '"a\t"',
       },
       {
         input: "\ta",
-        expected: '"\t"a',
+        expected: '"\ta"',
       },
       {
         input: "a\t\tb",
-        expected: 'a"\t\t"b',
+        expected: '"a\t\tb"',
       },
     ],
     "<character tabulation> (\\t) + space (' ')": [
       {
         input: "a\t b",
-        expected: 'a"\t "b',
+        expected: '"a\t b"',
       },
       {
         input: "a \tb",
-        expected: 'a" \t"b',
+        expected: '"a \tb"',
       },
     ],
     "<character tabulation> (\\t) + backslashes ('\\')": [
       {
         input: "a\\\tb",
-        expected: 'a\\\\"\t"b',
+        expected: '"a\\\\\tb"',
       },
       {
         input: "a\\\\\tb",
-        expected: 'a\\\\\\\\"\t"b',
+        expected: '"a\\\\\\\\\tb"',
       },
     ],
     "<end of line> (\\n)": [
       {
         input: "a\nb",
-        expected: 'a" "b',
+        expected: '"a b"',
       },
       {
         input: "a\nb\nc",
-        expected: 'a" "b" "c',
+        expected: '"a b c"',
       },
       {
         input: "a\n",
-        expected: 'a" "',
+        expected: '"a "',
       },
       {
         input: "\na",
-        expected: '" "a',
+        expected: '" a"',
       },
     ],
     "<carriage return> (\\r)": [
       {
         input: "a\rb",
-        expected: "ab",
+        expected: '"ab"',
       },
       {
         input: "a\rb\rc",
-        expected: "abc",
+        expected: '"abc"',
       },
       {
         input: "\ra",
-        expected: "a",
+        expected: '"a"',
       },
       {
         input: "a\r",
-        expected: "a",
+        expected: '"a"',
       },
     ],
     "<carriage return> (\\r) + <end of line> (\\n)": [
       {
         input: "a\r\nb",
-        expected: 'a" "b',
+        expected: '"a b"',
       },
       {
         input: "a\r\nb\r\nc",
-        expected: 'a" "b" "c',
+        expected: '"a b c"',
       },
       {
         input: "a\r\n",
-        expected: 'a" "',
+        expected: '"a "',
       },
       {
         input: "\r\na",
-        expected: '" "a',
+        expected: '" a"',
       },
     ],
     "<escape> (\\u001B)": [
       {
         input: "a\u001Bb",
-        expected: "ab",
+        expected: '"ab"',
       },
       {
         input: "a\u001Bb\u001Bc",
-        expected: "abc",
+        expected: '"abc"',
       },
       {
         input: "a\u001B",
-        expected: "a",
+        expected: '"a"',
       },
       {
         input: "\u001Ba",
-        expected: "a",
+        expected: '"a"',
       },
     ],
     "<space> (' ')": [
       {
         input: "a b",
-        expected: 'a" "b',
+        expected: '"a b"',
       },
       {
         input: "a b c",
-        expected: 'a" "b" "c',
+        expected: '"a b c"',
       },
       {
         input: "a ",
-        expected: 'a" "',
+        expected: '"a "',
       },
       {
         input: " a",
-        expected: '" "a',
+        expected: '" a"',
       },
       {
         input: "a  b",
-        expected: 'a"  "b',
+        expected: '"a  b"',
       },
     ],
     "<space> (' ') + backslashes ('\\')": [
       {
         input: "a\\ b",
-        expected: 'a\\\\" "b',
+        expected: '"a\\\\ b"',
       },
       {
         input: "a\\\\ b",
-        expected: 'a\\\\\\\\" "b',
+        expected: '"a\\\\\\\\ b"',
       },
     ],
     "<control sequence introducer> (\\u009B)": [
       {
         input: "a\u009Bb",
-        expected: "ab",
+        expected: '"ab"',
       },
       {
         input: "a\u009Bb\u009Bc",
-        expected: "abc",
+        expected: '"abc"',
       },
       {
         input: "a\u009B",
-        expected: "a",
+        expected: '"a"',
       },
       {
         input: "\u009Ba",
-        expected: "a",
+        expected: '"a"',
       },
     ],
     'single quotes ("\'")': [
       {
         input: "a'b",
-        expected: "a'b",
+        expected: '"a\'b"',
       },
       {
         input: "a'b'c",
-        expected: "a'b'c",
+        expected: "\"a'b'c\"",
       },
       {
         input: "a'",
-        expected: "a'",
+        expected: '"a\'"',
       },
       {
         input: "'a",
-        expected: "'a",
+        expected: '"\'a"',
       },
     ],
     "double quotes ('\"')": [
       {
         input: 'a"b',
-        expected: 'a\\^"b',
+        expected: '"a\\^"b"',
       },
       {
         input: 'a"b"c',
-        expected: 'a\\^"b\\^"c',
+        expected: '"a\\^"b\\^"c"',
       },
       {
         input: 'a"',
-        expected: 'a\\^"',
+        expected: '"a\\^""',
       },
       {
         input: '"a',
-        expected: '\\^"a',
+        expected: '"\\^"a"',
       },
       {
         input: 'a""b',
-        expected: 'a\\^"\\^"b',
+        expected: '"a\\^"\\^"b"',
       },
     ],
     "double quotes ('\"') + whitespace": [
       {
         input: 'a "b',
-        expected: 'a" "\\^"b',
+        expected: '"a \\^"b"',
       },
       {
         input: 'a" b',
-        expected: 'a\\^"" "b',
+        expected: '"a\\^" b"',
       },
       {
         input: 'a " b',
-        expected: 'a" "\\^"" "b',
+        expected: '"a \\^" b"',
       },
     ],
     "double quotes ('\"') + backslashes ('\\')": [
       {
         input: 'a\\"b',
-        expected: 'a\\\\\\^"b',
+        expected: '"a\\\\\\^"b"',
       },
       {
         input: 'a\\\\"b',
-        expected: 'a\\\\\\\\\\^"b',
+        expected: '"a\\\\\\\\\\^"b"',
       },
     ],
     "backticks ('`')": [
       {
         input: "a`b",
-        expected: "a`b",
+        expected: '"a`b"',
       },
       {
         input: "a`b`c",
-        expected: "a`b`c",
+        expected: '"a`b`c"',
       },
       {
         input: "a`",
-        expected: "a`",
+        expected: '"a`"',
       },
       {
         input: "`a",
-        expected: "`a",
+        expected: '"`a"',
       },
     ],
     "carets ('^')": [
       {
         input: "a^b",
-        expected: "a^^b",
+        expected: '"a^^b"',
       },
       {
         input: "a^b^c",
-        expected: "a^^b^^c",
+        expected: '"a^^b^^c"',
       },
       {
         input: "a^",
-        expected: "a^^",
+        expected: '"a^^"',
       },
       {
         input: "^a",
-        expected: "^^a",
+        expected: '"^^a"',
       },
     ],
     "carets ('^') + double quotes ('\"')": [
       {
         input: 'a"b^c',
-        expected: 'a\\^"b^^c',
+        expected: '"a\\^"b^^c"',
       },
       {
         input: 'a"b"c^d',
-        expected: 'a\\^"b\\^"c^^d',
+        expected: '"a\\^"b\\^"c^^d"',
       },
       {
         input: 'a^b"c',
-        expected: 'a^^b\\^"c',
+        expected: '"a^^b\\^"c"',
       },
     ],
     "dollar signs ('$')": [
       {
         input: "a$b",
-        expected: "a$b",
+        expected: '"a$b"',
       },
       {
         input: "a$b$c",
-        expected: "a$b$c",
+        expected: '"a$b$c"',
       },
       {
         input: "a$",
-        expected: "a$",
+        expected: '"a$"',
       },
       {
         input: "$a",
-        expected: "$a",
+        expected: '"$a"',
       },
     ],
     "percentage signs ('%')": [
       {
         input: "a%b",
-        expected: "a^%b",
+        expected: '"a^%b"',
       },
       {
         input: "a%b%c",
-        expected: "a^%b^%c",
+        expected: '"a^%b^%c"',
       },
       {
         input: "a%",
-        expected: "a^%",
+        expected: '"a^%"',
       },
       {
         input: "%a",
-        expected: "^%a",
+        expected: '"^%a"',
       },
     ],
     "percentage signs ('%') + double quotes ('\"')": [
       {
         input: 'a"b%c',
-        expected: 'a\\^"b^%c',
+        expected: '"a\\^"b^%c"',
       },
       {
         input: 'a"b"c%d',
-        expected: 'a\\^"b\\^"c^%d',
+        expected: '"a\\^"b\\^"c^%d"',
       },
       {
         input: 'a%b"c',
-        expected: 'a^%b\\^"c',
+        expected: '"a^%b\\^"c"',
       },
     ],
     "ampersands ('&')": [
       {
         input: "a&b",
-        expected: "a^&b",
+        expected: '"a^&b"',
       },
       {
         input: "a&b&c",
-        expected: "a^&b^&c",
+        expected: '"a^&b^&c"',
       },
       {
         input: "a&",
-        expected: "a^&",
+        expected: '"a^&"',
       },
       {
         input: "&a",
-        expected: "^&a",
+        expected: '"^&a"',
       },
     ],
     "ampersands ('&') + double quotes ('\"')": [
       {
         input: 'a"b&c',
-        expected: 'a\\^"b^&c',
+        expected: '"a\\^"b^&c"',
       },
       {
         input: 'a"b"c&d',
-        expected: 'a\\^"b\\^"c^&d',
+        expected: '"a\\^"b\\^"c^&d"',
       },
       {
         input: 'a&b"c',
-        expected: 'a^&b\\^"c',
+        expected: '"a^&b\\^"c"',
       },
     ],
     "hyphens ('-')": [
       {
         input: "a-b",
-        expected: "a-b",
+        expected: '"a-b"',
       },
       {
         input: "a-b-c",
-        expected: "a-b-c",
+        expected: '"a-b-c"',
       },
       {
         input: "a-",
-        expected: "a-",
+        expected: '"a-"',
       },
       {
         input: "-a",
-        expected: "-a",
+        expected: '"-a"',
       },
     ],
     "backslashes ('\\')": [
       {
         input: "a\\b",
-        expected: "a\\b",
+        expected: '"a\\b"',
       },
       {
         input: "a\\b\\c",
-        expected: "a\\b\\c",
+        expected: '"a\\b\\c"',
       },
       {
         input: "a\\",
-        expected: "a\\",
+        expected: '"a\\"',
       },
       {
         input: "\\a",
-        expected: "\\a",
+        expected: '"\\a"',
       },
     ],
     "pipes ('|')": [
       {
         input: "a|b",
-        expected: "a^|b",
+        expected: '"a^|b"',
       },
       {
         input: "a|b|c",
-        expected: "a^|b^|c",
+        expected: '"a^|b^|c"',
       },
       {
         input: "a|",
-        expected: "a^|",
+        expected: '"a^|"',
       },
       {
         input: "|a",
-        expected: "^|a",
+        expected: '"^|a"',
       },
     ],
     "pipes ('|') + double quotes ('\"')": [
       {
         input: 'a"b|c',
-        expected: 'a\\^"b^|c',
+        expected: '"a\\^"b^|c"',
       },
       {
         input: 'a"b"c|d',
-        expected: 'a\\^"b\\^"c^|d',
+        expected: '"a\\^"b\\^"c^|d"',
       },
       {
         input: 'a|b"c',
-        expected: 'a^|b\\^"c',
+        expected: '"a^|b\\^"c"',
       },
     ],
     "angle brackets ('<', '>')": [
       {
         input: "a<b",
-        expected: "a^<b",
+        expected: '"a^<b"',
       },
       {
         input: "a<b<c",
-        expected: "a^<b^<c",
+        expected: '"a^<b^<c"',
       },
       {
         input: "a<",
-        expected: "a^<",
+        expected: '"a^<"',
       },
       {
         input: "<a",
-        expected: "^<a",
+        expected: '"^<a"',
       },
       {
         input: "a>b",
-        expected: "a^>b",
+        expected: '"a^>b"',
       },
       {
         input: "a>b>c",
-        expected: "a^>b^>c",
+        expected: '"a^>b^>c"',
       },
       {
         input: "a>",
-        expected: "a^>",
+        expected: '"a^>"',
       },
       {
         input: ">a",
-        expected: "^>a",
+        expected: '"^>a"',
       },
       {
         input: "a<b>c",
-        expected: "a^<b^>c",
+        expected: '"a^<b^>c"',
       },
     ],
     "angle brackets ('<', '>') + double quotes ('\"')": [
       {
         input: 'a"b>c',
-        expected: 'a\\^"b^>c',
+        expected: '"a\\^"b^>c"',
       },
       {
         input: 'a"b<c',
-        expected: 'a\\^"b^<c',
+        expected: '"a\\^"b^<c"',
       },
       {
         input: 'a"b"c>d',
-        expected: 'a\\^"b\\^"c^>d',
+        expected: '"a\\^"b\\^"c^>d"',
       },
       {
         input: 'a"b"c<d',
-        expected: 'a\\^"b\\^"c^<d',
+        expected: '"a\\^"b\\^"c^<d"',
       },
       {
         input: 'a>b"c',
-        expected: 'a^>b\\^"c',
+        expected: '"a^>b\\^"c"',
       },
       {
         input: 'a<b"c',
-        expected: 'a^<b\\^"c',
+        expected: '"a^<b\\^"c"',
       },
     ],
     "left double quotation mark ('“')": [
       {
         input: "a“b",
-        expected: "a“b",
+        expected: '"a“b"',
       },
       {
         input: "a“b“c",
-        expected: "a“b“c",
+        expected: '"a“b“c"',
       },
       {
         input: "a“",
-        expected: "a“",
+        expected: '"a“"',
       },
       {
         input: "“a",
-        expected: "“a",
+        expected: '"“a"',
       },
     ],
     "right double quotation mark ('”')": [
       {
         input: "a”b",
-        expected: "a”b",
+        expected: '"a”b"',
       },
       {
         input: "a”b”c",
-        expected: "a”b”c",
+        expected: '"a”b”c"',
       },
       {
         input: "a”",
-        expected: "a”",
+        expected: '"a”"',
       },
       {
         input: "”a",
-        expected: "”a",
+        expected: '"”a"',
       },
     ],
     "double low-9 quotation mark ('„')": [
       {
         input: "a„b",
-        expected: "a„b",
+        expected: '"a„b"',
       },
       {
         input: "a„b„c",
-        expected: "a„b„c",
+        expected: '"a„b„c"',
       },
       {
         input: "a„",
-        expected: "a„",
+        expected: '"a„"',
       },
       {
         input: "„a",
-        expected: "„a",
+        expected: '"„a"',
       },
     ],
     "left single quotation mark ('‘')": [
       {
         input: "a‘b",
-        expected: "a‘b",
+        expected: '"a‘b"',
       },
       {
         input: "a‘b‘c",
-        expected: "a‘b‘c",
+        expected: '"a‘b‘c"',
       },
       {
         input: "a‘",
-        expected: "a‘",
+        expected: '"a‘"',
       },
       {
         input: "‘a",
-        expected: "‘a",
+        expected: '"‘a"',
       },
     ],
     "right single quotation mark ('’')": [
       {
         input: "a’b",
-        expected: "a’b",
+        expected: '"a’b"',
       },
       {
         input: "a’b’c",
-        expected: "a’b’c",
+        expected: '"a’b’c"',
       },
       {
         input: "a’",
-        expected: "a’",
+        expected: '"a’"',
       },
       {
         input: "’a",
-        expected: "’a",
+        expected: '"’a"',
       },
     ],
     "single low-9 quotation mark ('‚')": [
       {
         input: "a‚b",
-        expected: "a‚b",
+        expected: '"a‚b"',
       },
       {
         input: "a‚b‚c",
-        expected: "a‚b‚c",
+        expected: '"a‚b‚c"',
       },
       {
         input: "a‚",
-        expected: "a‚",
+        expected: '"a‚"',
       },
       {
         input: "‚a",
-        expected: "‚a",
+        expected: '"‚a"',
       },
     ],
     "single high-reversed-9 quotation mark ('‛')": [
       {
         input: "a‛b",
-        expected: "a‛b",
+        expected: '"a‛b"',
       },
       {
         input: "a‛b‛c",
-        expected: "a‛b‛c",
+        expected: '"a‛b‛c"',
       },
       {
         input: "a‛",
-        expected: "a‛",
+        expected: '"a‛"',
       },
       {
         input: "‛a",
-        expected: "‛a",
+        expected: '"‛a"',
       },
     ],
   },

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -4694,7 +4694,7 @@ export const quote = {
       },
       {
         input: "a\\",
-        expected: '"a\\"',
+        expected: '"a\\\\"',
       },
       {
         input: "\\a",

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -4340,11 +4340,11 @@ export const quote = {
     "<character tabulation> (\\t) + backslashes ('\\')": [
       {
         input: "a\\\tb",
-        expected: '"a\\\\\tb"',
+        expected: '"a\\\tb"',
       },
       {
         input: "a\\\\\tb",
-        expected: '"a\\\\\\\\\tb"',
+        expected: '"a\\\\\tb"',
       },
     ],
     "<end of line> (\\n)": [
@@ -4444,11 +4444,11 @@ export const quote = {
     "<space> (' ') + backslashes ('\\')": [
       {
         input: "a\\ b",
-        expected: '"a\\\\ b"',
+        expected: '"a\\ b"',
       },
       {
         input: "a\\\\ b",
-        expected: '"a\\\\\\\\ b"',
+        expected: '"a\\\\ b"',
       },
     ],
     "<control sequence introducer> (\\u009B)": [
@@ -4490,47 +4490,47 @@ export const quote = {
     "double quotes ('\"')": [
       {
         input: 'a"b',
-        expected: '"a\\"b"',
+        expected: '"a""b"',
       },
       {
         input: 'a"b"c',
-        expected: '"a\\"b\\"c"',
+        expected: '"a""b""c"',
       },
       {
         input: 'a"',
-        expected: '"a\\""',
+        expected: '"a"""',
       },
       {
         input: '"a',
-        expected: '"\\"a"',
+        expected: '"""a"',
       },
       {
         input: 'a""b',
-        expected: '"a\\"\\"b"',
+        expected: '"a""""b"',
       },
     ],
     "double quotes ('\"') + whitespace": [
       {
         input: 'a "b',
-        expected: '"a \\"b"',
+        expected: '"a ""b"',
       },
       {
         input: 'a" b',
-        expected: '"a\\" b"',
+        expected: '"a"" b"',
       },
       {
         input: 'a " b',
-        expected: '"a \\" b"',
+        expected: '"a "" b"',
       },
     ],
     "double quotes ('\"') + backslashes ('\\')": [
       {
         input: 'a\\"b',
-        expected: '"a\\\\\\"b"',
+        expected: '"a\\\\""b"',
       },
       {
         input: 'a\\\\"b',
-        expected: '"a\\\\\\\\\\"b"',
+        expected: '"a\\\\\\\\""b"',
       },
     ],
     "backticks ('`')": [
@@ -4554,33 +4554,33 @@ export const quote = {
     "carets ('^')": [
       {
         input: "a^b",
-        expected: '"a^^b"',
+        expected: '"a"^^"b"',
       },
       {
         input: "a^b^c",
-        expected: '"a^^b^^c"',
+        expected: '"a"^^"b"^^"c"',
       },
       {
         input: "a^",
-        expected: '"a^^"',
+        expected: '"a"^^""',
       },
       {
         input: "^a",
-        expected: '"^^a"',
+        expected: '""^^"a"',
       },
     ],
     "carets ('^') + double quotes ('\"')": [
       {
         input: 'a"b^c',
-        expected: '"a\\"b^^c"',
+        expected: '"a""b"^^"c"',
       },
       {
         input: 'a"b"c^d',
-        expected: '"a\\"b\\"c^^d"',
+        expected: '"a""b""c"^^"d"',
       },
       {
         input: 'a^b"c',
-        expected: '"a^^b\\"c"',
+        expected: '"a"^^"b""c"',
       },
     ],
     "dollar signs ('$')": [
@@ -4604,65 +4604,65 @@ export const quote = {
     "percentage signs ('%')": [
       {
         input: "a%b",
-        expected: '"a%b"',
+        expected: '"a"^%"b"',
       },
       {
         input: "a%b%c",
-        expected: '"a%b%c"',
+        expected: '"a"^%"b"^%"c"',
       },
       {
         input: "a%",
-        expected: '"a%"',
+        expected: '"a"^%""',
       },
       {
         input: "%a",
-        expected: '"%a"',
+        expected: '""^%"a"',
       },
     ],
     "percentage signs ('%') + double quotes ('\"')": [
       {
         input: 'a"b%c',
-        expected: '"a\\"b%c"',
+        expected: '"a""b"^%"c"',
       },
       {
         input: 'a"b"c%d',
-        expected: '"a\\"b\\"c%d"',
+        expected: '"a""b""c"^%"d"',
       },
       {
         input: 'a%b"c',
-        expected: '"a%b\\"c"',
+        expected: '"a"^%"b""c"',
       },
     ],
     "ampersands ('&')": [
       {
         input: "a&b",
-        expected: '"a&b"',
+        expected: '"a"^&"b"',
       },
       {
         input: "a&b&c",
-        expected: '"a&b&c"',
+        expected: '"a"^&"b"^&"c"',
       },
       {
         input: "a&",
-        expected: '"a&"',
+        expected: '"a"^&""',
       },
       {
         input: "&a",
-        expected: '"&a"',
+        expected: '""^&"a"',
       },
     ],
     "ampersands ('&') + double quotes ('\"')": [
       {
         input: 'a"b&c',
-        expected: '"a\\"b&c"',
+        expected: '"a""b"^&"c"',
       },
       {
         input: 'a"b"c&d',
-        expected: '"a\\"b\\"c&d"',
+        expected: '"a""b""c"^&"d"',
       },
       {
         input: 'a&b"c',
-        expected: '"a&b\\"c"',
+        expected: '"a"^&"b""c"',
       },
     ],
     "hyphens ('-')": [
@@ -4704,97 +4704,97 @@ export const quote = {
     "pipes ('|')": [
       {
         input: "a|b",
-        expected: '"a|b"',
+        expected: '"a"^|"b"',
       },
       {
         input: "a|b|c",
-        expected: '"a|b|c"',
+        expected: '"a"^|"b"^|"c"',
       },
       {
         input: "a|",
-        expected: '"a|"',
+        expected: '"a"^|""',
       },
       {
         input: "|a",
-        expected: '"|a"',
+        expected: '""^|"a"',
       },
     ],
     "pipes ('|') + double quotes ('\"')": [
       {
         input: 'a"b|c',
-        expected: '"a\\"b|c"',
+        expected: '"a""b"^|"c"',
       },
       {
         input: 'a"b"c|d',
-        expected: '"a\\"b\\"c|d"',
+        expected: '"a""b""c"^|"d"',
       },
       {
         input: 'a|b"c',
-        expected: '"a|b\\"c"',
+        expected: '"a"^|"b""c"',
       },
     ],
     "angle brackets ('<', '>')": [
       {
         input: "a<b",
-        expected: '"a<b"',
+        expected: '"a"^<"b"',
       },
       {
         input: "a<b<c",
-        expected: '"a<b<c"',
+        expected: '"a"^<"b"^<"c"',
       },
       {
         input: "a<",
-        expected: '"a<"',
+        expected: '"a"^<""',
       },
       {
         input: "<a",
-        expected: '"<a"',
+        expected: '""^<"a"',
       },
       {
         input: "a>b",
-        expected: '"a>b"',
+        expected: '"a"^>"b"',
       },
       {
         input: "a>b>c",
-        expected: '"a>b>c"',
+        expected: '"a"^>"b"^>"c"',
       },
       {
         input: "a>",
-        expected: '"a>"',
+        expected: '"a"^>""',
       },
       {
         input: ">a",
-        expected: '">a"',
+        expected: '""^>"a"',
       },
       {
         input: "a<b>c",
-        expected: '"a<b>c"',
+        expected: '"a"^<"b"^>"c"',
       },
     ],
     "angle brackets ('<', '>') + double quotes ('\"')": [
       {
         input: 'a"b>c',
-        expected: '"a\\"b>c"',
+        expected: '"a""b"^>"c"',
       },
       {
         input: 'a"b<c',
-        expected: '"a\\"b<c"',
+        expected: '"a""b"^<"c"',
       },
       {
         input: 'a"b"c>d',
-        expected: '"a\\"b\\"c>d"',
+        expected: '"a""b""c"^>"d"',
       },
       {
         input: 'a"b"c<d',
-        expected: '"a\\"b\\"c<d"',
+        expected: '"a""b""c"^<"d"',
       },
       {
         input: 'a>b"c',
-        expected: '"a>b\\"c"',
+        expected: '"a"^>"b""c"',
       },
       {
         input: 'a<b"c',
-        expected: '"a<b\\"c"',
+        expected: '"a"^<"b""c"',
       },
     ],
     "left double quotation mark ('“')": [


### PR DESCRIPTION
Closes #1989
Relates to #986

## Summary

This updates the escaping and quoting logic for CMD to make it more consistent. The previous approach would break in some cases (e.g. with Maven/Java). The new approach is perhaps more expected, actually quoting the entire argument in double quotes and accounting for special character within those parameters.

## Testing

This change has been extensively fuzz tested using the [CMD fuzzing workflow](https://github.com/ericcornelissen/shescape/actions/workflows/fuzz-cmd.yml). First, CI jobs 711 to 727 (correspondingly roughly to the first part if the commit history) were used to determine a _working_ escape+quote strategy. After that, jobs 728 to 747 were used to find bugs in the change set - this is roughly `(20*10*3)/60 = 10` hours of fuzzing (on top of which I locally fuzzed as well).