### PR TITLE
Minimize test fixtures

### DIFF
--- a/test/fixtures/unix.js
+++ b/test/fixtures/unix.js
@@ -6927,93 +6927,93 @@ export const flag = {
     "sample strings": [
       {
         input: "foobar",
-        expected: { unquoted: "foobar", quoted: "foobar" },
+        expected: { unquoted: "foobar" },
       },
     ],
     "single hyphen (-)": [
       {
         input: "-a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a-",
-        expected: { unquoted: "a-", quoted: "a-" },
+        expected: { unquoted: "a-" },
       },
       {
         input: "-a-",
-        expected: { unquoted: "a-", quoted: "a-" },
+        expected: { unquoted: "a-" },
       },
       {
         input: "-ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a-b",
-        expected: { unquoted: "a-b", quoted: "a-b" },
+        expected: { unquoted: "a-b" },
       },
       {
         input: "-a-b",
-        expected: { unquoted: "a-b", quoted: "a-b" },
+        expected: { unquoted: "a-b" },
       },
       {
         input: "-a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
     "double hyphen (--)": [
       {
         input: "--a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a--",
-        expected: { unquoted: "a--", quoted: "a--" },
+        expected: { unquoted: "a--" },
       },
       {
         input: "--a--",
-        expected: { unquoted: "a--", quoted: "a--" },
+        expected: { unquoted: "a--" },
       },
       {
         input: "--ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a--b",
-        expected: { unquoted: "a--b", quoted: "a--b" },
+        expected: { unquoted: "a--b" },
       },
       {
         input: "--a--b",
-        expected: { unquoted: "a--b", quoted: "a--b" },
+        expected: { unquoted: "a--b" },
       },
       {
         input: "--a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
     "many hyphens (/-{3,}/)": [
       {
         input: "---a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "---ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "---a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
       {
         input: "----a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "----ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "----a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
   },

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -3879,133 +3879,133 @@ export const flag = {
     "sample strings": [
       {
         input: "foobar",
-        expected: { unquoted: "foobar", quoted: "foobar" },
+        expected: { unquoted: "foobar" },
       },
     ],
     "single hyphen (-)": [
       {
         input: "-a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a-",
-        expected: { unquoted: "a-", quoted: "a-" },
+        expected: { unquoted: "a-" },
       },
       {
         input: "-a-",
-        expected: { unquoted: "a-", quoted: "a-" },
+        expected: { unquoted: "a-" },
       },
       {
         input: "-ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a-b",
-        expected: { unquoted: "a-b", quoted: "a-b" },
+        expected: { unquoted: "a-b" },
       },
       {
         input: "-a-b",
-        expected: { unquoted: "a-b", quoted: "a-b" },
+        expected: { unquoted: "a-b" },
       },
       {
         input: "-a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
     "double hyphen (--)": [
       {
         input: "--a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a--",
-        expected: { unquoted: "a--", quoted: "a--" },
+        expected: { unquoted: "a--" },
       },
       {
         input: "--a--",
-        expected: { unquoted: "a--", quoted: "a--" },
+        expected: { unquoted: "a--" },
       },
       {
         input: "--ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a--b",
-        expected: { unquoted: "a--b", quoted: "a--b" },
+        expected: { unquoted: "a--b" },
       },
       {
         input: "--a--b",
-        expected: { unquoted: "a--b", quoted: "a--b" },
+        expected: { unquoted: "a--b" },
       },
       {
         input: "--a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
     "many hyphens (/-{3,}/)": [
       {
         input: "---a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "---ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "---a=b",
-        expected: { unquoted: "a=b", quoted: "a=b" },
+        expected: { unquoted: "a=b" },
       },
     ],
     "forward slash (/)": [
       {
         input: "/a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a/",
-        expected: { unquoted: "a/", quoted: "a/" },
+        expected: { unquoted: "a/" },
       },
       {
         input: "/a/",
-        expected: { unquoted: "a/", quoted: "a/" },
+        expected: { unquoted: "a/" },
       },
       {
         input: "/ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a/b",
-        expected: { unquoted: "a/b", quoted: "a/b" },
+        expected: { unquoted: "a/b" },
       },
       {
         input: "/a/b",
-        expected: { unquoted: "a/b", quoted: "a/b" },
+        expected: { unquoted: "a/b" },
       },
     ],
     "multiple forward slashes (//{2,}/)": [
       {
         input: "//a",
-        expected: { unquoted: "a", quoted: "a" },
+        expected: { unquoted: "a" },
       },
       {
         input: "a//",
-        expected: { unquoted: "a//", quoted: "a//" },
+        expected: { unquoted: "a//" },
       },
       {
         input: "//a//",
-        expected: { unquoted: "a//", quoted: "a//" },
+        expected: { unquoted: "a//" },
       },
       {
         input: "//ab",
-        expected: { unquoted: "ab", quoted: "ab" },
+        expected: { unquoted: "ab" },
       },
       {
         input: "a//b",
-        expected: { unquoted: "a//b", quoted: "a//b" },
+        expected: { unquoted: "a//b" },
       },
       {
         input: "//a//b",
-        expected: { unquoted: "a//b", quoted: "a//b" },
+        expected: { unquoted: "a//b" },
       },
     ],
   },


### PR DESCRIPTION
Relates to #2036

## Summary

Omit unnecessary values from the test fixtures. In particular, without a shell (i.e. when shell is `null` in the fixtures) quoting arguments is not possible (see [`docs/api.md`](https://github.com/ericcornelissen/shescape/blob/b5afc4d39e54e4068f0697e746d80b11a250f950/docs/api.md?plain=1#L40C1-L41C32)).