### PR TITLE
Use proper private fields

### DIFF
--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -55,6 +55,9 @@ import { checkedToString } from "../internal/reflection.js";
  * );
  */
 export class Shescape {
+  #escape;
+  #quote;
+
   /**
    * Create a new {@link Shescape} instance.
    *
@@ -75,9 +78,9 @@ export class Shescape {
       const escape = helpers.getEscapeFunction(shellName);
       if (flagProtection) {
         const flagProtect = helpers.getFlagProtectionFunction(shellName);
-        this._escape = (arg) => flagProtect(escape(arg));
+        this.#escape = (arg) => flagProtect(escape(arg));
       } else {
-        this._escape = escape;
+        this.#escape = escape;
       }
     }
 
@@ -85,9 +88,9 @@ export class Shescape {
       const [escape, quote] = helpers.getQuoteFunction(shellName);
       if (flagProtection) {
         const flagProtect = helpers.getFlagProtectionFunction(shellName);
-        this._quote = (arg) => quote(flagProtect(escape(arg)));
+        this.#quote = (arg) => quote(flagProtect(escape(arg)));
       } else {
-        this._quote = (arg) => quote(escape(arg));
+        this.#quote = (arg) => quote(escape(arg));
       }
     }
   }
@@ -104,7 +107,7 @@ export class Shescape {
    */
   escape(arg) {
     const argAsString = checkedToString(arg);
-    return this._escape(argAsString);
+    return this.#escape(argAsString);
   }
 
   /**
@@ -137,7 +140,7 @@ export class Shescape {
    */
   quote(arg) {
     const argAsString = checkedToString(arg);
-    return this._quote(argAsString);
+    return this.#quote(argAsString);
   }
 
   /**


### PR DESCRIPTION
## Summary

Update the `Shescape` class to use actual [private fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), instead of implied private fields through a naming convention.

According to MDN (link above) this language feature has been supported in Node.js since v14.6, which is before [our earliest supported version, v14.18.0](https://github.com/ericcornelissen/shescape/blob/322a4b25a828d4315396a1487c3636aac7adc1ab/package.json#L42). Hence, this should not cause compatibility issues for anyone (as confirmed by the compatibility tests).

Technically this is a breaking, but I'm inclined to ignore that as these fields should really not have been used in the first place. That being said, if there's push back after releasing I'd be willing to revert the change and delay it until v3.