### PR TITLE
Prototype implementation of using linear regular expressions

### DIFF
--- a/config/rollup.js
+++ b/config/rollup.js
@@ -1,6 +1,7 @@
 // Configuration file for Rollup (https://rollupjs.org/)
 
 const external = [
+  "@ericcornelissen/lregexp",
   "node:fs",
   "node:os",
   "node:path",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.6",
       "license": "MPL-2.0",
       "dependencies": {
+        "@ericcornelissen/lregexp": "^1.0.1",
         "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
       },
       "devDependencies": {
@@ -703,6 +704,15 @@
       },
       "peerDependencies": {
         "eslint": "8.x || 9.x"
+      }
+    },
+    "node_modules/@ericcornelissen/lregexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ericcornelissen/lregexp/-/lregexp-1.0.1.tgz",
+      "integrity": "sha512-C0RkEMhewfyddOHx8CqTCgnWT2tSalQ8MslCfujQyUDWd0bnNcuvVkCWMdYRYKev6Npa9AO1z75qN/p4ekvAHA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-supported-regexp-flag": "^2.0.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -9490,6 +9500,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-supported-regexp-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-2.0.0.tgz",
+      "integrity": "sha512-8i4+OYUjdUaJ88KAs1WojIThDFjIpeYNrSlYy1g/At2p9YjQ7HEmB1yn60un0jRFjM3TQbKPMAluTPEPncZfqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/is-symbol": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "injection"
   ],
   "dependencies": {
+    "@ericcornelissen/lregexp": "^1.0.1",
     "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {

--- a/src/internal/unix/no-shell.js
+++ b/src/internal/unix/no-shell.js
@@ -3,6 +3,8 @@
  * @license MPL-2.0
  */
 
+import RegExp from "@ericcornelissen/lregexp";
+
 /**
  * The error message for use of quoting functionality.
  *
@@ -12,13 +14,14 @@
 const unsupportedError = "Quoting is not supported when no shell is used";
 
 /**
- * Escape an argument for shell-less use.
- *
- * @param {string} arg The argument to escape.
- * @returns {string} The escaped argument.
+ * TODO.
  */
-function escapeArg(arg) {
-  return arg.replace(/[\0\u0008\u001B\u009B]/gu, "").replace(/\r(?!\n)/gu, "");
+function escapeArg() {
+  const controlCharacters = new RegExp("[\0\u0008\u001B\u009B]", "gu");
+  const newLines = new RegExp("\r(?!\n)", "gu");
+  return function (arg) {
+    return arg.replace(controlCharacters, "").replace(newLines, "");
+  };
 }
 
 /**
@@ -27,7 +30,7 @@ function escapeArg(arg) {
  * @returns {Function} A function to escape arguments.
  */
 export function getEscapeFunction() {
-  return escapeArg;
+  return escapeArg();
 }
 
 /**
@@ -49,14 +52,13 @@ export function getQuoteFunction() {
 }
 
 /**
- * Remove any prefix from the provided argument that might be interpreted as a
- * flag on Unix systems.
- *
- * @param {string} arg The argument to update.
- * @returns {string} The updated argument.
+ * TODO.
  */
-function stripFlagPrefix(arg) {
-  return arg.replace(/^-+/gu, "");
+function stripFlagPrefix() {
+  const leadingHyphens = new RegExp("^-+", "gu");
+  return function (arg) {
+    return arg.replace(leadingHyphens, "");
+  };
 }
 
 /**
@@ -65,5 +67,5 @@ function stripFlagPrefix(arg) {
  * @returns {Function} A function to protect against flag injection.
  */
 export function getFlagProtectionFunction() {
-  return stripFlagPrefix;
+  return stripFlagPrefix();
 }

--- a/test/unit/unix/index.test.js
+++ b/test/unit/unix/index.test.js
@@ -36,8 +36,7 @@ test("the default shell", (t) => {
 
 test("escape function for no shell", (t) => {
   const actual = unix.getEscapeFunction(noShell);
-  const expected = nosh.getEscapeFunction();
-  t.deepEqual(actual, expected);
+  t.is(typeof actual, "function");
 });
 
 for (const { module, shellName } of shells) {
@@ -59,8 +58,9 @@ testProp(
 
 test("quote function for no shell", (t) => {
   const actual = unix.getQuoteFunction(noShell);
-  const expected = nosh.getQuoteFunction();
-  t.deepEqual(actual, expected);
+  t.is(actual.length, 2);
+  t.is(typeof actual[0], "function");
+  t.is(typeof actual[1], "function");
 });
 
 for (const { module, shellName } of shells) {
@@ -127,8 +127,7 @@ testProp(
 
 test("flag protection function for no shell", (t) => {
   const actual = unix.getFlagProtectionFunction(noShell);
-  const expected = nosh.getFlagProtectionFunction();
-  t.is(actual, expected);
+  t.is(typeof actual, "function");
 });
 
 for (const { module, shellName } of shells) {


### PR DESCRIPTION
Relates to #2122

## Summary

Using a dedicated package I created for transparently creating regular expressions with the `l` flag (when available). This requires some refactoring to avoid significant performance overhead by pre-initializing the regular expressions in a closure which can than reuse it for repeated escaping.

For this proof of concept I just implemented it for one of the escape modules. Also, it is not tested yet as I did not figure out a way to run AVA tests with the `--enable-experimental-regexp-engine` flag.