### PR TITLE
Disable npm cache for publish job (explicitly)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/setup-node@v6.0.0
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: npm clean-install


### PR DESCRIPTION
## Summary

Based on [the `actions/setup-node` guidance](https://github.com/actions/setup-node/blob/2028fbc5c25fe9cf00d9f06a71cc4710d4507903/README.md?plain=1#L204):

> [...]. For workflows with elevated privileges or access to sensitive information, we recommend disabling automatic caching for npm by setting `package-manager-cache: false` when caching is not required for secure operation.
