### PR TITLE
Revert "Set the npm `devEngines` field in package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,17 +154,5 @@
     "transpile:cjs": "rollup --config config/rollup.js",
     "transpile:cts": "node script/create-d-cts.js",
     "verify": "npm run check && npm run coverage"
-  },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": "^24.0.0",
-      "onFail": "warn"
-    },
-    "packageManager": {
-      "name": "npm",
-      "version": ">=11.5.1",
-      "onFail": "warn"
-    }
   }
 }


### PR DESCRIPTION
Reverts ericcornelissen/shescape#2298 because it breaks dependabot which is still using an older version of the npm CLI.

```log
 Dependabot encountered '2' error(s) during execution, please check the logs for more details.
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|                                                                                 Dependencies failed to update                                                                                  |
+--------------------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
| Dependency               | Error Type                     | Error Details                                                                                                                      |
+--------------------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
| fast-check               | dependency_file_not_resolvable | {                                                                                                                                  |
|                          |                                |   "message": "Invalid package manager specification in package.json. The packageManager field must specify a valid semver version" |
|                          |                                | }                                                                                                                                  |
| @ericcornelissen/lregexp | dependency_file_not_resolvable | {                                                                                                                                  |
|                          |                                |   "message": "Invalid package manager specification in package.json. The packageManager field must specify a valid semver version" |
|                          |                                | }                                                                                                                                  |
+--------------------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
Failure running container a774b10ff19c2c49f34ca0679677899e4902788e833382f2908b147df0aec8e8: Error: Command failed with exit code 1: /bin/sh -c $DEPENDABOT_HOME/dependabot-updater/bin/run update_files
Cleaned up container a774b10ff19c2c49f34ca0679677899e4902788e833382f2908b147df0aec8e8
  proxy | 2026/01/03 17:25:41 Posting metrics to remote API endpoint
  proxy | 2026/01/03 17:25:41 74/160 calls cached (46%)
Error: Dependabot encountered an error performing the update

Error: The updater encountered one or more errors.
```