### PR TITLE
Update `.nsprc`

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -3,5 +3,10 @@
     "active": true,
     "expiry": "2027-01-01",
     "notes": "Pending https://github.com/microsoft/typed-rest-client/issues/400"
+  },
+  "GHSA-h67p-54hq-rp68": {
+    "active": true,
+    "expiry": "2027-01-01",
+    "notes": "Pending https://github.com/vadimdemedes/supertap/issues/7 and https://github.com/yarnpkg/berry/issues/7186"
   }
 }


### PR DESCRIPTION
Caused by GHSA-h67p-54hq-rp68
Relates to [Audit job #3132](https://github.com/ericcornelissen/shescape/actions/runs/27605060595) and #2549
See also https://github.com/vadimdemedes/supertap/issues/7 and https://github.com/yarnpkg/berry/issues/7186