### PR TITLE
Attempt fixing vulnerable dependencies when detected

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -98,3 +98,24 @@ jobs:
         run: npm clean-install
       - name: Audit for vulnerabilities
         run: npm run audit:vulnerabilities
+      - name: Bump vulnerable dependencies
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        run: npm audit fix
+      - name: Create automation token
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        uses: actions/create-github-app-token@v2.2.0
+        id: automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+      - name: Create Pull Request
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        uses: peter-evans/create-pull-request@v8.0.0
+        with:
+          token: ${{ steps.automation-token.outputs.token }}
+          title: Update vulnerable dependencies
+          body: |
+            _This Pull Request was created automatically based on at least one
+            known vulnerability detected in CI._
+          branch: bump-vulnerable-dependencies
+          commit-message: Fix vulnerable dependencies with `npm audit fix`


### PR DESCRIPTION
Relates to #1170, [`audit-dev.yml` job #2449](https://github.com/ericcornelissen/shescape/actions/runs/20611615660)

## Summary

Extend the `audit-dev.yml` job "Vulnerabilities" to try and fix the vulnerabilities with `npm audit fix` and submit a PR for the changes if any vulnerabilities are detected on a schedule (we don't want this for non-schedule jobs because it would get messy, e.g. creating PRs to merge the fix into (unrelated) development branches).