### PR TITLE
Replace `peter-evans/create-pull-request` by `gh pr create`

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -72,8 +72,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TOKEN: ${{ steps.automation-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
           git checkout -B bump-vulnerable-dependencies
           git add package.json package-lock.json

--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -68,12 +68,21 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Create Pull Request
         if: ${{ github.event_name == 'schedule' && failure() }}
-        uses: peter-evans/create-pull-request@v8.1.1
-        with:
-          token: ${{ steps.automation-token.outputs.token }}
-          title: Update vulnerable dependencies
-          body: |
-            _This Pull Request was created automatically based on at least one
-            known vulnerability detected in CI._
-          branch: bump-vulnerable-dependencies
-          commit-message: Fix vulnerable dependencies with `npm audit fix`
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TOKEN: ${{ steps.automation-token.outputs.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B bump-vulnerable-dependencies
+          git add package.json package-lock.json
+          git commit --message 'Fix vulnerable dependencies with `npm audit fix`'
+
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${REPOSITORY}"
+          git push --force origin bump-vulnerable-dependencies
+
+          gh pr create \
+            --title='Update vulnerable dependencies' \
+            --body='_This Pull Request was created automatically based on at least one known vulnerability detected in CI._' \
+            --base='main' --head='bump-vulnerable-dependencies'

--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -16,5 +16,4 @@ ericcornelissen/tool-versions-update-action@v2.2.0 hEKQk7PtggFp4V/aUnbNy7/VbpQsY
 github/codeql-action@c10b8064de6f491fea524254123dbe5e09572f13 biCVbjMb0TYE58eDxHHs6yyxABH/SaM1g1VtU1Brpqk=
 github/codeql-action@v4.35.1 biCVbjMb0TYE58eDxHHs6yyxABH/SaM1g1VtU1Brpqk=
 peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 OLxtm/mOdNIRqAWWLjgrnEjNt0OL1Lak9MN9hbOXQNc=
-peter-evans/create-pull-request@v8.1.1 NeaLc9XTsvYCe9F+UP10n8w1SXZ6h08FoZmtE65ScBY=
 stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 g4PCgPHeeaVpSPTRcoBKth4QnrZGGQXwBEoEAsAXivs=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,24 @@ jobs:
       - name: Update CHANGELOG
         run: node script/release/bump-changelog.js
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8.1.1
-        with:
-          token: ${{ steps.automation-token.outputs.token }}
-          title: New ${{ github.event.inputs.update_type }} release
-          body: |
-            _This Pull Request was created automatically_
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TOKEN: ${{ steps.automation-token.outputs.token }}
+          UPDATE_TYPE: ${{ github.event.inputs.update_type }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout -B "release-${UPDATE_TYPE}"
+          git add .
+          git commit --message 'Version bump'
+
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${REPOSITORY}"
+          git push --force origin "release-${UPDATE_TYPE}"
+
+          gh pr create \
+            --title="New ${UPDATE_TYPE} release" \
+            --body='_This Pull Request was created automatically_
 
             ---
 
@@ -76,7 +88,5 @@ jobs:
             - [ ] The major version branch is updated.
 
             [npm]: https://www.npmjs.com/package/shescape
-            [semantic versioning]: https://semver.org/spec/v2.0.0.html
-          branch: release-${{ github.event.inputs.update_type }}
-          branch-suffix: random
-          commit-message: Version bump
+            [semantic versioning]: https://semver.org/spec/v2.0.0.html' \
+            --base='main' --head="release-${UPDATE_TYPE}"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -52,8 +52,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TOKEN: ${{ steps.automation-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
           git checkout -B npm-transitive-dependencies
           git add package.json package-lock.json

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -48,14 +48,22 @@ jobs:
           npm install typescript@^5.0.0
           npm uninstall typescript
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8.1.1
-        with:
-          token: ${{ steps.automation-token.outputs.token }}
-          title: Update transitive dependencies
-          body: _This Pull Request was created automatically_
-          branch: npm-transitive-dependencies
-          labels: dependencies
-          commit-message: Update transitive dependencies
-          add-paths: |
-            package.json
-            package-lock.json
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TOKEN: ${{ steps.automation-token.outputs.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B npm-transitive-dependencies
+          git add package.json package-lock.json
+          git commit --message 'Update transitive dependencies'
+
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${REPOSITORY}"
+          git push --force origin npm-transitive-dependencies
+
+          gh pr create \
+            --title='Update transitive dependencies' \
+            --body='_This Pull Request was created automatically_' \
+            --base='main' --head='npm-transitive-dependencies' \
+            --label='dependencies'

--- a/config/actionlint.yml
+++ b/config/actionlint.yml
@@ -1,0 +1,6 @@
+# Configuration file for actionlint (https://github.com/rhysd/actionlint)
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - "SC2016:info"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "audit:vulnerabilities": "better-npm-audit audit",
     "audit:vulnerabilities:runtime": "better-npm-audit audit --production",
     "check": "npm-run-all check:*",
-    "check:ci": "node script/maybe-run.js actionlint",
+    "check:ci": "node script/maybe-run.js actionlint -config-file config/actionlint.yml",
     "check:dependencies": "node script/check-runtime-deps.js",
     "check:formatting": "npm run _prettier -- --check",
     "check:js": "npm run _eslint -- '**/*.{cjs,js}'",


### PR DESCRIPTION
Closes #2406

## Summary

Remove an external dependency by using an existing dependency to do the same job. This is the simplest I could come up with that achieves what we want (weekly PRs) without accounting for edge cases (such as last week's PR hasn't been merged yet). My hope is that even without accounting for "unexpected" scenarios this approach will work 99.99% of the time.

As a point of comparison, this changes the implementation from 9 lines to 12 lines (ignoring whitespace and counting multiple lines that could reasonable be considered 1 line as 1).