### PR TITLE
Disable npm cache when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,6 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          cache: npm
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Update the publishing workflow to avoid using a cache when publishing the package to NPM. This is in order to avoid the published package from being affacted by a poisened cache.

Per the `actions/setup-cache` docs: ["The cache input is optional, and caching is turned off by default."](https://github.com/actions/setup-node/blob/08f58d1471bff7f3a07d167b4ad7df25d5fcfcb6/README.md#caching-global-packages-data)