### PR TITLE
Invalidate actions with `ghasum` when a problem is detected

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -265,8 +265,6 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
-      - name: Dummy action for testing purposes
-        uses: actions/setup-java@v5.1.0
       - name: Install csh
         if: ${{ matrix.name == 'Ubuntu' }}
         run: sudo apt-get --assume-yes install csh

--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -11,7 +11,6 @@ actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 yeXVQWV
 actions/create-github-app-token@v2.2.0 yeXVQWVRe7LlkqUY9Xco8LpJ+V2avq5OP33tZYbGnXk=
 actions/github-script@v7 szdLNpz8Va2xlE22zZc+JipfRGfMZw13OOZGxLuaGqM=
 actions/labeler@v6.0.0 vIbx/9sZYOT56jy87glclJ87y9Vd1y4SPRfS862VkeA=
-actions/setup-java@v5.1.0 hzGkcTiiDYqECET2xIRbsCTZmPfGNRIS3EA+y6sk3ew=
 actions/setup-node@v4.3.0 42jvLeHkfmB6GxoSth6I7EvbxtWh47IRGuqDDrNCYhM=
 actions/setup-node@v6.0.0 GRqp8XDY/VE7U6CS0j0+ssTCaCaa2ba5wGKAjhRCR1s=
 actions/setup-python@v5 MTHBGEHwb+MeIw3xRLiVuM/uyRfuK8hlVXL+Z/yEA8c=


### PR DESCRIPTION
Relates to #2045, https://github.com/chains-project/ghasum/issues/323#issuecomment-3706998081

## Summary

Update the `ghasum` action to remove all actions from the runner if it detects an issue. This prevents the actions from running. Actions could still run if `ghasum` fails because of conditions (e.g., `if: failure()`) or through post-step scripts.