### PR TITLE
Test that all escape functions are stateless

### DIFF
--- a/test/unit/unix/shells.test.js
+++ b/test/unit/unix/shells.test.js
@@ -40,11 +40,26 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     });
   }
 
-  testProp(`escape function for ${shellName}`, [fc.string()], (t, arg) => {
-    const escapeFn = shellExports.getEscapeFunction();
-    const result = escapeFn(arg);
-    t.is(typeof result, "string");
-  });
+  testProp(
+    `${shellName} escape function return type`,
+    [fc.string()],
+    (t, arg) => {
+      const escapeFn = shellExports.getEscapeFunction();
+      const result = escapeFn(arg);
+      t.is(typeof result, "string");
+    },
+  );
+
+  testProp(
+    `escape function for ${shellName} is stateless`,
+    [fc.string()],
+    (t, arg) => {
+      const escapeFn = shellExports.getEscapeFunction();
+      const result1 = escapeFn(arg);
+      const result2 = escapeFn(arg);
+      t.is(result1, result2);
+    },
+  );
 
   test(`escape performance for ${shellName}`, macros.duration, {
     arbitraries: [fc.string({ size: "xlarge" })],
@@ -71,12 +86,23 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
   }
 
   testProp(
-    `flag protection function for ${shellName}`,
+    `${shellName} flag protection function return type`,
     [fc.string()],
     (t, arg) => {
       const flagProtect = shellExports.getFlagProtectionFunction();
       const result = flagProtect(arg);
       t.is(typeof result, "string");
+    },
+  );
+
+  testProp(
+    `flag protection function for ${shellName} is stateless`,
+    [fc.string()],
+    (t, arg) => {
+      const flagProtect = shellExports.getFlagProtectionFunction();
+      const result1 = flagProtect(arg);
+      const result2 = flagProtect(arg);
+      t.is(result1, result2);
     },
   );
 
@@ -96,13 +122,32 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       });
     }
 
-    testProp(`quote function for ${shellName}`, [fc.string()], (t, arg) => {
-      const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
-      const intermediate = escapeFn(arg);
-      t.is(typeof intermediate, "string");
-      const result = quoteFn(intermediate);
-      t.is(typeof result, "string");
-    });
+    testProp(
+      `${shellName} quote function return type`,
+      [fc.string()],
+      (t, arg) => {
+        const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
+        const intermediate = escapeFn(arg);
+        t.is(typeof intermediate, "string");
+        const result = quoteFn(intermediate);
+        t.is(typeof result, "string");
+      },
+    );
+
+    testProp(
+      `quote function for ${shellName} is stateless`,
+      [fc.string()],
+      (t, arg) => {
+        const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
+        const intermediate1 = escapeFn(arg);
+        const intermediate2 = escapeFn(arg);
+        t.is(intermediate1, intermediate2);
+
+        const result1 = quoteFn(intermediate1);
+        const result2 = quoteFn(intermediate2);
+        t.is(result1, result2);
+      },
+    );
 
     test(`quote performance for ${shellName}`, macros.duration, {
       arbitraries: [fc.string({ size: "xlarge" })],

--- a/test/unit/win/shells.test.js
+++ b/test/unit/win/shells.test.js
@@ -33,11 +33,26 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
     });
   }
 
-  testProp(`escape function for ${shellName}`, [fc.string()], (t, arg) => {
-    const escapeFn = shellExports.getEscapeFunction();
-    const result = escapeFn(arg);
-    t.is(typeof result, "string");
-  });
+  testProp(
+    `${shellName} escape function return type`,
+    [fc.string()],
+    (t, arg) => {
+      const escapeFn = shellExports.getEscapeFunction();
+      const result = escapeFn(arg);
+      t.is(typeof result, "string");
+    },
+  );
+
+  testProp(
+    `escape function for ${shellName} is stateless`,
+    [fc.string()],
+    (t, arg) => {
+      const escapeFn = shellExports.getEscapeFunction();
+      const result1 = escapeFn(arg);
+      const result2 = escapeFn(arg);
+      t.is(result1, result2);
+    },
+  );
 
   test(`escape performance for ${shellName}`, macros.duration, {
     arbitraries: [fc.string({ size: "xlarge" })],
@@ -55,12 +70,23 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
   }
 
   testProp(
-    `flag protection function for ${shellName}`,
+    `${shellName} flag protection function return type`,
     [fc.string()],
     (t, arg) => {
       const flagProtect = shellExports.getFlagProtectionFunction();
       const result = flagProtect(arg);
       t.is(typeof result, "string");
+    },
+  );
+
+  testProp(
+    `flag protection function for ${shellName} is stateless`,
+    [fc.string()],
+    (t, arg) => {
+      const flagProtect = shellExports.getFlagProtectionFunction();
+      const result1 = flagProtect(arg);
+      const result2 = flagProtect(arg);
+      t.is(result1, result2);
     },
   );
 
@@ -80,13 +106,32 @@ for (const [shellName, shellExports] of Object.entries(shells)) {
       });
     }
 
-    testProp(`quote function for ${shellName}`, [fc.string()], (t, arg) => {
-      const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
-      const intermediate = escapeFn(arg);
-      t.is(typeof intermediate, "string");
-      const result = quoteFn(intermediate);
-      t.is(typeof result, "string");
-    });
+    testProp(
+      `${shellName} quote function return type`,
+      [fc.string()],
+      (t, arg) => {
+        const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
+        const intermediate = escapeFn(arg);
+        t.is(typeof intermediate, "string");
+        const result = quoteFn(intermediate);
+        t.is(typeof result, "string");
+      },
+    );
+
+    testProp(
+      `quote function for ${shellName} is stateless`,
+      [fc.string()],
+      (t, arg) => {
+        const [escapeFn, quoteFn] = shellExports.getQuoteFunction();
+        const intermediate1 = escapeFn(arg);
+        const intermediate2 = escapeFn(arg);
+        t.is(intermediate1, intermediate2);
+
+        const result1 = quoteFn(intermediate1);
+        const result2 = quoteFn(intermediate2);
+        t.is(result1, result2);
+      },
+    );
 
     test(`quote performance for ${shellName}`, macros.duration, {
       arbitraries: [fc.string({ size: "xlarge" })],


### PR DESCRIPTION
## Summary

Ensure regular expressions aren't being used in a stateful way, which may lead to faulty results when one Shescape instance is used to multiple times escape arguments.