### PR TITLE
Improve `npm run clean` experience

### DIFF
--- a/script/clean.js
+++ b/script/clean.js
@@ -20,26 +20,38 @@ const files = [
   "testing.d.cts",
   "testing.d.ts",
 ];
-const folders = [".nyc_output/", ".temp/", "_reports/"];
+const folders = [".cache/", ".temp/", "_reports/"];
 
 for (const file of files) {
-  const filePath = path.resolve(common.projectRoot, file);
-  deleteFile(filePath);
+  deleteFile(file);
 }
 
 for (const folder of folders) {
-  const folderPath = path.resolve(common.projectRoot, folder);
-  deleteFolder(folderPath);
+  deleteFolder(folder);
 }
 
 // -----------------------------------------------------------------------------
 
-function deleteFile(filePath) {
-  fs.rmSync(filePath, { force: true });
+function deleteFile(entry) {
+  const filePath = path.resolve(common.projectRoot, entry);
+  try {
+    fs.rmSync(filePath);
+    console.log(`remove ${entry}`);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.error(`# failed to delete file: ${entry} (${error.message})`);
+    }
+  }
 }
 
-function deleteFolder(folderPath) {
-  if (fs.existsSync(folderPath)) {
+function deleteFolder(entry) {
+  const folderPath = path.resolve(common.projectRoot, entry);
+  try {
     fs.rmSync(folderPath, { recursive: true });
+    console.log(`remove ${entry}`);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.error(`# failed to delete folder: ${entry} (${error.message})`);
+    }
   }
 }

--- a/script/clean.js
+++ b/script/clean.js
@@ -9,7 +9,10 @@ import path from "node:path";
 
 import { common } from "./_.js";
 
-const files = [
+const toBeRemoved = [
+  ".cache/",
+  ".temp/",
+  "_reports/",
   "src/modules/index.cjs",
   "src/modules/stateless.cjs",
   "src/modules/testing.cjs",
@@ -20,38 +23,21 @@ const files = [
   "testing.d.cts",
   "testing.d.ts",
 ];
-const folders = [".cache/", ".temp/", "_reports/"];
 
-for (const file of files) {
-  deleteFile(file);
-}
-
-for (const folder of folders) {
-  deleteFolder(folder);
+for (const entry of toBeRemoved) {
+  remove(entry);
 }
 
 // -----------------------------------------------------------------------------
 
-function deleteFile(entry) {
-  const filePath = path.resolve(common.projectRoot, entry);
+function remove(entry) {
+  const entryPath = path.resolve(common.projectRoot, entry);
   try {
-    fs.rmSync(filePath);
+    fs.rmSync(entryPath, { recursive: true });
     console.log(`remove ${entry}`);
   } catch (error) {
     if (error.code !== "ENOENT") {
-      console.error(`# failed to delete file: ${entry} (${error.message})`);
-    }
-  }
-}
-
-function deleteFolder(entry) {
-  const folderPath = path.resolve(common.projectRoot, entry);
-  try {
-    fs.rmSync(folderPath, { recursive: true });
-    console.log(`remove ${entry}`);
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      console.error(`# failed to delete folder: ${entry} (${error.message})`);
+      console.error(`# failed to delete: ${entry} (${error.message})`);
     }
   }
 }


### PR DESCRIPTION
Closes #2070

## Summary

This updates the clean.js script to:

1. Update the list of things to delete. In particular remove the `.nyc_output/` folder which isn't being created anymore for a long time and add the `.cache/` folder.
2. Add logging for a. what files and folders are actually being removed. b. when files or folder cannot be removed.

For me, this was an experiment in using Copilot.