### PR TITLE
Freeze release audit workflow's actions

### DIFF
--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
           ref: v2

--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -4,6 +4,7 @@ actions/cache@v4.2.3 A/Paejdu47oer1Zf9zbtOgbMTG3OmOiXsgB6oodFIOU=
 actions/cache@v4.2.4 Wn6UGuh8/0fkcOLI8uEQmhssKaMEfnm77brXOpwKe7A=
 actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 aYx2ZNrV/U9daVa5XJLnuR3depD7lQqzkyRhH4E9bOU=
 actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 g2V9DAwkHBbZHaTOx4M2g/r9wI49KupzyARL47t/rEQ=
+actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 e6ng7MJDyAPkTZ/6d/plZK2YhZRzJZvxhYAPUPpNAzc=
 actions/create-github-app-token@v2.1.0 VrFa97EVkoNy8fiAGL4gQVWBoycJDF3yVgStHeqfSX8=
 actions/labeler@v5.0.0 MoPG2jErWXx5EBXxrXiGl8rHTQrpsA7+2vpxJuzEH3w=
 actions/setup-node@v4.3.0 42jvLeHkfmB6GxoSth6I7EvbxtWh47IRGuqDDrNCYhM=


### PR DESCRIPTION
Relates to #2045, #2115

## Summary

Otherwise action checksum verification fails during execution of that job because of the mismatch between the workflow on main and the workflow on v2.

It does not appear to be possible to start the job from the v2 branch on a schedule ([`schedule:` docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idruns-on)).