### PR TITLE
Stop using `step-security/harden-runner`

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -21,21 +21,6 @@ jobs:
     name: Deprecations
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            ghcr.io:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -57,21 +42,6 @@ jobs:
     permissions:
       pull-requests: write # To comment on a Pull Request
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            files.pythonhosted.org:443
-            github.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -94,21 +64,6 @@ jobs:
     name: Vulnerabilities
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            ghcr.io:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -11,21 +11,6 @@ jobs:
     name: v2
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            ghcr.io:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,20 +27,6 @@ jobs:
           - sh
           - yml
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -73,19 +59,6 @@ jobs:
     permissions:
       security-events: write # To upload CodeQL results
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            ghcr.io:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pkg-containers.githubusercontent.com:443
-            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -103,14 +76,6 @@ jobs:
     name: ODGen
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -125,20 +90,6 @@ jobs:
     needs:
       - transpile
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -193,20 +144,6 @@ jobs:
     needs:
       - test-integration
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -239,20 +176,6 @@ jobs:
           - 22.0.0
           - 24.0.0
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -286,21 +209,6 @@ jobs:
           - name: Windows
             os: windows-2025
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            azure.archive.ubuntu.com:80
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -339,21 +247,6 @@ jobs:
           - name: Windows
             os: windows-2025
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            azure.archive.ubuntu.com:80
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -381,20 +274,6 @@ jobs:
     needs:
       - test-unit
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -431,21 +310,6 @@ jobs:
     needs:
       - test-integration
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            azure.archive.ubuntu.com:80
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -484,20 +348,6 @@ jobs:
     name: Unit
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -517,20 +367,6 @@ jobs:
     name: Transpile
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -18,5 +18,4 @@ github/codeql-action@v3.29.0 EHmrWPs3TigbNzGrCQBGGHmtmbW5+gPaF8Qj+Zs/aPc=
 ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 gvjXrRLNR3TlC3CVK24y2qFmYYZIwtY49Fc+kgUu0OY=
 peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f RJ6PdiHuRhSu1uU10pn41Zb8vMnM+035dJrl0e8UD3I=
 peter-evans/create-pull-request@v7.0.6 RJ6PdiHuRhSu1uU10pn41Zb8vMnM+035dJrl0e8UD3I=
-step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 r3LXfyvTAaxJJDhqPNr6jaljM0lmpDjkWdN8Bmk/QB0=
 tibdex/github-app-token@v2.1.0 ZNSBo6XSE0yxs8IkHEkVtUC9MkEeXTclXpMLl6zAmCs=

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,13 +11,6 @@ jobs:
       pull-requests: write # To assign labels
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,21 +21,6 @@ jobs:
           - name: Windows
             os: windows-2025
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            azure.archive.ubuntu.com:80
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -70,16 +55,6 @@ jobs:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,19 +15,6 @@ jobs:
       release_notes: ${{ steps.version.outputs.release_notes }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -65,14 +52,6 @@ jobs:
     permissions:
       contents: write # To push a ref
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            github.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -104,15 +83,6 @@ jobs:
     permissions:
       contents: write # To create a GitHub Release
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            github.com:443
       - name: Create GitHub release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
@@ -133,22 +103,6 @@ jobs:
     needs:
       - check
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,20 +21,6 @@ jobs:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/reusable-fuzz.yml
+++ b/.github/workflows/reusable-fuzz.yml
@@ -27,21 +27,6 @@ jobs:
       matrix:
         target: ${{ fromJson(inputs.targets) }}
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            azure.archive.ubuntu.com:80
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:


### PR DESCRIPTION
Reverts #317

## Summary

Drop the CI runtime protection offered by the harden-runner, triggered by the network access control being too unreliable and having caused to many problems over the years (this PR in particular due to recent failures of the [labeler job](https://github.com/ericcornelissen/shescape/actions/runs/15968172441)). Moreover, the protection is partial and therefor limited. In particular it does nothing for the Windows and macOS jobs, allowing easy bypass in practice, nor container-based jobs (e.g. Semgrep).