### PR TITLE
Relax `@ericcornelissen/lregexp` version, omit `Fix 'invalid typescript@5.6.1-rc' issue`

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -43,10 +43,6 @@ jobs:
 
           npm install --save-peer @ericcornelissen/lregexp@1.0.7
           sed -i 's/"@ericcornelissen\/lregexp": "1.0.7"/"@ericcornelissen\/lregexp": "^1.0.7"/g' package*.json
-      - name: Fix 'invalid typescript@5.6.1-rc' issue
-        run: |
-          npm install typescript@^5.0.0
-          npm uninstall typescript
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -41,8 +41,8 @@ jobs:
           npm install which@3.0.0
           sed -i 's/"which": "3.0.0"/"which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"/g' package*.json
 
-          npm install --save-peer @ericcornelissen/lregexp@1.0.9
-          sed -i 's/"@ericcornelissen\/lregexp": "1.0.9"/"@ericcornelissen\/lregexp": "^1.0.9"/g' package*.json
+          npm install --save-peer @ericcornelissen/lregexp@1.0.7
+          sed -i 's/"@ericcornelissen\/lregexp": "1.0.7"/"@ericcornelissen\/lregexp": "^1.0.7"/g' package*.json
       - name: Fix 'invalid typescript@5.6.1-rc' issue
         run: |
           npm install typescript@^5.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25 || ^26"
       },
       "peerDependencies": {
-        "@ericcornelissen/lregexp": "^1.0.9"
+        "@ericcornelissen/lregexp": "^1.0.7"
       },
       "peerDependenciesMeta": {
         "@ericcornelissen/lregexp": {
@@ -720,18 +720,16 @@
       }
     },
     "node_modules/@ericcornelissen/lregexp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ericcornelissen/lregexp/-/lregexp-1.0.9.tgz",
-      "integrity": "sha512-Dr5VFLiaimf7Vg3Ohd3+SNpxF0/8S45z04yShWyvoTO5DDu63DW1HGtoXsPspDP1/RMxxAdqcGjqme2fwT2k/A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@ericcornelissen/lregexp/-/lregexp-1.0.7.tgz",
+      "integrity": "sha512-1FFCOKq49eWRCinu3VuTfV1jv0kgeSET89OHDAUDaASzvIpwmh2/nFUayoEXB65mPT3atgECjlu3KVTIQU7jhw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-supported-regexp-flag": "^2.0.0"
       },
       "engines": {
-        "bun": "^1.2.0",
-        "deno": "^2.0.0",
-        "node": "^12.20.0 || ^14.13.0 || ^15 || ^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22 || ^23 || ^24 || ^25 || ^26"
+        "node": "^12.20.0 || ^14.13.0 || ^15 || ^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22 || ^23 || ^24 || ^25"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependencies": {
-    "@ericcornelissen/lregexp": "^1.0.9"
+    "@ericcornelissen/lregexp": "^1.0.7"
   },
   "peerDependenciesMeta": {
     "@ericcornelissen/lregexp": {


### PR DESCRIPTION
Relates to #2275, #2520

## Summary

- Relaxing `@ericcornelissen/lregexp` because we're still compatible with 1.0.7 and anyone on Node.js `^26` can upgrade to 1.0.9 as necessary(?)
- Tested the weekly transitive dependency update steps locally and it appeared that the `typescript@5.6.1-rc` error no longer occurs, so removing that step from CI.