### PR TITLE
Update "Prefer `execFile`, `fork`, or `spawn`" tip

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -114,8 +114,8 @@ exec(`git clean -n -- ${shescape.quote(userInput)}`);
 
 ### Prefer `execFile`, `fork`, or `spawn`
 
-... without an explicit shell (or the synchronous variants `execFileSync` or
-`spawnSync`).
+... or the synchronous variants `execFileSync` or `spawnSync` **without** a
+shell (i.e. `shell: false`).
 
 These functions spawn the command directly without first spawning a shell -
 provided the `shell` option is left undefined. As a result, most shell injection


### PR DESCRIPTION
Relates to #1012, https://github.com/ericcornelissen/shescape/issues/2009#user-content-fn-1-7b66e55b443c54504bca43701930dbf0

## Summary

Clarify what "without an explicit shell" means in the tips by rewording it to be more explicit in terms of implementation.