### PR TITLE
Harden CMD escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning].
 
 ## Unreleased
 
-- _No changes yet_
+- Escaping `!` for CMD. ([#2676])
 
 ## 3.0.1 (2026-07-22)
 
@@ -437,6 +437,7 @@ Versioning].
 [#2534]: https://github.com/ericcornelissen/shescape/pull/2534
 [#2572]: https://github.com/ericcornelissen/shescape/pull/2572
 [#2649]: https://github.com/ericcornelissen/shescape/pull/2649
+[#2676]: https://github.com/ericcornelissen/shescape/pull/2676
 [552e8ea]: https://github.com/ericcornelissen/shescape/commit/552e8eab56861720b1d4e5474fb65741643358f9
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/src/internal/win/cmd.js
+++ b/src/internal/win/cmd.js
@@ -14,7 +14,7 @@ import RegExp from "../regexp.cjs";
 export function getEscapeFunction() {
   const controls = new RegExp(/[\0\u0008\r\u001B\u009B]/g);
   const newlines = new RegExp(/\n/g);
-  const specials = new RegExp(/([%&()<>^|])/g);
+  const specials = new RegExp(/([!%&()<>^|])/g);
   const quotes = new RegExp(/"/g);
   const backslashes = new RegExp(/(^|[^\\])(\\*)\0/g);
   return (arg) =>
@@ -36,7 +36,7 @@ function getQuoteEscapeFunction() {
   const controls = new RegExp(/[\0\u0008\r\u001B\u009B]/g);
   const newlines = new RegExp(/\n/g);
   const quotes = new RegExp(/"/g);
-  const specials = new RegExp(/([%&<>^|])/g);
+  const specials = new RegExp(/([!%&<>^|])/g);
   const backslashes = new RegExp(/(^|[^\\])(\\+)("|$)/g);
   return (arg) =>
     arg

--- a/src/testing.js
+++ b/src/testing.js
@@ -23,6 +23,7 @@ export const injectionStrings = [
   "$PATH",
   "$Env:PATH",
   "%PATH%",
+  "!PATH!",
 ];
 
 /**

--- a/test/fixtures/win.js
+++ b/test/fixtures/win.js
@@ -629,6 +629,38 @@ export const escape = {
         expected: "`a",
       },
     ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "a^!b",
+      },
+      {
+        input: "a!b!c",
+        expected: "a^!b^!c",
+      },
+      {
+        input: "a!",
+        expected: "a^!",
+      },
+      {
+        input: "!a",
+        expected: "^!a",
+      },
+    ],
+    "exclamation marks ('!') + double quotes ('\"')": [
+      {
+        input: 'a"b!c',
+        expected: 'a\\^"b^!c',
+      },
+      {
+        input: 'a"b"c!d',
+        expected: 'a\\^"b\\^"c^!d',
+      },
+      {
+        input: 'a!b"c',
+        expected: 'a^!b\\^"c',
+      },
+    ],
     "at signs ('@')": [
       {
         input: "a@b",
@@ -2065,6 +2097,24 @@ export const escape = {
       {
         input: "`a",
         expected: "``a",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "a!b",
+      },
+      {
+        input: "a!b!c",
+        expected: "a!b!c",
+      },
+      {
+        input: "a!",
+        expected: "a!",
+      },
+      {
+        input: "!a",
+        expected: "!a",
       },
     ],
     "at signs ('@')": [
@@ -4211,6 +4261,64 @@ export const quote = {
         expected: '"`a"',
       },
     ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: '"a"^!"b"',
+      },
+      {
+        input: "a!b!c",
+        expected: '"a"^!"b"^!"c"',
+      },
+      {
+        input: "a!",
+        expected: '"a"^!""',
+      },
+      {
+        input: "!a",
+        expected: '""^!"a"',
+      },
+      {
+        input: "a\\!b",
+        expected: '"a\\\\"^!"b"',
+      },
+      {
+        input: "!\\",
+        expected: '""^!"\\\\"',
+      },
+    ],
+    "exclamation marks ('!') + double quotes ('\"')": [
+      {
+        input: 'a"b!c',
+        expected: '"a""b"^!"c"',
+      },
+      {
+        input: 'a"b"c!d',
+        expected: '"a""b""c"^!"d"',
+      },
+      {
+        input: 'a!b"c',
+        expected: '"a"^!"b""c"',
+      },
+    ],
+    "at signs ('@')": [
+      {
+        input: "a@b",
+        expected: '"a@b"',
+      },
+      {
+        input: "a@b@c",
+        expected: '"a@b@c"',
+      },
+      {
+        input: "a@",
+        expected: '"a@"',
+      },
+      {
+        input: "@a",
+        expected: '"@a"',
+      },
+    ],
     "carets ('^')": [
       {
         input: "a^b",
@@ -5071,6 +5179,46 @@ export const quote = {
       {
         input: "`a",
         expected: "'`a'",
+      },
+    ],
+    "exclamation marks ('!')": [
+      {
+        input: "a!b",
+        expected: "'a!b'",
+      },
+      {
+        input: "a!b!c",
+        expected: "'a!b!c'",
+      },
+      {
+        input: "a!",
+        expected: "'a!'",
+      },
+      {
+        input: "!a",
+        expected: "'!a'",
+      },
+    ],
+    "at signs ('@')": [
+      {
+        input: "a@b",
+        expected: "'a@b'",
+      },
+      {
+        input: "a@b@c",
+        expected: "'a@b@c'",
+      },
+      {
+        input: "a@",
+        expected: "'a@'",
+      },
+      {
+        input: "@a",
+        expected: "'@a'",
+      },
+      {
+        input: "@a@b",
+        expected: "'@a@b'",
       },
     ],
     "carets ('^')": [


### PR DESCRIPTION
## Summary

Update CMD escaping to escape `!`. Hardens against uses with `EnableDelayedExpansion` (see <https://batch-man.com/setlocal/> for more details on this option). While I was able to observe this behavior when manually using CMD, I was not able to trigger it through Node.js' `child_process` APIs.