### PR TITLE
Set the npm `devEngines` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=24.0.0",
+      "version": "^24.0.0",
       "onFail": "warn"
     },
     "packageManager": {


### PR DESCRIPTION
Relates to b696667d5237b86828a2b7ba744e276d1e43b8d2, #2256

## Summary

This sets the [`devEngines` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) in the project manifest (i.e., `package.json`) to instruct the npm CLI to enforce the Node.js and npm CLI version during development. The Node.js version is set more liberally than `.nvmrc` to minimize trouble for contributors not using NVM (but still use a recent enough version to run all development tooling). The npm CLI version is set to the minimum version that supports trusted publishing (see <https://docs.npmjs.com/trusted-publishers>).