### PR TITLE
Update dirty-waters configuration

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -58,7 +58,7 @@ jobs:
           gradual_report: false
           ignore_cache: false
           package_manager: npm
-          specified_smells: --check-code-signature --check-source-code --check-source-code-sha
+          specified_smells: --check-source-code --check-source-code-sha
           x_to_fail: 0
   vulnerabilities:
     name: Vulnerabilities

--- a/config/dirty-waters.json
+++ b/config/dirty-waters.json
@@ -1,15 +1,10 @@
 {
   "ignore": {
-    "@andrewbranch/untar.js@1.0.3": ["source_code"],
-    "@braidai/lang@1.1.1": ["source_code"],
     "concat-map@0.0.1": ["source_code"],
     "file-entry-cache@8.0.0": ["source_code"],
     "flat-cache@4.0.1": ["source_code"],
-    "micro-spelling-correcter@1.1.1": ["source_code"],
-    "minipass-pipeline@1.2.4": ["source_code"],
-    "promise-all-reject-late@1.0.1": ["source_code"],
 
-    "@jridgewell/gen-mapping@0.3.8": ["source_code_sha"],
+    "@fast-check/ava@2.0.2": ["source_code_sha"],
     "@loaderkit/resolve@1.0.4": ["source_code_sha"],
     "@pnpm/config.env-replace@1.1.0": ["source_code_sha"],
     "@pnpm/network.ca-file@1.0.2": ["source_code_sha"],
@@ -17,8 +12,11 @@
     "@types/.+": ["source_code_sha"],
     "acorn-import-attributes@1.9.5": ["source_code_sha"],
     "cli-progress@3.12.0": ["source_code_sha"],
-    "lines-and-columns@1.2.4": ["source_code_sha"],
-    "slashes@3.0.12": ["source_code_sha"],
-    "tap-yaml@3.0.0": ["source_code_sha"]
+    "cacheable-request@10.2.14": ["source_code_sha"],
+    "fast-check@4.2.0": ["source_code_sha"],
+    "keyv@4.5.4": ["source_code_sha"],
+    "lodash.get@4.4.2": ["source_code_sha"],
+    "lodash.merge@4.6.2": ["source_code_sha"],
+    "lodash.truncate@4.4.2": ["source_code_sha"]
   }
 }


### PR DESCRIPTION
Relates to #1883

## Summary

This disables a dirty-waters check and updates the ignores in accordance with [a recent dirty-waters report](https://github.com/ericcornelissen/shescape/actions/runs/16666050963/job/47172588980#step:4:3126). I'm not happy this is a separate Pull Request, I would've preferred these (latter) updates to co-occur with dependency updates...

I'm not 100% sure why `dirty-waters` didn't complain sooner. I vaguely remember it having some runtime errors leading it to be unable to comment the report on Pull Requests as a result of which I might have just ignored the necessary updates accidentally. However, there might also be something going on with its [`x_to_fail` option](https://github.com/chains-project/dirty-waters-action/blob/2a5212bf8abe0c97b77f6aa5de5eedb839efa637/action.yml#L54).

## Details

First, this disables the code signature check because it appears to be a bit broken (`npm audit signature` reports all "1263 packages have verified registry signatures" whereas dirty-waters says 35 don't, I manually checked one of the packages it reports and it appears to have a valid registry signature...) moreover it's not that meaningful as it's a registry signature, not a signature from the package maintainer.

Second, this updates the configuration file with new ignores based on the updated report. I briefly reviewed these reports (indicating it is perhaps not the most useful signal...).